### PR TITLE
fix bug with mortality label always being zero if hospital_expire_flag is a string

### DIFF
--- a/pyhealth/tasks/mortality_prediction.py
+++ b/pyhealth/tasks/mortality_prediction.py
@@ -33,7 +33,7 @@ class MortalityPredictionMIMIC3(BaseTask):
             next_visit = visits[i + 1]
 
             # Check discharge status for mortality label - more robust handling
-            if next_visit.hospital_expire_flag not in [0, 1]:
+            if next_visit.hospital_expire_flag not in [0, 1, "0", "1"]:
                 mortality_label = 0
             else:
                 mortality_label = int(next_visit.hospital_expire_flag)


### PR DESCRIPTION
Pranav Herur
pherur2
CaliForest: Calibrated Random Forest for Health Data
[CaliForest Paper](https://pmc.ncbi.nlm.nih.gov/articles/PMC8299436/)

fix bug with mortality label always being zero if `hospital_expire_flag` is a string value

in my testing with the examples `hospital_expire_flag` came in as "0" or "1" and would always get set to 0
meaning every label would become 0