### PR TITLE
Add HurtfulWordsDataset and MaskedBiasScoreTask for masked language model evaluation

### DIFF
--- a/examples/masked_gender_bias_score.py
+++ b/examples/masked_gender_bias_score.py
@@ -1,0 +1,69 @@
+# ------------------------------------------------------------------------------
+# Example Script: HurtfulWordsDataset + MaskedBiasScoreTask
+#
+# Name:
+#   Zilal Eiz Al Din
+#
+# NetID:
+#   zelalae2
+#
+# Purpose:
+#   This script demonstrates how to:
+#   - Load the HurtfulWordsDataset (MIMIC-III noteevents) 
+#   - Apply the MaskedBiasScoreTask to compute gender bias scores
+#   - Iterate through the generated samples
+#   - Print patient information and bias-related log-probabilities
+#
+# Paper Reference:
+#   Hurtful Words: Quantifying Biases in Clinical Contextual Word Embeddings
+#   https://arxiv.org/abs/2003.11515
+#
+# Usage:
+#   This is a simple script for manual inspection and demonstration.
+#   To run:
+#       $ python example_hurtfulwords_task.py
+#
+# Note:
+#   This script assumes you have access to MIMIC-III CSVs at the specified root path.
+# ------------------------------------------------------------------------------
+from pyhealth.datasets import HurtfulWordsDataset
+from pyhealth.tasks import MaskedBiasScoreTask
+
+# ------------------------------------------------------------------------------
+# STEP 1: Load the HurtfulWordsDataset
+# ------------------------------------------------------------------------------
+
+# Update this path to point to your local MIMIC-III CSV files
+root='/srv/local/data/physionet.org/files/mimiciii/1.4'
+
+# Initialize the dataset
+dataset = HurtfulWordsDataset(root=f"{root}", tables=["noteevents"])
+
+# Print basic dataset statistics
+print(dataset.stats())
+
+# ------------------------------------------------------------------------------
+# STEP 2: Set the MaskedBiasScoreTask
+# ------------------------------------------------------------------------------k
+
+# Initialize the bias evaluation t
+task = MaskedBiasScoreTask()
+
+# Apply the task to the dataset
+sample_dataset = dataset.set_task(task)
+
+# ------------------------------------------------------------------------------
+# STEP 3: Iterate through the samples and display results
+# ------------------------------------------------------------------------------
+for sample in sample_dataset.samples:
+    patient_id = sample["patient_id"][0]  # Get the patient ID from the tuple
+    male_log_prob = round(sample["male_log_prob"].item(), 4)
+    female_log_prob = round(sample["female_log_prob"].item(), 4)
+    bias_score = round(sample["bias_score"].item(), 4)
+    masked_text = sample["masked_text"]   # Get the masked text
+    print(f"Patient ID: {patient_id}")
+    print(f"LogP(M): {male_log_prob}")
+    print(f"LogP(F): {female_log_prob}")
+    print(f"Bias Score: {bias_score}")
+    print(f"Masked Text:\n{masked_text[:300]}...")  # Print only first 300 characters
+    print("-" * 80)

--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -42,3 +42,4 @@ from .splitter import split_by_patient, split_by_sample, split_by_visit
 from .tuab import TUABDataset
 from .tuev import TUEVDataset
 from .utils import collate_fn_dict, collate_fn_dict_with_padding, get_dataloader
+from .hurtfulwords_dataset import HurtfulWordsDataset

--- a/pyhealth/datasets/hurtfulwords_dataset.py
+++ b/pyhealth/datasets/hurtfulwords_dataset.py
@@ -1,0 +1,234 @@
+
+# ------------------------------------------------------------------------------
+# Contribution Header
+#
+# Name: 
+#   Zilal Eiz Al Din
+#
+# NetID: 
+#   zelalae2@illinois.edu
+#
+# Paper Title: 
+#   Hurtful Words: Quantifying Biases in Clinical Contextual Word Embeddings
+#
+# Paper Link:
+#   https://arxiv.org/pdf/2003.11515
+#
+#   This contribution implements the HurtfulWordsDataset, a new dataset class 
+#   within the PyHealth framework. The HurtfulWordsDataset is designed to 
+#   preprocess clinical notes from the MIMIC-III database by applying 
+#   de-identification masking (PHI replacement) and gendered term masking, 
+#   to support masked language model evaluation tasks.
+#
+#   The dataset class reads from NOTEEVENTS tables, applies cleaning and 
+#   masking logic aligned with the "Hurtful Words" paper, and prepares input 
+#   samples compatible with bias evaluation tasks that require masked templates.
+#
+#   Main preprocessing steps include:
+#   - Replacing protected health information (PHI) fields with placeholder tokens.
+#   - Masking gendered words such as "he", "she", "male", "female", etc.
+#   - Cleaning formatting artifacts (line breaks, numbering, underscores).
+#
+#   This implementation enables reproducibility of masked bias evaluation 
+#   experiments on ClinicalBERT and related models, directly following the 
+#   methodology described in the "Hurtful Words" paper.
+# ------------------------------------------------------------------------------
+
+import os
+import re
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import polars as pl
+from nltk.tokenize import sent_tokenize
+from pyhealth.datasets import BaseDataset
+
+logger = logging.getLogger(__name__)
+
+
+class HurtfulWordsDataset(BaseDataset):
+    """Dataset class for masked language modeling on de-identified clinical notes.
+
+    This dataset parses NOTEEVENTS from MIMIC-III and applies preprocessing
+    including PHI masking and gendered term masking.
+
+    Attributes:
+        root: Directory containing the MIMIC-III CSV files.
+        tables: List of tables to load, must include "noteevents".
+        dataset_name: Name of the dataset.
+        config_path: Path to YAML config file.
+    """
+
+    def __init__(
+        self,
+        root: str,
+        tables: List[str],
+        dataset_name: Optional[str] = None,
+        config_path: Optional[str] = None,
+    ):
+        """Initializes HurtfulWordsDataset.
+
+        Args:
+            root: Directory containing CSV files.
+            tables: List of tables to load (must include "noteevents").
+            dataset_name: Optional name of the dataset (default: "hurtfulwords").
+            config_path: Optional path to YAML config (default: mimic3.yaml).
+        """
+        if config_path is None:
+            config_path = Path(__file__).parent / "configs" / "mimic3.yaml"
+
+        assert "noteevents" in tables, "Must include 'noteevents' in tables."
+
+        super().__init__(
+            root=root,
+            tables=tables,
+            dataset_name=dataset_name or "hurtfulwords",
+            config_path=config_path,
+        )
+
+    @property
+    def collected_global_event_df(self) -> pl.DataFrame:
+        """Returns preprocessed event DataFrame with masked text.
+
+        Filtering and masking are applied:
+        - Only specific note categories are kept.
+        - PHI patterns are replaced.
+        - Gendered terms are masked.
+
+        Returns:
+            A Polars DataFrame containing patient_id, event_type, timestamp,
+            and a masked note text.
+
+        Example:
+            dataset.collected_global_event_df.select(["patient_id", "noteevents/masked_text"])
+        """
+        df = super().collected_global_event_df
+
+        allowed_categories = [
+            "Nursing", "Nursing/other", "Physician", "Discharge summary"
+        ]
+        df = df.filter(pl.col("noteevents/category").is_in(allowed_categories))
+
+        if "noteevents/text" not in df.columns:
+            raise ValueError("Missing expected column: noteevents/text")
+
+        df = df.with_columns([
+            pl.col("noteevents/text").map_elements(
+                self._process_note,
+                return_dtype=pl.Utf8
+            ).alias("noteevents/masked_text")
+        ])
+
+        return df
+
+    def _process_note(self, note: str) -> str:
+        """Applies full preprocessing to a clinical note.
+
+        This includes PHI masking, gendered word masking, and formatting cleanups.
+
+        Args:
+            note: The raw clinical note as a string.
+
+        Returns:
+            A cleaned and masked version of the note as a string.
+
+        Example:
+            masked_note = self._process_note("Patient is a 45-year-old male admitted...")
+        """
+        note = self._replace_phi(note)
+        note = self._mask_gendered_terms(note)
+        note = self._clean_note_format(note)
+        return note
+
+    def _replace_phi(self, text: str) -> str:
+        """Replaces de-identified PHI tags (e.g., **NAME**) with placeholders.
+
+        Args:
+            text: Input text string containing PHI tags.
+
+        Returns:
+            String with PHI tags replaced with generic tokens like PHINAMEPHI.
+
+        Example:
+            result = self._replace_phi("Patient [**Name**] admitted to [**Hospital**]")
+        """
+        return re.sub(r'\[\*\*(.*?)\*\*\]', self._repl_phi, text)
+
+    def _repl_phi(self, match: re.Match) -> str:
+        """Replacement logic for PHI fields based on keyword detection.
+
+        Args:
+            match: A regex match object from _replace_phi().
+
+        Returns:
+            Replacement string based on PHI type (e.g., PHINAMEPHI).
+        """
+        label = match.group(1).lower().strip()
+
+        if self._is_date(label) or "holiday" in label:
+            return "PHIDATEPHI"
+        elif "hospital" in label:
+            return "PHIHOSPITALPHI"
+        elif any(word in label for word in ["location", "university", "state", "country"]):
+            return "PHILOCATIONPHI"
+        elif any(word in label for word in ["name", "attending", "dictator", "contact"]):
+            return "PHINAMEPHI"
+        elif "telephone" in label or "number" in label:
+            return "PHINUMBERPHI"
+        elif "age over 90" in label:
+            return "PHIAGEPHI"
+        else:
+            return "PHIOTHERPHI"
+
+    def _is_date(self, s: str) -> bool:
+        """Checks if a string looks like a date.
+
+        Args:
+            s: The input string.
+
+        Returns:
+            Boolean indicating whether the string resembles a date.
+
+        Example:
+            True if input is "2003-04-25" or contains "month", "year".
+        """
+        return bool(re.search(r"\d{4}-\d{1,2}-\d{1,2}", s) or "month" in s or "year" in s)
+
+    def _mask_gendered_terms(self, text: str) -> str:
+        """Masks gender-related words with [MASK].
+
+        Args:
+            text: Clinical note text after PHI replacement.
+
+        Returns:
+            Text with gendered words replaced.
+
+        Example:
+            "The patient is a male" -> "The patient is a [MASK]"
+        """
+        return re.sub(
+            r"\b(male|gentleman|man|he|female|woman|she|his|her|him)\b",
+            "[MASK]",
+            text,
+            flags=re.IGNORECASE
+        )
+
+    def _clean_note_format(self, note: str) -> str:
+        """Final formatting cleanup on a clinical note.
+
+        Args:
+            note: Partially processed clinical note.
+
+        Returns:
+            Cleaned note text.
+
+        Example:
+            Removes line breaks, list numbers, underscores, etc.
+        """
+        note = re.sub(r'\n', ' ', note)
+        note = re.sub(r'[0-9]+\.', '', note)
+        note = re.sub(r'[-_=]{2,}', '', note)
+        note = re.sub(r'\bdr\.', 'doctor', note, flags=re.IGNORECASE)
+        note = re.sub(r'\bm\.d\.', 'md', note, flags=re.IGNORECASE)
+        return note.strip()

--- a/pyhealth/tasks/masked_bias_score.py
+++ b/pyhealth/tasks/masked_bias_score.py
@@ -1,0 +1,149 @@
+# ------------------------------------------------------------------------------
+# Contribution Header
+#
+# Name: 
+#   Zilal Eiz Al Din
+#
+# NetID: 
+#   zelalae2@illinois.edu
+#
+# Paper Title: 
+#   Hurtful Words: Quantifying Biases in Clinical Contextual Word Embeddings
+#
+# Paper Link:
+#   https://arxiv.org/pdf/2003.11515
+#
+# This contribution implements the MaskedBiasScoreTask, a task implements masked token prediction evaluation to quantify gender bias
+# in masked language models applied to clinical notes.
+
+# Given clinical notes with gendered words masked (e.g., "he", "she", "male", "female" replaced with [MASK]), 
+# this task computes the model's log-probability of predicting "he" versus "she" at each masked position.
+
+# For each input sample (a masked clinical note), the task outputs:
+# - The log-probability assigned to "he" (male_log_prob)
+# - The log-probability assigned to "she" (female_log_prob)
+# - The bias score, computed as (male_log_prob - female_log_prob)
+
+# Inputs:
+# - `masked_text` (text): Clinical note with gendered words masked with [MASK].
+
+# Outputs:
+# - `male_log_prob` (regression): Log probability assigned to "he" at the masked position.
+# - `female_log_prob` (regression): Log probability assigned to "she" at the masked position.
+# - `bias_score` (regression): Difference between male and female log-probabilities.
+
+# This task supports masked language model evaluation for reproducibility of experiments 
+# described in "Hurtful Words: Quantifying Biases in Clinical Contextual Word Embeddings" (2020).
+
+# Example Usage:
+#     >>> task = MaskedBiasScoreTask()
+#     >>> sample_dataset = dataset.set_task(task)
+#     >>> print(sample_dataset.samples[0])  # print one sample
+#------------------------------------------------------------------------------
+from dataclasses import dataclass, field
+from pyhealth.data.data import Patient
+from typing import Dict, List
+
+from pyhealth.tasks import BaseTask
+from pyhealth.data import Patient
+from transformers import AutoTokenizer, AutoModelForMaskedLM
+import torch
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MaskedBiasScoreTask(BaseTask):
+    logger.info("Task Started!")
+    """Task to compute male/female log-probability difference from masked notes.
+
+    Args:
+        task_name (str): Name of the task.
+        input_schema (Dict): Expected input fields from the patient data.
+        output_schema (Dict): Output fields after processing.
+
+    Example:
+        >>> from pyhealth.tasks import MaskedBiasScoreTask
+        >>> task = MaskedBiasScoreTask()
+        >>> print(task)
+    """
+
+    task_name: str = "masked_bias_score"
+    input_schema: Dict[str, str] = field(default_factory=lambda: {"masked_text": "text"})
+    output_schema: Dict[str, str] = field(default_factory=lambda: {
+        "male_log_prob": "regression",
+        "female_log_prob": "regression",
+        "bias_score": "regression",
+    })
+
+    def __call__(self, patient: Patient) -> List[Dict]:
+        """Processes one patient to calculate male/female log-probability difference.
+
+        Args:
+            patient (Patient): A PyHealth Patient object containing masked text.
+
+        Returns:
+            List[Dict]: A list of one or more dictionaries containing:
+                - patient_id
+                - visit_id
+                - male_log_prob
+                - female_log_prob
+                - bias_score
+        """
+        samples = []
+
+        # Load HuggingFace model once (can optimize if needed)
+        model_name = "bert-base-uncased"
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = AutoModelForMaskedLM.from_pretrained(model_name)
+        model.eval()
+
+        male_token = "he"
+        female_token = "she"
+        
+
+        for event in patient.get_events(event_type="noteevents"):
+            visit_id = event.attr_dict.get("visit_id")
+            text = event.attr_dict.get("masked_text")
+            if not text or "[MASK]" not in text:
+                continue
+
+            # Tokenize input
+            inputs = tokenizer(text, return_tensors="pt", truncation=True, max_length=512)
+            with torch.no_grad():
+                outputs = model(**inputs)
+                logits = outputs.logits
+
+            # Find [MASK] token position
+            mask_token_index = (inputs.input_ids == tokenizer.mask_token_id).nonzero(as_tuple=True)[1]
+            if len(mask_token_index) == 0:
+                continue
+
+            mask_logits = logits[0, mask_token_index, :]
+            log_probs = torch.nn.functional.log_softmax(mask_logits, dim=-1)
+
+            male_id = tokenizer.convert_tokens_to_ids(male_token)
+            female_id = tokenizer.convert_tokens_to_ids(female_token)
+
+            male_log_prob = log_probs[0, male_id].item()
+            female_log_prob = log_probs[0, female_id].item()
+            bias_score = male_log_prob - female_log_prob
+
+            sample = {
+                "patient_id": patient.patient_id,
+                "timestamp": event.timestamp,
+                "male_log_prob": male_log_prob,
+                "female_log_prob": female_log_prob,
+                "bias_score": bias_score,
+                "masked_text": text
+            }
+            samples.append(sample)
+
+        return samples
+
+
+if __name__ == "__main__":
+    task = MaskedBiasScoreTask()
+    print(task)
+    print(type(task))

--- a/pyhealth/unittests/test_datasets/test_hurtfulwords_cleaning_data.py
+++ b/pyhealth/unittests/test_datasets/test_hurtfulwords_cleaning_data.py
@@ -1,0 +1,70 @@
+# ------------------------------------------------------------------------------
+# Unit Tests for HurtfulWordsDataset
+#
+# Name:
+#   Zilal Eiz Al Din
+#
+# NetID:
+#   zelalae2
+#
+# Purpose:
+#   This file contains unit tests for verifying the preprocessing logic of 
+#   the HurtfulWordsDataset, including:
+#   - PHI replacement
+#   - Gendered word masking
+#   - Clinical note formatting cleanup
+#
+# Dataset:
+#   HurtfulWordsDataset from pyhealth.datasets
+#
+# Usage:
+#   Run `pytest` to automatically discover and run these tests.
+# ------------------------------------------------------------------------------
+
+import pytest
+from pyhealth.datasets import HurtfulWordsDataset
+
+# STEP 1: Load dataset
+# Update the root path to where MIMIC-III CSVs are stored
+root='/content/drive/MyDrive/Data/physionet.org/files/mimiciii/1.4'
+dataset = HurtfulWordsDataset(root=f"{root}", tables=["noteevents"])
+
+# ------------------------------------------------------------------------------
+# Test 1: PHI Replacement
+# ------------------------------------------------------------------------------
+
+def test_phi_replacement():
+    test_note = "Patient admitted to [**Hospital**] on [**Date**]. Treated by [**Name**]."
+    masked_note = dataset._replace_phi(test_note)
+    assert "PHIHOSPITALPHI" in masked_note
+    assert "PHINAMEPHI" in masked_note
+# ------------------------------------------------------------------------------
+# Test 2: Gendered Word Masking
+# ------------------------------------------------------------------------------
+
+def test_gendered_word_masking():
+    test_note = "The patient is a male and he was treated."
+    masked_note = dataset._mask_gendered_terms(test_note)
+    assert "[MASK]" in masked_note
+    assert "male" not in masked_note.lower()
+
+# ------------------------------------------------------------------------------
+# Test 3: Clinical Note Formatting
+# ------------------------------------------------------------------------------
+
+def test_clean_note_format():
+    dirty_note = "1. This is a line\n2. Another line\n--- end ---"
+    clean_note = dataset._clean_note_format(dirty_note)
+    assert "\n" not in clean_note
+    assert "---" not in clean_note
+    assert clean_note.startswith("This is a line")
+
+# ------------------------------------------------------------------------------
+# Run tests directly (if needed)
+# ------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    test_phi_replacement()
+    test_gendered_word_masking()
+    test_clean_note_format()
+    print("All HurtfulWordsDataset tests passed successfully!")

--- a/pyhealth/unittests/test_datasets/test_hurtfulwords_logP_task.py
+++ b/pyhealth/unittests/test_datasets/test_hurtfulwords_logP_task.py
@@ -1,0 +1,84 @@
+# ------------------------------------------------------------------------------
+# Integration Test for HurtfulWordsDataset + MaskedBiasScoreTask
+#
+# Name:
+#   Zilal Eiz Al Din
+#
+# NetID:
+#   zelalae2
+#
+# Purpose:
+#   This file contains an integration test that verifies end-to-end functionality
+#   of the HurtfulWordsDataset and MaskedBiasScoreTask combination. 
+#
+#   It checks that:
+#   - The dataset can be loaded from MIMIC-III NOTEEVENTS.
+#   - The preprocessing (PHI masking, gender masking) works.
+#   - The MaskedBiasScoreTask can successfully compute male and female 
+#     log-probabilities and bias scores.
+#   - The outputs are correctly typed and formatted.
+#
+# Dataset:
+#   HurtfulWordsDataset (MIMIC-III)
+#
+# Task:
+#   MaskedBiasScoreTask
+#
+# Usage:
+#   Run `pytest` to automatically discover and run this integration test.
+# ------------------------------------------------------------------------------
+
+import pytest
+import torch
+from pyhealth.datasets import HurtfulWordsDataset
+from pyhealth.tasks import MaskedBiasScoreTask
+
+# Path to your local MIMIC-III CSVs
+MIMIC_ROOT = "/srv/local/data/physionet.org/files/mimiciii/1.4"
+
+# ------------------------------------------------------------------------------
+# Integration Test
+# ------------------------------------------------------------------------------
+@pytest.mark.integration
+def test_hurtfulwords_dataset_with_maskedbiasscoretask():
+    # STEP 1: Load dataset
+    dataset = HurtfulWordsDataset(root=f"{MIMIC_ROOT}", tables=["noteevents"])
+
+    # Call it to print 
+    dataset.stats()
+
+    # STEP 2: Set the task
+    task = MaskedBiasScoreTask()
+    sample_dataset = dataset.set_task(task)
+
+    # SampleDataset should not be empty
+    assert len(sample_dataset) > 0
+
+    # STEP 3: Iterate over a few samples
+    for sample in sample_dataset.samples[:10]:
+        assert "patient_id" in sample
+        assert "masked_text" in sample
+        assert "male_log_prob" in sample
+        assert "female_log_prob" in sample
+        assert "bias_score" in sample
+
+        assert isinstance(sample["masked_text"], str)
+        assert isinstance(sample["male_log_prob"], torch.Tensor)
+        assert isinstance(sample["female_log_prob"], torch.Tensor)
+        assert isinstance(sample["bias_score"], torch.Tensor)
+
+        male_log_prob = round(sample["male_log_prob"].item(), 4)
+        female_log_prob = round(sample["female_log_prob"].item(), 4)
+        bias_score = round(sample["bias_score"].item(), 4)
+
+        assert isinstance(male_log_prob, float)
+        assert isinstance(female_log_prob, float)
+        assert isinstance(bias_score, float)
+
+# ------------------------------------------------------------------------------
+# Run manually if needed
+# ------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    test_hurtfulwords_dataset_with_maskedbiasscoretask()
+    print("Integration test for HurtfulWordsDataset and MaskedBiasScoreTask passed successfully!")


### PR DESCRIPTION
- I am Zilal Eiz Al Din - with NetId: zelalae2@illinois.edu
- I have added a Contribution to Datasets by adding the HurtfulWordsDataset Class, and a Contribution to the Tasks by adding the MaskedBiasScoreTask Class with unittests (test_hurtfulwords_cleaning_data.py and test_hurtfulwords_logP_task.py) and an example (masked_gender_bias_score.py)
- I added these contributions based on the paper called 'Hurtful Words: Quantifying Biases in Clinical Contextual Word
Embeddings' to have a dataset with MASK gendered words (he, she, male, female.. ) and to calculate the log probability of the masked word as a task.
- Includes unit tests and example scripts.
- Rebased with latest sunlabuiuc/main.
- Allow maintainers to edit this PR for minor changes.
- To test the code, under unittests folder, there is two files called test_hurtfulwords_cleaning_data.py and test_hurtfulwords_logP_task.py), you can run them.
- To test the code, under examples folder, there is a file called masked_gender_bias_score.py.

