### PR TITLE
fix very low accuracy metric

### DIFF
--- a/pyhealth/__init__.py
+++ b/pyhealth/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+import sys
 
 __version__ = "1.1.3"
 
@@ -11,9 +12,8 @@ if not os.path.exists(BASE_CACHE_PATH):
 
 # logging
 logger = logging.getLogger(__name__)
-logger.propagate = False
 logger.setLevel(logging.INFO)
-handler = logging.StreamHandler()
+handler = logging.StreamHandler(sys.stdout)
 formatter = logging.Formatter("%(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)

--- a/pyhealth/medcode/utils.py
+++ b/pyhealth/medcode/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from urllib.parse import urljoin
 from urllib.request import urlretrieve
@@ -10,6 +11,8 @@ from pyhealth.utils import create_directory
 BASE_URL = "https://storage.googleapis.com/pyhealth/resource/"
 MODULE_CACHE_PATH = os.path.join(BASE_CACHE_PATH, "medcode")
 create_directory(MODULE_CACHE_PATH)
+
+logger = logging.getLogger(__name__)
 
 
 def download_and_read_csv(filename: str, refresh_cache: bool = False) -> pd.DataFrame:
@@ -29,5 +32,6 @@ def download_and_read_csv(filename: str, refresh_cache: bool = False) -> pd.Data
     local_filepath = os.path.join(MODULE_CACHE_PATH, filename)
     online_filepath = urljoin(BASE_URL, filename)
     if (not os.path.exists(local_filepath)) or refresh_cache:
+        logger.debug(f"downloading {online_filepath} to {local_filepath}")
         urlretrieve(online_filepath, local_filepath)
     return pd.read_csv(local_filepath, dtype=str)

--- a/pyhealth/metrics/multilabel.py
+++ b/pyhealth/metrics/multilabel.py
@@ -122,7 +122,7 @@ def multilabel_metrics_fn(
             )
             output["pr_auc_samples"] = pr_auc_samples
         elif metric == "accuracy":
-            accuracy = sklearn_metrics.accuracy_score(y_true, y_pred)
+            accuracy = sklearn_metrics.accuracy_score(y_true.flatten(), y_pred.flatten())
             output["accuracy"] = accuracy
         elif metric == "f1_micro":
             f1_micro = sklearn_metrics.f1_score(y_true, y_pred, average="micro")


### PR DESCRIPTION
The accuracy of multilabel task is ~0.002 no matter how tuned the parameters, comparing to the ~0.91 on the [benchmark](https://pyhealth.readthedocs.io/en/latest/#benchmark-on-healthcare-tasks). The reason for the low accuracy is that input of `sklearn_metrics.accuracy_score` is not flattened. Given a 200 classes prediction, the accuracy counts right when the 200 is exactly matched the ground truth. If we flatten the predictions and targets before calling `sklearn_metrics.accuracy_score`, then the accuracy is about the same as the benchmark.

Also, I have added some logging enhancement in this PR.