### PR TITLE
Added ability to set custom number of patients for dev mode if we need more than the standard 1000

### DIFF
--- a/pyhealth/datasets/mimic4.py
+++ b/pyhealth/datasets/mimic4.py
@@ -196,6 +196,7 @@ class MIMIC4Dataset(BaseDataset):
         cxr_config_path: Path to the CXR config file
         dataset_name: Name of the dataset
         dev: Whether to enable dev mode (limit to 1000 patients)
+        dev_limit (Optional(int)): Optionally have a custom patient limit number in dev
     """
 
     def __init__(
@@ -211,6 +212,7 @@ class MIMIC4Dataset(BaseDataset):
         cxr_config_path: Optional[str] = None,
         dataset_name: str = "mimic4",
         dev: bool = False,  # Added dev parameter
+        dev_limit: Optional[int] = None,
     ):
         log_memory_usage("Starting MIMIC4Dataset init")
 
@@ -221,6 +223,7 @@ class MIMIC4Dataset(BaseDataset):
         self.tables = None
         self.config = None
         self.dev = dev  # Store dev mode flag
+        self.dev_limit = dev_limit
         
         # We need at least one root directory
         if not any([ehr_root, note_root, cxr_root]):
@@ -238,7 +241,8 @@ class MIMIC4Dataset(BaseDataset):
                 root=ehr_root,
                 tables=ehr_tables,
                 config_path=ehr_config_path,
-                dev=dev  # Pass dev mode flag
+                dev=dev,  # Pass dev mode flag
+                dev_limit=dev_limit
             )
             log_memory_usage("After EHR dataset initialization")
 
@@ -249,7 +253,8 @@ class MIMIC4Dataset(BaseDataset):
                 root=note_root,
                 tables=note_tables,
                 config_path=note_config_path,
-                dev=dev  # Pass dev mode flag
+                dev=dev,  # Pass dev mode flag
+                dev_limit=dev_limit
             )
             log_memory_usage("After Note dataset initialization")
 
@@ -260,7 +265,8 @@ class MIMIC4Dataset(BaseDataset):
                 root=cxr_root,
                 tables=cxr_tables,
                 config_path=cxr_config_path,
-                dev=dev  # Pass dev mode flag
+                dev=dev,  # Pass dev mode flag
+                dev_limit=dev_limit
             )
             log_memory_usage("After CXR dataset initialization")
 


### PR DESCRIPTION
Creon Creonopoulos (creonc2)
Kevin Nguyn (kn28)

Type of Contribution: Dataset options enhancement

Description:
When trying to set custom task functions on the mimic dataset, the ability to initialize the mimic class in dev mode is vey helpful because it removes the need to process thousands of records on machines that are not built with that much power. However, some tasks can be a little more niche and only 1000 records are not enough to produce accurate results when the models are trained. For this reason, we added the ability to set an optional custom parameter when initializing the dataset to manually set the number of patient records we would like to process. This gives full control over the number of patients to be processed to developers who want to do work on less powerful machines but still want to grab potentially significant amounts of samples.

Key Files:
pyhealth/datasets/base_dataset.py

Contains:
Updated constructor arguments to include optional **dev_limit** parameter.