### PR TITLE
fix mask create bug

### DIFF
--- a/pyhealth/models/adacare.py
+++ b/pyhealth/models/adacare.py
@@ -460,7 +460,7 @@ class AdaCare(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -474,7 +474,7 @@ class AdaCare(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/adacare.py
+++ b/pyhealth/models/adacare.py
@@ -460,7 +460,7 @@ class AdaCare(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -474,7 +474,7 @@ class AdaCare(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/agent.py
+++ b/pyhealth/models/agent.py
@@ -589,7 +589,7 @@ class Agent(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
                 mask_dict[feature_key] = mask
 
             # for case 2: [[code1, code2], [code3, ...], ...]
@@ -604,7 +604,7 @@ class Agent(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
                 mask_dict[feature_key] = mask
 
             # for case 3: [[1.5, 2.0, 0.0], ...]

--- a/pyhealth/models/agent.py
+++ b/pyhealth/models/agent.py
@@ -589,7 +589,7 @@ class Agent(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
                 mask_dict[feature_key] = mask
 
             # for case 2: [[code1, code2], [code3, ...], ...]
@@ -604,7 +604,7 @@ class Agent(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
                 mask_dict[feature_key] = mask
 
             # for case 3: [[1.5, 2.0, 0.0], ...]

--- a/pyhealth/models/concare.py
+++ b/pyhealth/models/concare.py
@@ -862,7 +862,7 @@ class ConCare(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -876,7 +876,7 @@ class ConCare(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/concare.py
+++ b/pyhealth/models/concare.py
@@ -862,7 +862,7 @@ class ConCare(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -876,7 +876,7 @@ class ConCare(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/grasp.py
+++ b/pyhealth/models/grasp.py
@@ -518,7 +518,7 @@ class GRASP(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -532,7 +532,7 @@ class GRASP(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/grasp.py
+++ b/pyhealth/models/grasp.py
@@ -518,7 +518,7 @@ class GRASP(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -532,7 +532,7 @@ class GRASP(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/mlp.py
+++ b/pyhealth/models/mlp.py
@@ -243,7 +243,7 @@ class MLP(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
                 # (patient, embedding_dim)
                 x = self.mean_pooling(x, mask)
 
@@ -259,7 +259,7 @@ class MLP(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
                 # (patient, embedding_dim)
                 x = self.mean_pooling(x, mask)
 

--- a/pyhealth/models/mlp.py
+++ b/pyhealth/models/mlp.py
@@ -243,7 +243,7 @@ class MLP(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
                 # (patient, embedding_dim)
                 x = self.mean_pooling(x, mask)
 
@@ -259,7 +259,7 @@ class MLP(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
                 # (patient, embedding_dim)
                 x = self.mean_pooling(x, mask)
 

--- a/pyhealth/models/rnn.py
+++ b/pyhealth/models/rnn.py
@@ -318,7 +318,7 @@ class RNN(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -332,7 +332,7 @@ class RNN(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/rnn.py
+++ b/pyhealth/models/rnn.py
@@ -318,7 +318,7 @@ class RNN(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -332,7 +332,7 @@ class RNN(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/stagenet.py
+++ b/pyhealth/models/stagenet.py
@@ -465,7 +465,7 @@ class StageNet(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
                 mask_dict[feature_key] = mask
 
             # for case 2: [[code1, code2], [code3, ...], ...]
@@ -480,7 +480,7 @@ class StageNet(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
                 mask_dict[feature_key] = mask
 
             # for case 3: [[1.5, 2.0, 0.0], ...]

--- a/pyhealth/models/stagenet.py
+++ b/pyhealth/models/stagenet.py
@@ -465,7 +465,7 @@ class StageNet(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
                 mask_dict[feature_key] = mask
 
             # for case 2: [[code1, code2], [code3, ...], ...]
@@ -480,7 +480,7 @@ class StageNet(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
                 mask_dict[feature_key] = mask
 
             # for case 3: [[1.5, 2.0, 0.0], ...]

--- a/pyhealth/models/tcn.py
+++ b/pyhealth/models/tcn.py
@@ -380,7 +380,7 @@ class TCN(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -394,7 +394,7 @@ class TCN(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/tcn.py
+++ b/pyhealth/models/tcn.py
@@ -380,7 +380,7 @@ class TCN(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -394,7 +394,7 @@ class TCN(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/transformer.py
+++ b/pyhealth/models/transformer.py
@@ -374,7 +374,7 @@ class Transformer(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -388,7 +388,7 @@ class Transformer(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                mask = torch.sum(x, dim=2) != 0
+                maks = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):

--- a/pyhealth/models/transformer.py
+++ b/pyhealth/models/transformer.py
@@ -374,7 +374,7 @@ class Transformer(BaseModel):
                 # (patient, event, embedding_dim)
                 x = self.embeddings[feature_key](x)
                 # (patient, event)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 2: [[code1, code2], [code3, ...], ...]
             elif (dim_ == 3) and (type_ == str):
@@ -388,7 +388,7 @@ class Transformer(BaseModel):
                 # (patient, visit, embedding_dim)
                 x = torch.sum(x, dim=2)
                 # (patient, visit)
-                maks = torch.any(x !=0, dim=2)
+                mask = torch.any(x !=0, dim=2)
 
             # for case 3: [[1.5, 2.0, 0.0], ...]
             elif (dim_ == 2) and (type_ in [float, int]):


### PR DESCRIPTION
I was faced a bug that the sum of `dim` is 0 but the elements in dim are not zero. If using `sum` to get mask, this case will cause bugs. The right way is to use `torch.any(x !=0, dim=2)`.
