### PR TITLE
[CS598-DL4H] Add Diabetes dataset and task

### DIFF
--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -28,6 +28,7 @@ class SampleSignalDataset:
 from .base_dataset import BaseDataset
 from .cardiology import CardiologyDataset
 from .covid19_cxr import COVID19CXRDataset
+from .diabetes import DiabetesDataset
 from .eicu import eICUDataset
 from .isruc import ISRUCDataset
 from .medical_transcriptions import MedicalTranscriptionsDataset

--- a/pyhealth/datasets/configs/diabetes.yaml
+++ b/pyhealth/datasets/configs/diabetes.yaml
@@ -1,0 +1,16 @@
+version: "1.0"
+tables:
+  diabetes:
+    file_path: "diabetes.csv"
+    patient_id: null
+    timestamp: null
+    attributes:
+    - "Pregnancies"
+    - "Glucose"
+    - "BloodPressure"
+    - "SkinThickness"
+    - "Insulin"
+    - "BMI"
+    - "DiabetesPedigreeFunction"
+    - "Age"
+    - "Outcome"

--- a/pyhealth/datasets/diabetes.py
+++ b/pyhealth/datasets/diabetes.py
@@ -1,0 +1,62 @@
+import logging
+from pathlib import Path
+from typing import Optional
+
+from ..tasks import DiabetesPrediction
+from .base_dataset import BaseDataset
+
+logger = logging.getLogger(__name__)
+
+
+class DiabetesDataset(BaseDataset):
+    """Diabetes dataset from the Indian National Institute of Diabetes and Digestive and Kidney Diseases
+
+    Dataset is available at:
+    https://www.kaggle.com/datasets/mathchi/diabetes-data-set
+
+    All patients are females of at least 21 years of age of Pima Indian heritage.
+
+    Args:
+        root: Root directory of the raw data.
+        dataset_name: Name of the dataset. Defaults to "diabetes".
+        config_path: Path to the configuration file. If None, uses default config.
+
+    Attributes:
+        root: Root directory of the raw data (should contain many csv files).
+        dataset_name: Name of the dataset.
+        config_path: Path to the configuration file.
+
+    Examples:
+        >>> from pyhealth.datasets import DiabetesDataset
+        >>> dataset = DiabetesDataset(
+        ...     root="path/to/diabetes",
+        ... )
+        >>> dataset.stats()
+        >>> samples = dataset.set_task()
+        >>> print(samples[0])
+    """
+
+    def __init__(
+        self,
+        root: str,
+        dataset_name: Optional[str] = None,
+        config_path: Optional[str] = None,
+    ) -> None:
+        if config_path is None:
+            logger.info("No config path provided, using default config")
+            config_path = (
+                Path(__file__).parent / "configs" / "diabetes.yaml"
+            )
+        default_tables = ["diabetes"]
+        super().__init__(
+            root=root,
+            tables=default_tables,
+            dataset_name=dataset_name or "diabetes",
+            config_path=config_path,
+        )
+        return
+
+    @property
+    def default_task(self) -> DiabetesPrediction:
+        """Returns the default task for this dataset."""
+        return DiabetesPrediction()

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -7,6 +7,7 @@ from .cardiology_detect import (
     cardiology_isWA_fn,
 )
 from .covid19_cxr_classification import COVID19CXRClassification
+from .diabetes_prediction import DiabetesPrediction
 from .drug_recommendation import (
     drug_recommendation_eicu_fn,
     drug_recommendation_mimic3_fn,

--- a/pyhealth/tasks/diabetes_prediction.py
+++ b/pyhealth/tasks/diabetes_prediction.py
@@ -1,0 +1,94 @@
+from typing import Any, Dict, List
+
+from ..data import Patient
+from .base_task import BaseTask
+
+
+class DiabetesPrediction(BaseTask):
+    """Task for predicting whether or not a patient has diabetes.
+
+    This task takes various biomarkers as input and predicts whether or not
+    a patient will develop (or currently has) diabetes.
+
+    Args:
+        patient: a Patient object
+
+    Returns:
+        samples: a list of samples. Each sample is a dict including patient_id, various biomarkers,
+            as well as the predicted target (outcome)
+            {
+                "patient_id": xxx,
+                "pregnancies": number of times the patient has gotten pregnant,
+                "blood_pressure": diastolic blood pressure (mm Hg),
+                "skin_thickness": triceps skin fold thickness (mm),
+                "insulin": 2-hour serum insulin (mu U/ml),
+                "bmi": body mass index,
+                "diabetes_pedigree_function": diabetes pedigree function,
+                "age": age in years
+                "outcome": 0 or 1 - this is the predicted target
+            }
+    """
+    task_name: str = "DiabetesPrediction"
+    input_schema: Dict[str, str] = {
+        "pregnancies": "raw",
+        "glucose": "raw",
+        "blood_pressure": "raw",
+        "skin_thickness": "raw",
+        "insulin": "raw",
+        "bmi": "raw",
+        "diabetes_pedigree_fn": "raw",
+        "age": "raw"
+    }
+    output_schema: Dict[str, str] = {"outcome": "binary"}
+
+    def __call__(self, patient: Patient) -> List[Dict[str, Any]]:
+        """Process a patient record to extract medical transcription samples.
+
+        Args:
+            patient (Patient): Patient record containing medical
+                transcription events
+
+        Returns:
+            List[Dict[str, Any]]: List of samples containing transcription
+                and medical specialty
+        """
+        event = patient.get_events(event_type="diabetes")
+        # There should be only one event
+        assert len(event) == 1
+        event = event[0]
+
+        try:
+            pregnancies = int(event.Pregnancies)
+            glucose = int(event.Glucose)
+            blood_pressure = int(event.BloodPressure)
+            skin_thickness = int(event.SkinThickness)
+            insulin = int(event.Insulin)
+            bmi = float(event.BMI)
+            diabetes_pedigree_fn = float(event.DiabetesPedigreeFunction)
+            age = int(event.Age)
+            outcome = int(event.Outcome)
+        except:
+            return []
+
+        sample = {
+            "pregnancies": pregnancies,
+            "glucose": glucose,
+            "blood_pressure": blood_pressure,
+            "skin_thickness": skin_thickness,
+            "insulin": insulin,
+            "bmi": bmi,
+            "diabetes_pedigree_fn": diabetes_pedigree_fn,
+            "age": age,
+            "outcome": outcome
+        }
+        return [sample]
+
+if __name__ == "__main__":
+    from pyhealth.datasets import DiabetesDataset
+
+    # change the root as needed
+    root = "/srv/local/data/diabetes"
+    dataset = DiabetesDataset(root=root)
+
+    samples = dataset.set_task()
+    print(samples[0])


### PR DESCRIPTION
**Authored by**: Jonathan Luo (jluo28@illinois.edu)
**Paper title**: N/A
**Paper link**: N/A
**Description**: Adds a diabetes dataset along with a simple prediction task. The prediction task is tested via a main function in the task file.

**Changed files**:
- `pyhealth/datasets/__init__.py`
- `pyhealth/datasets/configs/diabetes.yaml`
- `pyhealth/datasets/diabetes.py`
- pyhealth/tasks/__init__.py`
- `pyhealth/tasks/diabetes_prediction.py`