### PR TITLE
Add the MIMIC-SBDH dataset loader class

### DIFF
--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -38,6 +38,7 @@ from .omop import OMOPDataset
 from .sample_dataset import SampleDataset
 from .shhs import SHHSDataset
 from .sleepedf import SleepEDFDataset
+from .sbdh import SBDHDataset
 from .splitter import split_by_patient, split_by_sample, split_by_visit
 from .tuab import TUABDataset
 from .tuev import TUEVDataset

--- a/pyhealth/datasets/configs/sbdh.yaml
+++ b/pyhealth/datasets/configs/sbdh.yaml
@@ -1,0 +1,22 @@
+version: "1.0"
+tables:
+  sbdh:
+    file_path: "MIMIC-SBDH.csv"
+    patient_id: "row_id"
+    join:
+      - file_path: "NOTEEVENTS.csv"
+        "on": "row_id"
+        how: "inner"
+        columns:
+          - "text"
+    timestamp: null
+    attributes:
+    - "sdoh_community_present"
+    - "sdoh_community_absent"
+    - "sdoh_education"
+    - "sdoh_economics"
+    - "sdoh_environment"
+    - "behavior_alcohol"
+    - "behavior_tobacco"
+    - "behavior_drug"
+    - "text"

--- a/pyhealth/datasets/sbdh.py
+++ b/pyhealth/datasets/sbdh.py
@@ -1,0 +1,117 @@
+"""
+MIMIC-SBDH Dataset Loader
+
+Authors: Youye Xie, Lanou Qu
+NetID: youyex2, lanouqu2
+Paper Title: MIMIC-SBDH: A Dataset for Social and Behavioral Determinants of Health
+Paper Link: https://proceedings.mlr.press/v149/ahsan21a/ahsan21a.pdf
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional
+import polars as pl
+import pandas as pd
+import re
+from .base_dataset import BaseDataset
+
+logger = logging.getLogger(__name__)
+
+
+class SBDHDataset(BaseDataset):
+    """
+    A dataset class for handling MIMIC-SBDH data.
+
+    This module implements the `SBDHDataset` class, a custom dataset class for loading 
+    and managing the MIMIC-SBDH dataset using the PyHealth framework. It combines 
+    social history free-text data from MIMIC-III NOTEEVENTS with structured SBDH 
+    labels provided by the MIMIC-SBDH project.
+
+    SBDH label (MIMIC-SBDH.csv) is available at https://github.com/hibaahsan/MIMIC-SBDH/blob/main/MIMIC-SBDH.csv
+    The MIMIC-III NOTEEVENTS (NOTEEVENTS.csv) is available at https://physionet.org/content/mimiciii/1.4/
+
+    Key Features:
+    - Loads both `MIMIC-SBDH.csv` (labels) and `NOTEEVENTS.csv` (clinical notes) located under a specified root directory.
+    - Extracts the "Social History" sections from clinical notes using regular expressions.
+    - Preprocesses text fields and prepares them as global events in the dataset.
+    - Supports standard PyHealth dataset methods such as `stats()`, `get_patient()`, and `get_events()`.
+
+    Attributes:
+        root (str): The root directory where the dataset is stored.
+        tables (List[str]): A list of tables to be included in the dataset.
+        dataset_name (Optional[str]): The name of the dataset.
+        config_path (Optional[str]): The path to the configuration file.
+    """
+
+    def __init__(
+        self,
+        root: str,
+        tables: Optional[str] = None,
+        dataset_name: Optional[str] = None,
+        config_path: Optional[str] = None,
+        **kwargs
+    ) -> None:
+        """
+        Initializes the MIMIC-SBDH with the specified parameters.
+
+        Args:
+            root (str): The root directory where the dataset is stored.
+            tables (Optional[str]): A list of additional tables to include.
+            dataset_name (Optional[str]): The name of the dataset. Defaults to "sbdh".
+            config_path (Optional[str]): The path to the configuration file. If not provided, a default config is used.
+        """
+        if config_path is None:
+            logger.info("No config path provided, using default config")
+            config_path = Path(__file__).parent / "configs" / "sbdh.yaml"
+        if tables is None:
+            tables = ["sbdh"]
+        super().__init__(
+            root=root,
+            tables=tables,
+            dataset_name=dataset_name or "sbdh",
+            config_path=config_path,
+            **kwargs
+        )
+ 
+        self.global_event_df = self.global_event_df.with_columns(pl.col('sbdh/text').map_elements(self._extract_social_history,return_dtype=pl.Utf8))
+        return
+    
+    def _extract_social_history(self, text: str) -> str:
+        """
+        Extract the social history section from the MIMIC-III NOTEEVENTS
+
+        Args:
+            text (str): The clinical note in the 'TEXT' column of NOTEEVENTS table.
+       
+        Returns:
+            match_pattern (str): The social history extracted from the clinical note.
+
+        """
+        if pd.isna(text):
+                return ""
+        text = text.lower()
+        # Look for the content between 'social history:' and the next section head or end of the file.
+        pattern = r"social history:\s*(.*?)(?=\n[a-z\s]+:|\Z)"
+        match_pattern = re.search(pattern, text, re.DOTALL)
+        if match_pattern:
+            return match_pattern.group(1).strip()
+        return ""
+    
+if __name__ == "__main__":
+    """
+    Usage:
+    1. Place `MIMIC-SBDH.csv` and `NOTEEVENTS.csv` in the same folder.
+    2. Initialize the dataset:
+        dataset = SBDHDataset(root="/path/to/dataset/folder")
+    3. Basic exploration:
+        dataset.stats()
+        patient_id = dataset.unique_patient_ids[0]
+        dataset.get_patient(patient_id).get_events()
+    """
+    dataset = SBDHDataset(
+        root="/path/to/dataset/folder"
+    )
+    dataset.stats()
+    patient_id = dataset.unique_patient_ids[0]
+    dataset.get_patient(patient_id).get_events()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ urllib3<=1.26.15
 numpy
 tqdm
 polars
+re
 transformers


### PR DESCRIPTION
Authors: Youye Xie, Lanou Qu
NetID: youyex2, lanouqu2
Paper Title: MIMIC-SBDH: A Dataset for Social and Behavioral Determinants of Health
Paper Link: [https://proceedings.mlr.press/v149/ahsan21a/ahsan21a.pdf](https://proceedings.mlr.press/v149/ahsan21a/ahsan21a.pdf)

This module implements the `SBDHDataset` class, a custom dataset class for loading and managing the MIMIC-SBDH dataset using the PyHealth framework. It combines social history free-text data from MIMIC-III NOTEEVENTS with structured SBDH labels provided by the MIMIC-SBDH project.

SBDH label (MIMIC-SBDH.csv) is available at [https://github.com/hibaahsan/MIMIC-SBDH/blob/main/MIMIC-SBDH.csv](https://github.com/hibaahsan/MIMIC-SBDH/blob/main/MIMIC-SBDH.csv)
The MIMIC-III NOTEEVENTS (NOTEEVENTS.csv) is available at [https://physionet.org/content/mimiciii/1.4/](https://physionet.org/content/mimiciii/1.4/)

Key Features:
- Loads both `MIMIC-SBDH.csv` (labels) and `NOTEEVENTS.csv` (clinical notes) located under a specified root directory.
- Extracts the "Social History" sections from clinical notes using regular expressions.
- Preprocesses text fields and prepares them as global events in the dataset.
- Supports standard PyHealth dataset methods such as `stats()`, `get_patient()`, and `get_events()`.

Video capture of running the code
[example.webm](https://github.com/user-attachments/assets/9c98f9c3-1dc0-4ffb-92d7-78a8d76af715)

  