### PR TITLE
Added task to replace different PHI data with specific words

### DIFF
--- a/examples/use_mimic3_note.py
+++ b/examples/use_mimic3_note.py
@@ -1,0 +1,42 @@
+from pyhealth.datasets import MIMIC3Dataset
+from pyhealth.datasets import split_by_patient, get_dataloader
+from pyhealth.tasks import MIMIC3NoteReplaceDeIdTask
+import logging
+
+if __name__ == "__main__":
+    
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.WARNING)
+    # STEP 1: load data
+    base_dataset = MIMIC3Dataset(
+        root="/home/adafe/selected", # path to the dataset
+        tables=[ "noteevents"], # specify the tables to load
+        config_path="/home/adafe/DLH/PyHealth/pyhealth/datasets/configs/mimic3.yaml" # path to the config file
+
+    )
+
+    # STEP 2: set task
+
+    task_instance = MIMIC3NoteReplaceDeIdTask()
+    sample_dataset = base_dataset.set_task(task_instance)    
+
+    print("After de-identification:")
+    """
+        for patient_id in base_dataset.unique_patient_ids[:5]:
+            patient = base_dataset.get_patient(patient_id)
+            print("------------------------------------------------")
+            print(f"Patient ID: {patient.patient_id}")
+            print(f"Patient Events: {patient.get_events(event_type='noteevents')}")
+    """
+
+    for i in range(5):
+        patient = base_dataset.get_patient(base_dataset.unique_patient_ids[i])
+        print("------------------------------------------------")
+        #print(f"Patient ID: {patient.patient_id}")
+        #print(f"Patient Events: {patient.get_events(event_type='noteevents')}")
+        #print("------------------------------------------------")
+        print(sample_dataset[i]['masked_text'])
+        print("------------------------------------------------")\
+
+
+        

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -47,3 +47,5 @@ from .sleep_staging import (
 )
 from .sleep_staging_v2 import SleepStagingSleepEDF
 from .temple_university_EEG_tasks import EEG_events_fn, EEG_isAbnormal_fn
+from .mimic3_note_tasks import MIMIC3NoteReplaceDeIdTask
+

--- a/pyhealth/tasks/mimic3_note_tasks.py
+++ b/pyhealth/tasks/mimic3_note_tasks.py
@@ -1,0 +1,211 @@
+# pyhealth/tasks/mimic3_note_tasks.py
+
+import re
+import os
+import nltk
+import logging
+import pandas as pd
+import numpy as np
+from typing import Dict, List, Union, Tuple, Optional
+from sklearn.model_selection import train_test_split
+from tqdm import tqdm
+
+from dataclasses import dataclass, field
+from pyhealth.data import Patient
+#from pyhealth.datasets import MIMIC3NoteDataset
+from pyhealth.tasks import BaseTask
+
+logger = logging.getLogger(__name__)
+
+# Ensure nltk packages are downloaded
+try:
+    nltk.data.find('tokenizers/punkt')
+except LookupError:
+    nltk.download('punkt')
+
+@dataclass
+class MIMIC3NoteReplaceDeIdTask(BaseTask):
+    """Task for de-identifying personal health information in MIMIC-III clinical notes.
+    
+    This task identifies and removes/masks PHI in clinical notes based on pattern detection
+    and rule-based methods. It directly updates the patient entity with deidentified text.
+    
+    """
+    task_name: str = "Deidentifying MIMIC-III Clinical Notes"
+    input_schema: Dict[str, str] = field(default_factory=lambda: {"text": "text"})
+    output_schema: Dict[str, str] = field(default_factory=lambda: {"masked_text": "text"})
+
+    def __call__(self, patient: Patient) -> List[Dict]:
+        """Processes a patient for the de-identification marking task and updates the patient entity directly.
+        
+        Args:
+            patient: Patient object containing clinical notes
+            
+        Returns:
+            List of dictionaries with patient_id, text, masked_text and timestamps fields
+        """
+        samples = []
+        
+        # Get all note events
+        note_events = patient.get_events(event_type="noteevents")
+        
+        # Process each note event
+        for event in note_events:
+            text = event.attr_dict.get("text", "")
+            if not text:
+                continue
+                
+            # Process the note and update the patient entity directly
+            masked_text = self.process_note(text)
+            
+            # Update the event text with the deidentified version
+            event.attr_dict["text"] = masked_text
+            event.attr_dict["phimasked"] = True  # Add a flag to indicate this note has been deidentified
+            
+            # Create a sample for return value
+
+            sample = {
+                "patient_id": patient.patient_id,
+                "text": text,
+                "masked_text": masked_text,
+                "timestamp": event.timestamp,                
+            }            
+
+
+            samples.append(sample)
+            
+        # Log the number of processed notes
+        #logger.info(f"Deidentified {len(samples)} notes for patient {patient.patient_id}")
+        
+        return samples
+    
+    def is_date(self, s: str) -> bool:
+        """Check if a string contains a date or time-related information.
+        Args:
+            s (str): The string to check.
+        Returns:
+            bool: True if the string contains date or time-related information, False otherwise.
+        """
+        return bool(re.search(r"\d{4}-\d{1,2}-\d{1,2}", s) or
+                    "month" in s or "year" in s)
+    
+    def replace_deid(self, text: str) -> str:
+        """Replaces [** ... **] tags with PHI placeholders.
+        Args:
+            text (str): Clinical note text.
+        Returns:
+            str: Text with PHI replaced by placeholder tokens.
+        """
+        
+        return re.sub(r"\[\*\*(.*?)\*\*\]", self.repl_deid, text)
+    
+    def repl_deid(self, match: re.Match) -> str:
+        """De-identify text by replacing PHI with mask strings.
+        Args:
+            match (re.Match): Regex match object containing the text to be replaced.
+        Returns:
+            str: The replacement string based on the matched text.
+        """
+
+        low_label = match.group(1).lower().strip()
+        date = self.is_date(low_label)
+
+        if date or 'holiday' in low_label:
+            label = 'PHIDATEPHI'
+
+        elif 'hospital' in low_label:
+            label = 'PHIHOSPITALPHI'
+
+        elif ('location' in low_label
+            or 'url ' in low_label
+            or 'university' in low_label
+            or 'address' in low_label
+            or 'po box' in low_label
+            or 'state' in low_label
+            or 'country' in low_label
+            or 'company' in low_label):
+            label = 'PHILOCATIONPHI'
+
+
+        elif ('name' in low_label
+            or 'dictator info' in low_label
+            or 'contact info' in low_label
+            or 'attending info' in low_label):
+            label = 'PHINAMEPHI'
+
+        elif 'telephone' in low_label:
+            label = 'PHICONTACTPHI'
+
+        elif ('job number' in low_label
+                or 'number' in low_label
+                or 'numeric identifier' in low_label
+                or re.search('^\d+$', low_label)
+                or re.search('^[\d-]+$', low_label)
+                or re.search('^[-\d/]+$', low_label)):
+            label = 'PHINUMBERPHI'
+
+        elif 'age over 90' in low_label:
+            label = 'PHIAGEPHI'
+
+        else:
+            label = 'PHIOTHERPHI'
+
+        return label
+   
+
+
+
+    
+    def mask_gendered_terms(self, text: str) -> str:
+        
+        """Replace gendered terms with a mask.
+            Args:
+            text (str): Clinical note text.     
+        
+            Returns:
+            str: Text with gendered terms replaced by a placeholder.
+        """
+
+        text = re.sub(
+            r"\b(male|gentleman|man|he|female|woman|she|his|her|him)\b",
+            "[GEND]",
+            text,
+            flags=re.IGNORECASE
+        )
+        text = re.sub(r"Sex:\s*[MFmf]", "Sex: [GEND]", text, flags=re.IGNORECASE)
+        return text
+
+    def clean_note_format(self, note: str) -> str:
+        """Clean and standardize the format of clinical notes.
+        Args:
+            note (str): Clinical note text.
+        Returns:
+            str: Cleaned and standardized clinical note text.
+        """
+        note = re.sub(r'\n', ' ', note)
+        note = re.sub(r'[0-9]+\.', '', note)
+
+        note = re.sub(r'[-_=]{2,}', '', note)
+        note = re.sub(r'\bdr\.', 'doctor', note, flags=re.IGNORECASE)
+        note = re.sub(r'\bm\.d\.', 'md', note, flags=re.IGNORECASE)
+        #note = re.sub(r'[ -_=]{2,}', '', note)
+        note = re.sub(r"\s+", " ", note)
+        
+        return note.strip()
+
+    def process_note(self, note: str) -> str:
+        """Process a clinical note through the complete pipeline.
+            Args:
+            note (str): Clinical note text.     
+            Returns:
+            str: Processed clinical note text.  
+        """
+        # Apply all text processing steps in sequence
+        #sections = process_note_helper(note)
+        note = self.replace_deid(note)
+        note = self.mask_gendered_terms(note)
+        note = self.clean_note_format(note)
+        return note
+
+if __name__ == "__main__":
+    task = MIMIC3NoteDeidentificationTask()

--- a/pyhealth/unittests/test_MIMIC3NoteReplaceDeIdTask.py
+++ b/pyhealth/unittests/test_MIMIC3NoteReplaceDeIdTask.py
@@ -1,0 +1,178 @@
+# pyhealth/tasks/test_mimic3_note_tasks.py
+
+import unittest
+import re
+from unittest.mock import patch, MagicMock
+import pandas as pd
+from pyhealth.tasks.mimic3_note_tasks import MIMIC3NoteReplaceDeIdTask
+from pyhealth.data import Patient
+import datetime
+
+class TestMIMIC3NoteReplaceDeIdTask(unittest.TestCase):
+    """Test cases for the MIMIC3NoteReplaceDeIdTask class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.task = MIMIC3NoteReplaceDeIdTask()
+        
+        # Create a mock patient
+        self.patient = MagicMock(spec=Patient)
+        self.patient.patient_id = "12345"
+        
+        # Create mock note events
+        self.note_event1 = MagicMock()
+        self.note_event1.attr_dict = {"text": "Patient [**Name (NI) **] was seen by Dr. [**Last Name (NamePattern1) **] on [**2018-01-15**]."}
+        self.note_event1.timestamp = datetime.datetime(2018, 1, 15, 10, 30)
+        
+        self.note_event2 = MagicMock()
+        self.note_event2.attr_dict = {"text": ""}  # Empty note
+        self.note_event2.timestamp = datetime.datetime(2018, 1, 16, 9, 15)
+        
+        self.note_event3 = MagicMock()
+        self.note_event3.attr_dict = {"text": "Patient is a 95-year-old [**Age over 90 **] male admitted on [**2018-01-10**] to [**Hospital **]."}
+        self.note_event3.timestamp = datetime.datetime(2018, 1, 17, 14, 45)
+
+    def test_task_initialization(self):
+        """Test task initialization and schema."""
+        self.assertEqual(self.task.task_name, "Deidentifying MIMIC-III Clinical Notes")
+        self.assertEqual(self.task.input_schema, {"text": "text"})
+        self.assertEqual(self.task.output_schema, {"masked_text": "text"})
+
+    def test_is_date(self):
+        """Test the is_date method."""
+        self.assertTrue(self.task.is_date("2022-01-15"))
+        self.assertTrue(self.task.is_date("2022-1-5"))
+        self.assertTrue(self.task.is_date("This is in the month of January"))
+        self.assertTrue(self.task.is_date("Next year 2024"))
+        self.assertFalse(self.task.is_date("This is not a date"))
+
+    def test_repl_deid(self):
+        """Test the repl_deid method with different categories."""
+        # Create mock Match objects for different PHI categories
+        match_date = MagicMock()
+        match_date.group.return_value = "2022-01-15"
+        self.assertEqual(self.task.repl_deid(match_date), "PHIDATEPHI")
+        
+        match_hospital = MagicMock()
+        match_hospital.group.return_value = "Hospital Name"
+        self.assertEqual(self.task.repl_deid(match_hospital), "PHIHOSPITALPHI")
+        
+        
+        match_name = MagicMock()
+        match_name.group.return_value = "First Name"
+        self.assertEqual(self.task.repl_deid(match_name), "PHINAMEPHI")
+        
+        match_telephone = MagicMock()
+        match_telephone.group.return_value = "telephone number"
+        self.assertEqual(self.task.repl_deid(match_telephone), "PHICONTACTPHI")
+        
+        match_number = MagicMock()
+        match_number.group.return_value = "123456"
+        self.assertEqual(self.task.repl_deid(match_number), "PHINUMBERPHI")
+        
+        match_age = MagicMock()
+        match_age.group.return_value = "age over 90"
+        self.assertEqual(self.task.repl_deid(match_age), "PHIAGEPHI")
+        
+        match_other = MagicMock()
+        match_other.group.return_value = "unknown category"
+        self.assertEqual(self.task.repl_deid(match_other), "PHIOTHERPHI")
+
+    def test_replace_deid(self):
+        """Test the replace_deid method for PHI replacement."""
+        input_text = "Patient [**Name (NI) **] was seen on [**2018-01-15**]."
+        expected_output = "Patient PHINAMEPHI was seen on PHIDATEPHI."
+        self.assertEqual(self.task.replace_deid(input_text), expected_output)
+
+    def test_mask_gendered_terms(self):
+        """Test masking of gendered terms."""
+        input_text = "The patient is a 45-year-old male. He was admitted yesterday."
+        expected_output = "The patient is a 45-year-old [GEND]. [GEND] was admitted yesterday."
+        self.assertEqual(self.task.mask_gendered_terms(input_text), expected_output)
+
+    def test_clean_note_format(self):
+        """Test cleaning and standardization of note format."""
+        input_text = "1. Patient history\n2. Current medications\n---\nSeen by Dr. Smith, M.D."
+        expected_output = "Patient history Current medications Seen by doctor Smith, md"
+        self.assertEqual(self.task.clean_note_format(input_text), expected_output)
+
+    def test_process_note(self):
+        """Test the complete note processing pipeline."""
+        input_text = "Patient [**Name (NI) **] is a 45-year-old male.\nHe was seen by Dr. [**Last Name (NamePattern1) **] on [**2018-01-15**]."
+        processed_text = self.task.process_note(input_text)
+        
+        # Check that PHI markers are replaced
+        self.assertNotIn("[**", processed_text)
+        self.assertNotIn("**]", processed_text)
+        
+        # Check that gendered terms are masked
+        self.assertIn("[GEND]", processed_text)
+        
+        # Check that formatting is cleaned
+        self.assertNotIn("\n", processed_text)
+
+    @patch('pyhealth.data.Patient')
+    def test_call_with_patient(self, mock_patient_class):
+        """Test the __call__ method with a patient containing notes."""
+        # Set up the patient to return our mock events
+        self.patient.get_events.return_value = [self.note_event1, self.note_event2, self.note_event3]
+        
+        # Call the task with the patient
+        results = self.task(self.patient)
+        
+        # Verify results
+        self.assertEqual(len(results), 2)  # Only 2 notes have content
+        
+        # Check that the patient entity was updated
+        self.assertEqual(self.note_event1.attr_dict["phimasked"], True)
+        self.assertEqual(self.note_event3.attr_dict["phimasked"], True)
+        
+        # Check first result
+        self.assertEqual(results[0]["patient_id"], "12345")
+        self.assertIn("PHINAMEPHI", results[0]["masked_text"])
+        self.assertIn("PHIDATEPHI", results[0]["masked_text"])
+        
+        # Check that empty notes were skipped
+        self.patient.get_events.assert_called_once_with(event_type="noteevents")
+
+    def test_call_with_empty_notes(self):
+        """Test the __call__ method with a patient having only empty notes."""
+        # Set up the patient to return only the empty note event
+        self.patient.get_events.return_value = [self.note_event2]
+        
+        # Call the task with the patient
+        results = self.task(self.patient)
+        
+        # Verify no results are returned for empty notes
+        self.assertEqual(len(results), 0)
+
+    def test_integration_process_notes(self):
+        """Integration test for processing multiple notes."""
+        # Set up more complex notes
+        complex_note = (
+            "Patient [**Name (NI) **], a 67-year-old female, was admitted to [**Hospital **] on [**2018-01-15**].\n"
+            "She was referred by Dr. [**Last Name (NamePattern1) **] from [**Location (un) **].\n"
+            "Medical Record Number: [**Medical Record Number(1) **]\n"
+            "Phone: [**Telephone/Fax (1) **]\n"
+            "Her address is [**Street Address(1) **], [**State **]."
+        )
+        
+        self.note_event1.attr_dict["text"] = complex_note
+        self.patient.get_events.return_value = [self.note_event1]
+        
+        # Process the notes
+        results = self.task(self.patient)
+        
+        # Check that all types of PHI were correctly masked
+        processed_text = results[0]["masked_text"]
+        self.assertIn("PHINAMEPHI", processed_text)
+        self.assertIn("PHIHOSPITALPHI", processed_text)
+        self.assertIn("PHIDATEPHI", processed_text)
+        self.assertIn("PHILOCATIONPHI", processed_text)
+        self.assertIn("PHINUMBERPHI", processed_text)
+        self.assertIn("PHICONTACTPHI", processed_text)
+        self.assertIn("[GEND]", processed_text)  # Gendered term replacement
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Name: Atul Dafe & Premnisha Balakumar
- NetIds: adafe2 & pb42
- Added new task ( pyhealth/tasks/mimic3_note_tasks.py) to replace PHI data with corresponding tags and mask gender for notes from MIMIC3 dataset. This is related to paper  'Hurtful Words: Quantifying Biases in Clinical Contextual Word
Embeddings'
- Also added example ( examples/use_mimic3_note.py) to demonstrate use of this task and unittests ( pyhealth/unittests/test_MIMIC3NoteReplaceDeIdTask.py)were created

