### PR TITLE
240119 fix build.io

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -13,7 +13,6 @@ formats:
     - htmlzip
 
 python:
-    version: "3.8"
     install:
         - method: pip
           path: .

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+
 sphinx:
     configuration: docs/conf.py
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,6 +2,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.8"
 
 sphinx:
     configuration: docs/conf.py


### PR DESCRIPTION
Due to an update in sphinx config file format, we need minor changes in the readthedocs.yaml file.
Follow https://docs.readthedocs.io/en/stable/config-file/v2.html#build