### PR TITLE
Add repr class methods for InnerMap and CrossMap

### DIFF
--- a/pyhealth/medcode/cross_map.py
+++ b/pyhealth/medcode/cross_map.py
@@ -59,7 +59,7 @@ class CrossMap:
         return
 
     def __repr__(self):
-        return f"CrossMap(source_vocabulary={self.s_vocab}, target_vocabulary={self.t_vocab})"
+        return f"CrossMap(source_vocabulary={self.s_vocab}, source_class={self.s_class} target_vocabulary={self.t_vocab}, target_class={self.t_class})"
 
     @classmethod
     def load(
@@ -114,36 +114,3 @@ class CrossMap:
         target_codes = self.mapping[source_code]
         target_codes = [self.t_class.convert(c, **target_kwargs) for c in target_codes]
         return target_codes
-
-    def get_source(self, refresh_cache: bool = False):
-        """Gets the source vocabulary as an `InnerMap` object
-
-        Args:
-            refresh_cache: whether to refresh the cache. Default is False.
-
-        Returns:
-            An `InnerMap` of the source vocabulary.
-
-        Examples:
-        >>> from pyhealth.medcode import CrossMap
-        >>> mapping = CrossMap("CCSCM", "ICD9CM")
-        >>> mapping
-        CrossMap(source_vocabulary=CCSCM, target_vocabulary=ICD9CM)
-        >>> ccscm_codes = mapping.get_source()
-        >>> ccscm_codes
-        InnerMap(vocabulary=CCSCM)
-        >>> ccscm_codes.lookup("108")
-        'Congestive heart failure; nonhypertensive'
-        """
-        return medcode.InnerMap.load(self.s_vocab, refresh_cache)
-
-    def get_target(self, refresh_cache: bool = False):
-        """Gets the target vocabulary as an `InnerMap` object
-
-        Args:
-            refresh_cache: whether to refresh the cache. Default is False.
-
-        Returns:
-            An `InnerMap` of the target vocabulary.
-        """
-        return medcode.InnerMap.load(self.t_vocab, refresh_cache)

--- a/pyhealth/medcode/cross_map.py
+++ b/pyhealth/medcode/cross_map.py
@@ -58,6 +58,9 @@ class CrossMap:
         self.t_class = getattr(medcode, target_vocabulary)()
         return
 
+    def __repr__(self):
+        return f"CrossMap(source_vocabulary={self.s_vocab}, target_vocabulary={self.t_vocab})"
+
     @classmethod
     def load(
         cls,
@@ -111,3 +114,36 @@ class CrossMap:
         target_codes = self.mapping[source_code]
         target_codes = [self.t_class.convert(c, **target_kwargs) for c in target_codes]
         return target_codes
+
+    def get_source(self, refresh_cache: bool = False):
+        """Gets the source vocabulary as an `InnerMap` object
+
+        Args:
+            refresh_cache: whether to refresh the cache. Default is False.
+
+        Returns:
+            An `InnerMap` of the source vocabulary.
+
+        Examples:
+        >>> from pyhealth.medcode import CrossMap
+        >>> mapping = CrossMap("CCSCM", "ICD9CM")
+        >>> mapping
+        CrossMap(source_vocabulary=CCSCM, target_vocabulary=ICD9CM)
+        >>> ccscm_codes = mapping.get_source()
+        >>> ccscm_codes
+        InnerMap(vocabulary=CCSCM)
+        >>> ccscm_codes.lookup("108")
+        'Congestive heart failure; nonhypertensive'
+        """
+        return medcode.InnerMap.load(self.s_vocab, refresh_cache)
+
+    def get_target(self, refresh_cache: bool = False):
+        """Gets the target vocabulary as an `InnerMap` object
+
+        Args:
+            refresh_cache: whether to refresh the cache. Default is False.
+
+        Returns:
+            An `InnerMap` of the target vocabulary.
+        """
+        return medcode.InnerMap.load(self.t_vocab, refresh_cache)

--- a/pyhealth/medcode/inner_map.py
+++ b/pyhealth/medcode/inner_map.py
@@ -172,3 +172,11 @@ class InnerMap(ABC):
         )
         return descendants
 
+
+if __name__ == "__main__":
+    icd9cm = InnerMap.load("ICD9CM")
+    print(icd9cm.stat())
+    print("428.0" in icd9cm)
+    print(icd9cm.lookup("4280"))
+    print(icd9cm.get_ancestors("428.0"))
+    print(icd9cm.get_descendants("428.0"))

--- a/pyhealth/medcode/inner_map.py
+++ b/pyhealth/medcode/inner_map.py
@@ -33,7 +33,6 @@ class InnerMap(ABC):
     ):
         # abstractmethod prevents initialization of this class
         self.vocabulary = vocabulary
-        self.refresh_cache = refresh_cache
 
         pickle_filepath = os.path.join(MODULE_CACHE_PATH, self.vocabulary + ".pkl")
         csv_filename = self.vocabulary + ".csv"
@@ -59,6 +58,9 @@ class InnerMap(ABC):
             logger.debug(f"Saved {vocabulary} code to {pickle_filepath}")
             save_pickle(self.graph, pickle_filepath)
         return
+
+    def __repr__(self):
+        return f"InnerMap(vocabulary={self.vocabulary})"
 
     @classmethod
     def load(_, vocabulary: str, refresh_cache: bool = False):

--- a/pyhealth/medcode/inner_map.py
+++ b/pyhealth/medcode/inner_map.py
@@ -60,7 +60,7 @@ class InnerMap(ABC):
         return
 
     def __repr__(self):
-        return f"InnerMap(vocabulary={self.vocabulary})"
+        return f"InnerMap(vocabulary={self.vocabulary}, graph={self.graph})"
 
     @classmethod
     def load(_, vocabulary: str, refresh_cache: bool = False):
@@ -172,11 +172,3 @@ class InnerMap(ABC):
         )
         return descendants
 
-
-if __name__ == "__main__":
-    icd9cm = InnerMap.load("ICD9CM")
-    print(icd9cm.stat())
-    print("428.0" in icd9cm)
-    print(icd9cm.lookup("4280"))
-    print(icd9cm.get_ancestors("428.0"))
-    print(icd9cm.get_descendants("428.0"))


### PR DESCRIPTION
Add `__repr__(self)` allows printing the class and its vocab parameters in a human-readable format
previously: 
```
<pyhealth.medcode.codes.icd9cm.ICD9CM object at 0x1042d5fd0>
<pyhealth.medcode.cross_map.CrossMap object at 0x1279f1160>
```
now:
```
InnerMap(vocabulary=ICD9CM, graph=DiGraph with 17736 nodes and 17733 edges)
CrossMap(source_vocabulary=CCSCM, source_class=InnerMap(vocabulary=CCSCM, graph=DiGraph with 285 nodes and 0 edges) target_vocabulary=ICD9CM, target_class=InnerMap(vocabulary=ICD9CM, graph=DiGraph with 17736 nodes and 17733 edges))
```

For the InnerMap, maybe ts sufficient to omit the DiGraph, or print some reduced form; open to feedback. I could also just add newlines to the attributes to make them stacked instead of just one long row.
Example usage:
```
>>> from pyhealth.medcode import CrossMap
>>> mapping = CrossMap("CCSCM", "ICD9CM")
>>> mapping
CrossMap(source_vocabulary=CCSCM, source_class=InnerMap(vocabulary=CCSCM, graph=DiGraph with 285 nodes and 0 edges) target_vocabulary=ICD9CM, target_class=InnerMap(vocabulary=ICD9CM, graph=DiGraph with 17736 nodes and 17733 edges))
>>> mapping.t_class
InnerMap(vocabulary=ICD9CM, graph=DiGraph with 17736 nodes and 17733 edges)
```

DL4H student, 
email: bdanek2@illinois.edu