### PR TITLE
Chatbot support for local models

### DIFF
--- a/chat-assistant/README.md
+++ b/chat-assistant/README.md
@@ -20,7 +20,7 @@ python app_rag.py
 
 ### Launch in Docker
 
-1. Modfiy environment variables (OPENAI_API_KEY, server address...)in `Dockerfile`.
+1. Modify environment variables (OPENAI_API_KEY, server address...)in `Dockerfile`.
 2. Build image by `docker build -t chat-pyhealth .`.
 3. Debug a container by `docker run -p 0.0.0.0:7861:7861 --name chat-pyhealth-c -v ./logs/:/app/logs/ chat-pyhealth`.
 4. Run a container by `docker run -d -p 0.0.0.0:7861:7861 --name chat-pyhealth-c -v ./logs/:/app/logs/ chat-pyhealth`.

--- a/chat-assistant/README.md
+++ b/chat-assistant/README.md
@@ -47,5 +47,28 @@ docker rmi chat-pyhealth # image
 docker cp [local file in host] chat-pyhealth-c:[container path]
 ```
 
+## Using a Local Model 
+You can also run an instance of a chat assistant that doesn't use an external LLM. There is a simple chat interface (source code is in [chat.py](/chat-assistant/chat.py)). This chat interface uses Streamlit, and the model is served using Ollama, so please install those too. 
+
+You can find the documentation for Ollama [here](https://ollama.com). Follow the installation steps listed there.
+
+To install Streamlit, run:
+
+```{python}
+pip install streamlit
+```
+
+### Steps to Run
+Please follow the steps (in order!) to get started.
+
+1. Navigate into the `chat-assistant` directory
+2. Generate the documents needed for embeddings:
+```{python}
+python generate_context.py
+```
+3. Start the app:
+```{python}
+streamlit run chat.py
+```
 
 **Let me know if you want to join and help us improve the current interface.**

--- a/chat-assistant/chat.py
+++ b/chat-assistant/chat.py
@@ -1,0 +1,80 @@
+import streamlit as st
+from sentence_transformers import SentenceTransformer
+import faiss
+import numpy as np
+import requests
+import pickle
+import faiss
+from sentence_transformers import SentenceTransformer
+import faiss
+import numpy as np
+
+model_base_url = "http://localhost:11501"
+
+# Load your saved data
+with open("docs.pkl", "rb") as f:
+    docs = pickle.load(f)  # Should be a list of strings or dicts
+
+# Detect and convert LangChain-style Document objects
+if hasattr(docs[0], "page_content"):
+    texts = [doc.page_content for doc in docs]
+elif isinstance(docs[0], dict):
+    texts = [doc["text"] for doc in docs]
+else:
+    texts = docs  # assume already a list of strings
+
+
+embedding_model = SentenceTransformer("all-MiniLM-L6-v2")
+doc_embeddings = embedding_model.encode(texts, show_progress_bar=True)
+
+index = faiss.IndexFlatL2(doc_embeddings.shape[1])
+index.add(np.array(doc_embeddings))
+
+def retrieve(query, top_k=3):
+    query_embedding = embedding_model.encode([query])
+    D, I = index.search(np.array(query_embedding), top_k)
+    results = [texts[i] for i in I[0]]
+
+    # Ensure results are all strings (in case still Document objects)
+    return [
+        r.page_content if hasattr(r, "page_content") else str(r)
+        for r in results
+    ]
+
+
+def generate_with_ollama(prompt, model="llama3"):
+    try:
+        res = requests.post(
+            model_base_url,
+            json={"model": model, "prompt": prompt, "stream": False}
+        )
+        return res.json().get("response", "[No response]")
+    except Exception as e:
+        return f"[Error contacting Ollama]: {e}"
+
+def rag_ask(query):
+    context = retrieve(query, top_k=3)
+    context_text = "\n".join(context)
+    # Adjust prompt if needed
+    prompt = f"""Answer the question using the context below. If the answer is not in the context, say you don't know.
+
+Context:
+{context_text}
+
+Question: {query}
+Answer:"""
+    return generate_with_ollama(prompt)
+
+# Streamlit UI
+st.title("🧠 Local RAG Chat (FAISS + Ollama)")
+if "history" not in st.session_state:
+    st.session_state.history = []
+
+user_input = st.text_input("Ask a question", key="input")
+if user_input:
+    response = rag_ask(user_input)
+    st.session_state.history.append((user_input, response))
+
+for q, a in reversed(st.session_state.history):
+    st.markdown(f"**You:** {q}")
+    st.markdown(f"**Assistant:** {a}")

--- a/chat-assistant/generate_context.py
+++ b/chat-assistant/generate_context.py
@@ -1,0 +1,30 @@
+from langchain.text_splitter import CharacterTextSplitter
+from langchain.document_loaders import UnstructuredFileLoader
+from langchain.vectorstores.faiss import FAISS
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.embeddings import OpenAIEmbeddings
+import pickle
+import os
+from langchain.embeddings import OllamaEmbeddings
+
+def vectorize_corpus(corpus_path):
+    print(f"Vectorizing {corpus_path}...")
+    loader = UnstructuredFileLoader(corpus_path)
+    raw_documents = loader.load()
+
+    print("Splitting text...")
+    text_splitter = CharacterTextSplitter(
+        separator="\n\n",
+        chunk_size=600,
+        chunk_overlap=100,
+        length_function=len,
+    )
+   
+    # Create the document embeddings
+    documents = text_splitter.split_documents(raw_documents)
+    with open("docs.pkl", "wb") as f:
+        pickle.dump(documents, f)
+
+
+vectorize_corpus('corpus/pyhealth-text.txt')
+vectorize_corpus('corpus/pyhealth-code.txt')


### PR DESCRIPTION
**Netid(s):** alvinjz2, pouriam2
**Type of contribution:** Other/feature enhancement
**Description:** There is a chat assistant in the repo, but it requires credits/access to OpenAI's API. I personally do not have any credits so I could not make use of the chat assistant in the repo. So, I decided to add functionality to use a local model instead of an external one. 
**Files to look at:** `generate_context.py` and `chat.py`