### PR TITLE
MIMIC4CXRDataset In-memory Metadata & Overwritable default_tables

### DIFF
--- a/pyhealth/datasets/mimic3.py
+++ b/pyhealth/datasets/mimic3.py
@@ -42,8 +42,8 @@ class MIMIC3Dataset(BaseDataset):
         if config_path is None:
             logger.info("No config path provided, using default config")
             config_path = Path(__file__).parent / "configs" / "mimic3.yaml"
-        default_tables = ["patients", "admissions", "icustays"]
-        tables = default_tables + tables
+            default_tables = ["patients", "admissions", "icustays"]
+            tables = default_tables + tables
         if "prescriptions" in tables:
             warnings.warn(
                 "Events from prescriptions table only have date timestamp (no specific time). "

--- a/pyhealth/datasets/mimic4.py
+++ b/pyhealth/datasets/mimic4.py
@@ -52,10 +52,11 @@ class MIMIC4EHRDataset(BaseDataset):
         if config_path is None:
             config_path = os.path.join(os.path.dirname(__file__), "configs", "mimic4_ehr.yaml")
             logger.info(f"Using default EHR config: {config_path}")
+            default_tables = ["patients", "admissions", "icustays"]
+            tables = tables + default_tables
 
         log_memory_usage(f"Before initializing {dataset_name}")
-        default_tables = ["patients", "admissions", "icustays"]
-        tables = tables + default_tables
+
         super().__init__(
             root=root,
             tables=tables,


### PR DESCRIPTION
NetId: bwg2
Type of contribution: Other/feature enhancement
Description: 
  - Updated mimic3/4 datasets to support overwriting default tables when utilizing a custom config
  - Modified MIMIC4CXRDataset's metadata process to eliminate the need for disk i/o when creating derived metadata columns.
    - Original file is processed on init with polars lazy-values configured for filepath and studytime, returned through an implementation of load_table 
Files to look at: mimi3.py, mimic4.py
