### PR TITLE
Fixing examples' bug in MIMIC-IV.

### DIFF
--- a/pyhealth/tasks/drug_recommendation.py
+++ b/pyhealth/tasks/drug_recommendation.py
@@ -114,7 +114,7 @@ def drug_recommendation_mimic4_fn(patient: Patient):
         >>> from pyhealth.datasets import MIMIC4Dataset
         >>> mimic4_base = MIMIC4Dataset(
         ...     root="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
-        ...     tables=["diagnoses_icd", "procedures_icd"],
+        ...     tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
         ...     code_mapping={"ICD10PROC": "CCSPROC"},
         ... )
         >>> from pyhealth.tasks import drug_recommendation_mimic4_fn

--- a/pyhealth/tasks/length_of_stay_prediction.py
+++ b/pyhealth/tasks/length_of_stay_prediction.py
@@ -105,7 +105,7 @@ def length_of_stay_prediction_mimic4_fn(patient: Patient):
         >>> from pyhealth.datasets import MIMIC4Dataset
         >>> mimic4_base = MIMIC4Dataset(
         ...     root="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
-        ...     tables=["diagnoses_icd", "procedures_icd"],
+        ...     tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
         ...     code_mapping={"ICD10PROC": "CCSPROC"},
         ... )
         >>> from pyhealth.tasks import length_of_stay_prediction_mimic4_fn

--- a/pyhealth/tasks/mortality_prediction.py
+++ b/pyhealth/tasks/mortality_prediction.py
@@ -82,7 +82,7 @@ def mortality_prediction_mimic4_fn(patient: Patient):
         >>> from pyhealth.datasets import MIMIC4Dataset
         >>> mimic4_base = MIMIC4Dataset(
         ...     root="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
-        ...     tables=["diagnoses_icd", "procedures_icd"],
+        ...     tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
         ...     code_mapping={"ICD10PROC": "CCSPROC"},
         ... )
         >>> from pyhealth.tasks import mortality_prediction_mimic4_fn

--- a/pyhealth/tasks/readmission_prediction.py
+++ b/pyhealth/tasks/readmission_prediction.py
@@ -86,7 +86,7 @@ def readmission_prediction_mimic4_fn(patient: Patient, time_window=15):
         >>> from pyhealth.datasets import MIMIC4Dataset
         >>> mimic4_base = MIMIC4Dataset(
         ...     root="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
-        ...     tables=["diagnoses_icd", "procedures_icd"],
+        ...     tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
         ...     code_mapping={"ICD10PROC": "CCSPROC"},
         ... )
         >>> from pyhealth.tasks import readmission_prediction_mimic4_fn


### PR DESCRIPTION
The tasks of Drug Recommendation, Length of Stay Prediction, Readmission Prediction, and Mortality Prediction for MIMIC-IV require the use of the 'prescriptions' table in the dataset; otherwise, the code will not run properly.