### PR TITLE
Ambiguous datetime usage on dateutils.parser.parse causes incorrect t…

### DIFF
--- a/pyhealth/datasets/eicu.py
+++ b/pyhealth/datasets/eicu.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from pyhealth.data import Event, Visit, Patient
 from pyhealth.datasets import BaseEHRDataset
-from pyhealth.datasets.utils import strptime
+from pyhealth.datasets.utils import strptime, padyear
 
 # TODO: add other tables
 
@@ -144,7 +144,7 @@ class eICUDataset(BaseEHRDataset):
             patient_id = f"{p_id}+{ha_id}"
 
             # hospital admission time (Jan 1 of hospitaldischargeyear, 00:00:00)
-            ha_datetime = strptime(str(p_info["hospitaldischargeyear"].values[0]))
+            ha_datetime = strptime(padyear(str(p_info["hospitaldischargeyear"].values[0])))
 
             # no exact birth datetime in eICU
             # use hospital admission time and age to approximate birth datetime

--- a/pyhealth/datasets/utils.py
+++ b/pyhealth/datasets/utils.py
@@ -39,6 +39,19 @@ def strptime(s: str) -> Optional[datetime]:
         return None
     return dateutil_parse(s)
 
+def padyear(year: str, month='1', day='1') -> str:
+    """Pad a date time year of format 'YYYY' to format 'YYYY-MM-DD'
+    
+    Args: 
+        year: str, year to be padded. Must be non-zero value.
+        month: str, month string to be used as padding. Must be in [1, 12]
+        day: str, day string to be used as padding. Must be in [1, 31]
+        
+    Returns:
+        padded_date: str, padded year.
+    
+    """
+    return f"{year}-{month}-{day}"
 
 def flatten_list(l: List) -> List:
     """Flattens a list of list.

--- a/pyhealth/unittests/test_datasets/test_eicu.py
+++ b/pyhealth/unittests/test_datasets/test_eicu.py
@@ -29,7 +29,7 @@ class TesteICUDataset(unittest.TestCase):
 
     def setUp(self):
         pass
-
+    
     def test_patient(self):
         # given parametes:
         selected_patient_id = "002-10009+193705"
@@ -38,7 +38,7 @@ class TesteICUDataset(unittest.TestCase):
 
         # expect:
         # patient data
-        expected_birth_datetime = pandas.Timestamp("1938-02-24 00:00:00")
+        expected_birth_datetime = pandas.Timestamp("1938-01-01 00:00:00")
         expected_death_datetime = None
         expected_ethnicity = "Caucasian"
         expected_gender = "Female"
@@ -47,8 +47,8 @@ class TesteICUDataset(unittest.TestCase):
         expected_visit_len = 1
         expected_visit_id = "224606"
         expected_visit_discharge_status = "Alive"
-        expected_discharge_time = datetime.datetime(2014, 2, 27, 0, 45)
-        expected_encounter_time = datetime.datetime(2014, 2, 24, 2, 59)
+        expected_discharge_time = datetime.datetime(2014, 1, 4, 0, 45)
+        expected_encounter_time = datetime.datetime(2014, 1, 1, 2, 59)
 
         # visit attribute dict data
         expected_visit_attr_dict_len = 2
@@ -72,7 +72,7 @@ class TesteICUDataset(unittest.TestCase):
                         0,
                         Event(
                             code="567.9",
-                            timestamp=pandas.Timestamp("2014-02-24 03:36:00"),
+                            timestamp=pandas.Timestamp("2014-01-01 03:36:00"),
                             vocabulary="ICD9CM",
                         ),
                     ),
@@ -80,7 +80,7 @@ class TesteICUDataset(unittest.TestCase):
                         1,
                         Event(
                             code="K65.0",
-                            timestamp=pandas.Timestamp("2014-02-24 03:36:00"),
+                            timestamp=pandas.Timestamp("2014-01-01 03:36:00"),
                             vocabulary="ICD10CM",
                         ),
                     ),
@@ -93,7 +93,7 @@ class TesteICUDataset(unittest.TestCase):
                         0,
                         Event(
                             code="MORPHINE INJ",
-                            timestamp=pandas.Timestamp("2014-02-23 21:09:00"),
+                            timestamp=pandas.Timestamp("2013-12-31 21:09:00"),
                             vocabulary="eICU_DRUGNAME",
                         ),
                     ),
@@ -101,7 +101,7 @@ class TesteICUDataset(unittest.TestCase):
                         5,
                         Event(
                             code="CIPROFLOXACIN IN D5W 400 MG/200ML IV SOLN",
-                            timestamp=pandas.Timestamp("2014-02-23 22:43:00"),
+                            timestamp=pandas.Timestamp("2013-12-31 22:43:00"),
                             vocabulary="eICU_DRUGNAME",
                         ),
                     ),
@@ -114,7 +114,7 @@ class TesteICUDataset(unittest.TestCase):
                         0,
                         Event(
                             code="sodium",
-                            timestamp=pandas.Timestamp("2014-02-23 21:04:00"),
+                            timestamp=pandas.Timestamp("2013-12-31 21:04:00"),
                             vocabulary="eICU_LABNAME",
                         ),
                     ),
@@ -122,7 +122,7 @@ class TesteICUDataset(unittest.TestCase):
                         2,
                         Event(
                             code="BUN",
-                            timestamp=pandas.Timestamp("2014-02-23 21:04:00"),
+                            timestamp=pandas.Timestamp("2013-12-31 21:04:00"),
                             vocabulary="eICU_LABNAME",
                         ),
                     ),
@@ -135,7 +135,7 @@ class TesteICUDataset(unittest.TestCase):
                         0,
                         Event(
                             code="notes/Progress Notes/Physical Exam/Physical Exam/Neurologic/GCS/Score/scored",
-                            timestamp=pandas.Timestamp("2014-02-24 03:05:00"),
+                            timestamp=pandas.Timestamp("2014-01-01 03:05:00"),
                             vocabulary="eICU_PHYSICALEXAMPATH",
                         ),
                     ),
@@ -143,7 +143,7 @@ class TesteICUDataset(unittest.TestCase):
                         1,
                         Event(
                             code="notes/Progress Notes/Physical Exam/Physical Exam Obtain Options/Performed - Structured",
-                            timestamp=pandas.Timestamp("2014-02-24 03:05:00"),
+                            timestamp=pandas.Timestamp("2014-01-01 03:05:00"),
                             vocabulary="eICU_PHYSICALEXAMPATH",
                         ),
                     ),


### PR DESCRIPTION
…imestamps in eICU (#125)

* Add repr class methods for InnerMap and CrossMap (#69)

* add repr methods for medcode maps, getters for CrossMap dom/codom

* fix: fuller repr & remove redundant getter

* add back test stub

* fix: Patch ambiguous datetime bug

* fix tests to run on default month and day params

---------