### PR TITLE
2-3× Speedup for `BaseDataset.set_task()`

### DIFF
--- a/pyhealth/data/data.py
+++ b/pyhealth/data/data.py
@@ -177,8 +177,10 @@ class Patient:
         # df = self._filter_by_event_type_regular(self.data_source, event_type)
         # df = self._filter_by_time_range_regular(df, start, end)
 
-        filters = filters or []
-        assert event_type is not None, "event_type must be provided if filters are provided"
+        if filters:
+            assert event_type is not None, "event_type must be provided if filters are provided"
+        else:
+            filters = []
         exprs = []
         for filt in filters:
             if not (isinstance(filt, tuple) and len(filt) == 3):

--- a/pyhealth/data/data.py
+++ b/pyhealth/data/data.py
@@ -1,7 +1,10 @@
+import operator
 from dataclasses import dataclass, field
 from datetime import datetime
+from functools import reduce
 from typing import Dict, List, Mapping, Optional, Union
 
+import numpy as np
 import polars as pl
 
 
@@ -91,7 +94,8 @@ class Patient:
 
     Attributes:
         patient_id (str): Unique patient identifier.
-        data_source (pl.DataFrame): DataFrame containing all events.
+        data_source (pl.DataFrame): DataFrame containing all events, sorted by timestamp.
+        event_type_partitions (Dict[str, pl.DataFrame]): Dictionary mapping event types to their respective DataFrame partitions.
     """
 
     def __init__(self, patient_id: str, data_source: pl.DataFrame) -> None:
@@ -104,6 +108,42 @@ class Patient:
         """
         self.patient_id = patient_id
         self.data_source = data_source.sort("timestamp")
+        self.event_type_partitions = self.data_source.partition_by("event_type", maintain_order=True, as_dict=True)
+
+    def _filter_by_time_range_regular(self, df: pl.DataFrame, start: Optional[datetime], end: Optional[datetime]) -> pl.DataFrame:
+        """Regular filtering by time. Time complexity: O(n)."""
+        if start is not None:
+            df = df.filter(pl.col("timestamp") >= start)
+        if end is not None:
+            df = df.filter(pl.col("timestamp") <= end)
+        return df
+
+    def _filter_by_time_range_fast(self, df: pl.DataFrame, start: Optional[datetime], end: Optional[datetime]) -> pl.DataFrame:
+        """Fast filtering by time using binary search on sorted timestamps. Time complexity: O(log n)."""
+        if start is None and end is None:
+            return df
+        df = df.filter(pl.col("timestamp").is_not_null())
+        ts_col = df["timestamp"].to_numpy()
+        start_idx = 0
+        end_idx = len(ts_col)
+        if start is not None:
+            start_idx = np.searchsorted(ts_col, start, side="left")
+        if end is not None:
+            end_idx = np.searchsorted(ts_col, end, side="right")
+        return df.slice(start_idx, end_idx - start_idx)
+
+    def _filter_by_event_type_regular(self, df: pl.DataFrame, event_type: Optional[str]) -> pl.DataFrame:
+        """Regular filtering by event type. Time complexity: O(n)."""
+        if event_type:
+            df = df.filter(pl.col("event_type") == event_type)
+        return df
+
+    def _filter_by_event_type_fast(self, df: pl.DataFrame, event_type: Optional[str]) -> pl.DataFrame:
+        """Fast filtering by event type using pre-built event type index. Time complexity: O(1)."""
+        if event_type:
+            return self.event_type_partitions.get((event_type,), df[:0])
+        else:
+            return df
 
     def get_events(
         self,
@@ -129,37 +169,39 @@ class Patient:
             Union[pl.DataFrame, List[Event]]: Filtered events as a DataFrame 
             or a list of Event objects.
         """
-        df = self.data_source
-        if event_type:
-            df = df.filter(pl.col("event_type") == event_type)
-        if start:
-            df = df.filter(pl.col("timestamp") >= start)
-        if end:
-            df = df.filter(pl.col("timestamp") <= end)
+        # faster filtering (by default)
+        df = self._filter_by_event_type_fast(self.data_source, event_type)
+        df = self._filter_by_time_range_fast(df, start, end)
+
+        # regular filtering (commented out by default)
+        # df = self._filter_by_event_type_regular(self.data_source, event_type)
+        # df = self._filter_by_time_range_regular(df, start, end)
 
         filters = filters or []
+        assert event_type is not None, "event_type must be provided if filters are provided"
+        exprs = []
         for filt in filters:
-            assert event_type is not None, "event_type must be provided if filters are provided"
             if not (isinstance(filt, tuple) and len(filt) == 3):
                 raise ValueError(f"Invalid filter format: {filt} (must be tuple of (attr, op, value))")
             attr, op, val = filt
             col_expr = pl.col(f"{event_type}/{attr}")
             # Build operator expression
             if op == "==":
-                expr = col_expr == val
+                exprs.append(col_expr == val)
             elif op == "!=":
-                expr = col_expr != val
+                exprs.append(col_expr != val)
             elif op == "<":
-                expr = col_expr < val
+                exprs.append(col_expr < val)
             elif op == "<=":
-                expr = col_expr <= val
+                exprs.append(col_expr <= val)
             elif op == ">":
-                expr = col_expr > val
+                exprs.append(col_expr > val)
             elif op == ">=":
-                expr = col_expr >= val
+                exprs.append(col_expr >= val)
             else:
                 raise ValueError(f"Unsupported operator: {op} in filter {filt}")
-            df = df.filter(expr)
+        if exprs:
+            df = df.filter(reduce(operator.and_, exprs))
         if return_df:
             return df
         return [Event.from_dict(d) for d in df.to_dicts()]

--- a/pyhealth/datasets/mimic4.py
+++ b/pyhealth/datasets/mimic4.py
@@ -210,7 +210,7 @@ class MIMIC4Dataset(BaseDataset):
         note_config_path: Optional[str] = None,
         cxr_config_path: Optional[str] = None,
         dataset_name: str = "mimic4",
-        dev: bool = False,  # Added dev parameter
+        dev: bool = False,
     ):
         log_memory_usage("Starting MIMIC4Dataset init")
 
@@ -220,8 +220,10 @@ class MIMIC4Dataset(BaseDataset):
         self.root = None
         self.tables = None
         self.config = None
-        self.dev = dev  # Store dev mode flag
-        
+        # Dev flag is only used in the MIMIC4Dataset class
+        # to ensure the same set of patients are used for all sub-datasets.
+        self.dev = dev
+
         # We need at least one root directory
         if not any([ehr_root, note_root, cxr_root]):
             raise ValueError("At least one root directory must be provided")
@@ -238,7 +240,6 @@ class MIMIC4Dataset(BaseDataset):
                 root=ehr_root,
                 tables=ehr_tables,
                 config_path=ehr_config_path,
-                dev=dev  # Pass dev mode flag
             )
             log_memory_usage("After EHR dataset initialization")
 
@@ -249,7 +250,6 @@ class MIMIC4Dataset(BaseDataset):
                 root=note_root,
                 tables=note_tables,
                 config_path=note_config_path,
-                dev=dev  # Pass dev mode flag
             )
             log_memory_usage("After Note dataset initialization")
 
@@ -260,7 +260,6 @@ class MIMIC4Dataset(BaseDataset):
                 root=cxr_root,
                 tables=cxr_tables,
                 config_path=cxr_config_path,
-                dev=dev  # Pass dev mode flag
             )
             log_memory_usage("After CXR dataset initialization")
 


### PR DESCRIPTION
## Main: 2× Speedup for BaseDataset.set_task()

This PR addresses a major bottleneck in `BaseDataset.set_task()`—the repeated calls to `Patient.get_events()`.
- Fast time range filtering via binary search on sorted timestamps (O(N) → O(log N))
- Efficient event type filtering using pre-built lookups (O(N) → O(1))
- Reduced timestamp precision from microseconds to milliseconds for lower processing overhead

Runtime improvements on full MIMIC-IV:
`InHospitalMortalityMIMIC4`: 40min -> 20min
`Readmission30DaysMIMIC4 `: 30min -> 14min
`MIMIC4EDBenchmark` (to be introduced in the next PR): 7hr -> 48min -> 20min

Should solve issue #331 

## Other Changes
1. Set `num_workers=1` by default in `set_task()` to reduce peak memory usage

2. Removed propagation of `dev` flag to child MIMIC-IV dataset classes to ensure consistent patient cohorts across sub-datasets

3. Refactor `InHospitalMortalityMIMIC4` and `Readmission30DaysMIMIC4` for improved performance and clarity