### PR TITLE
Contribution from pravins2 and ktandon3

### DIFF
--- a/pyhealth/models/attnmodel.py
+++ b/pyhealth/models/attnmodel.py
@@ -1,0 +1,56 @@
+import torch
+import torch.nn as nn
+from transformers import AutoModel
+from pyhealth.models import BaseModel
+
+# Define a new model that extends PyHealth's BaseModel
+class AttentionClinicalBERT(BaseModel):
+    def __init__(
+        self,
+        dataset,
+        mode: str = "multilabel",
+        model_name: str = "emilyalsentzer/Bio_ClinicalBERT",
+        hidden_size: int = 768,
+        dropout: float = 0.1,
+        num_attention_heads: int = 1,
+    ):
+        # Initialize the parent BaseModel with dataset and task settings
+        super(AttentionClinicalBERT, self).__init__(
+            dataset=dataset, mode=mode, feature_keys=["note"], target_keys=["labels"],
+        )
+
+        # Load a pretrained ClinicalBERT model
+        self.bert = AutoModel.from_pretrained(model_name)
+
+        # Dropout layer for regularization
+        self.dropout = nn.Dropout(dropout)
+
+        # Multihead attention layer applied over token-level BERT outputs
+        self.attention = nn.MultiheadAttention(embed_dim=hidden_size, num_heads=num_attention_heads, batch_first=True)
+
+        # Final classification layer mapping attention output to target size
+        self.classifier = nn.Linear(hidden_size, self.output_size)
+
+    def forward(self, **kwargs):
+        # Extract token IDs and attention masks from input
+        input_ids = kwargs["note"]["input_ids"]  # shape: [B, T]
+        attention_mask = kwargs["note"]["attention_mask"]  # shape: [B, T]
+
+        # Forward pass through BERT to get token-level embeddings
+        outputs = self.bert(input_ids=input_ids, attention_mask=attention_mask)
+        hidden_states = outputs.last_hidden_state  # shape: [B, T, H]
+
+        # Apply self-attention across token embeddings
+        # key_padding_mask should be False where tokens are valid
+        attn_output, _ = self.attention(hidden_states, hidden_states, hidden_states, key_padding_mask=~attention_mask.bool())
+
+        # Pool the attended output by averaging over the token dimension
+        pooled_output = attn_output.mean(dim=1)  # shape: [B, H]
+
+        # Apply dropout to the pooled representation
+        pooled_output = self.dropout(pooled_output)
+
+        # Run the pooled output through the classification head
+        logits = self.classifier(pooled_output)  # shape: [B, num_labels]
+
+        return logits

--- a/pyhealth/models/notes.txt
+++ b/pyhealth/models/notes.txt
@@ -1,0 +1,40 @@
+This model extends BaseModel and adds attention-based pooling on top of ClinicalBERT for multi-label classification tasks.
+Uses ClinicalBERT to extract token-level embeddings
+
+Applies multi-head attention to decide which tokens to focus on
+
+Pool the result and run it through a linear head for prediction
+
+
+
+
+Init function added parameters for 
+dataset: The PyHealth dataset object
+
+mode: Task type (multilabel, binary, or multiclass)
+
+model_name: HF model name for ClinicalBERT
+
+hidden_size: Dimensionality of BERT hidden states
+
+dropout: Dropout for regularization
+
+num_attention_heads: Number of heads for the self-attention module
+
+Adds self-attention across the token sequence — so the model can learn to weigh which tokens matter more.
+
+self.classifier = nn.Linear(hidden_size, self.output_size)
+
+
+Forward function 
+Returns token embeddings for each word in each sample.
+outputs = self.bert(input_ids=input_ids, attention_mask=attention_mask)
+hidden_states = outputs.last_hidden_state  # shape: [B, T, H]
+
+Applies multi-head self-attention across tokens
+
+Learns a weighted sum of token embeddings
+
+key_padding_mask ensures that padding tokens are ignored
+
+Then runs a linear classifier to get predictions (before sigmoid for multilabel)


### PR DESCRIPTION
This model extends BaseModel and adds attention-based pooling on top of ClinicalBERT for multi-label classification tasks. Uses ClinicalBERT to extract token-level embeddings

Applies multi-head attention to decide which tokens to focus on

Pool the result and run it through a linear head for prediction

Init function added parameters for
dataset: The PyHealth dataset object

mode: Task type (multilabel, binary, or multiclass)

model_name: HF model name for ClinicalBERT

hidden_size: Dimensionality of BERT hidden states

dropout: Dropout for regularization

num_attention_heads: Number of heads for the self-attention module

Adds self-attention across the token sequence — so the model can learn to weigh which tokens matter more.

self.classifier = nn.Linear(hidden_size, self.output_size)

Forward function
Returns token embeddings for each word in each sample. outputs = self.bert(input_ids=input_ids, attention_mask=attention_mask) hidden_states = outputs.last_hidden_state  # shape: [B, T, H]

Applies multi-head self-attention across tokens

Learns a weighted sum of token embeddings

key_padding_mask ensures that padding tokens are ignored

Then runs a linear classifier to get predictions (before sigmoid for multilabel)