### PR TITLE
solve readthedoc build issue (due to upgrade of urllib3)

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,7 +8,7 @@ formats:
     - htmlzip
 
 python:
-    version: "3.11"
+    version: "3.8"
     install:
         - method: pip
           path: .

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,7 +8,7 @@ formats:
     - htmlzip
 
 python:
-    version: "3.8"
+    version: "3.11"
     install:
         - method: pip
           path: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ networkx>=2.6.3
 pandas>=1.3.2,<2
 pandarallel>=1.5.3
 mne>=1.0.3
+urllib3<=1.26.15
 numpy
 tqdm


### PR DESCRIPTION
- readthedocs build is down for the new urllib3=2.0.2, check out this issue https://github.com/readthedocs/readthedocs.org/issues/10290
- restrict the urllib version in requirements.txt solves the issue.