### PR TITLE
allow special tokens to be passed through add_feature_transform_layer

### DIFF
--- a/docs/log.rst
+++ b/docs/log.rst
@@ -2,6 +2,13 @@ Development logs
 ======================
 We track the new development here:
 
+**Jan 8, 2023**
+
+.. code-block:: bash
+
+    1. Changed BaseModel.add_feature_transform_layer in models/base_model.py so that it accepts special_tokens if necessary
+
+
 **Dec 26, 2022**
 
 .. code-block:: bash

--- a/pyhealth/models/base_model.py
+++ b/pyhealth/models/base_model.py
@@ -26,11 +26,11 @@ class BaseModel(ABC, nn.Module):
     """
 
     def __init__(
-            self,
-            dataset: SampleDataset,
-            feature_keys: List[str],
-            label_key: str,
-            mode: str,
+        self,
+        dataset: SampleDataset,
+        feature_keys: List[str],
+        label_key: str,
+        mode: str,
     ):
         super(BaseModel, self).__init__()
         assert mode in VALID_MODE, f"mode must be one of {VALID_MODE}"
@@ -72,8 +72,8 @@ class BaseModel(ABC, nn.Module):
 
     @staticmethod
     def get_embedding_layers(
-            feature_tokenizers: Dict[str, Tokenizer],
-            embedding_dim: int,
+        feature_tokenizers: Dict[str, Tokenizer],
+        embedding_dim: int,
     ) -> nn.ModuleDict:
         """Gets the default embedding layers using the feature tokenizers.
 
@@ -169,10 +169,11 @@ class BaseModel(ABC, nn.Module):
 
         return batch, mask
 
-    def add_feature_transform_layer(self, feature_key: str, info):
+    def add_feature_transform_layer(self, feature_key: str, info, special_tokens=None):
         if info["type"] == str:
             # feature tokenizer
-            special_tokens = ["<pad>", "<unk>"]
+            if special_tokens is None:
+                special_tokens = ["<pad>", "<unk>"]
             tokenizer = Tokenizer(
                 tokens=self.dataset.get_all_tokens(key=feature_key),
                 special_tokens=special_tokens,
@@ -185,9 +186,7 @@ class BaseModel(ABC, nn.Module):
                 padding_idx=tokenizer.get_padding_index(),
             )
         elif info["type"] in [float, int]:
-            self.linear_layers[feature_key] = nn.Linear(
-                info["len"], self.embedding_dim
-            )
+            self.linear_layers[feature_key] = nn.Linear(info["len"], self.embedding_dim)
         else:
             raise ValueError("Unsupported feature type: {}".format(info["type"]))
 
@@ -248,9 +247,9 @@ class BaseModel(ABC, nn.Module):
             raise ValueError("Invalid mode: {}".format(self.mode))
 
     def prepare_labels(
-            self,
-            labels: Union[List[str], List[List[str]]],
-            label_tokenizer: Tokenizer,
+        self,
+        labels: Union[List[str], List[List[str]]],
+        label_tokenizer: Tokenizer,
     ) -> torch.Tensor:
         """Prepares the labels for model training and evaluation.
 


### PR DESCRIPTION
I noticed that some models use get_feature_tokenizers and some switched to add_feature_transform_layer, but the latter IMO should take special_tokens as an argument as well.