### PR TITLE
Add a mortality notes dataset

### DIFF
--- a/pyhealth/datasets/configs/mortality_notes.yaml
+++ b/pyhealth/datasets/configs/mortality_notes.yaml
@@ -1,0 +1,22 @@
+version: "1.0"
+tables:
+  admissions:
+    file_path: "ADMISSIONS.csv"
+    patient_id: "subject_id"
+    timestamp: null
+    attributes:
+      - "dischtime"
+      - "hadm_id"
+      - "hospital_expire_flag"
+
+  noteevents:
+    file_path: "NOTEEVENTS.csv"
+    patient_id: "subject_id"
+    timestamp: null
+    attributes:
+      - "row_id"
+      - "charttime"
+      - "chartdate"
+      - "hadm_id"
+      - "category"
+      - "text"

--- a/pyhealth/datasets/mortality_notes.py
+++ b/pyhealth/datasets/mortality_notes.py
@@ -1,0 +1,130 @@
+"""
+Name: Ryan Kupiec 
+NetID: rkupiec2
+Paper Title: Time-Aware Transformer-based Network for Clinical Notes
+Series Prediction
+Paper link: https://proceedings.mlr.press/v126/zhang20c/zhang20c.pdf
+Description: Merging of the NOTEEVENTS and ADMISSIONS datasets to create the mortality dataset required to run any of the code in the paper.
+"""
+
+from pathlib import Path
+import polars as pl
+from typing import List, Optional
+from .base_dataset import BaseDataset
+
+class MortalityNotesDataset(BaseDataset):
+    """
+    Mortality Notes dataset class for MIMIC‑III:  
+    - joins admissions → noteevents  
+    - drops same‑day notes  
+    - removes discharge summaries  
+    - fills missing charttimes with end‑of‑day  
+
+     Attributes:
+        root (str): The root directory where the dataset is stored.
+        dev (bool): Whether to pull a subset of the data.
+        config_path (Optional[str]): The path to the configuration file.
+        dataset_name (Optional[str]): The name of the dataset.
+    
+    Examples:
+        ds = MortalityNotesDataset(
+            root="~/Path/to/folder/with/csvs",
+            dev=False
+        )
+    """
+    def __init__(
+        self,
+        root: str,
+        dev: bool = False,
+        config_path: Optional[str] = None,
+        dataset_name: str = "mortality_notes",
+    ):
+        '''
+        Initialize the MortalityNotesDataset dataset.
+        Args:
+            root (str): The root directory where the dataset is stored.
+            dev (bool): Whether to pull a subset of the data.
+            config_path (Optional[str]): The path to the configuration file.
+            dataset_name (Optional[str]): The name of the dataset.
+        '''
+    
+        config_path = Path(__file__).parent / "configs" / "mortality_notes.yaml"
+        super().__init__(
+            root=root,
+            tables=["noteevents", "admissions"],
+            dataset_name=dataset_name,
+            config_path=config_path,
+            dev=dev
+        )
+        return
+
+    def preprocess_admissions(self, df: pl.LazyFrame) -> pl.LazyFrame:
+        df = df.with_columns([
+            pl.col("hadm_id").cast(pl.Int32),
+            pl.col("dischtime").str.to_datetime("%Y-%m-%d %H:%M:%S").dt.date()
+        ])
+        return df
+    
+    def preprocess_noteevents(self, df: pl.LazyFrame) -> pl.LazyFrame:
+        df = (
+            df
+            .filter(pl.col("hadm_id").is_not_null())
+            .filter(pl.col("category") != "Discharge summary")
+        )
+
+        df = df.with_columns([
+            pl.col("hadm_id").cast(pl.Int32),
+            (pl.when(pl.col("charttime").is_null())
+               .then(pl.col("chartdate") + pl.lit(" 23:59:59"))
+               .otherwise(pl.col("charttime"))
+             ).alias("charttime_fixed"),
+        ]).drop("charttime").rename({"charttime_fixed":"charttime"})
+
+        df = df.with_columns([
+            pl.col("charttime").str.to_datetime("%Y-%m-%d %H:%M:%S").dt.date(),
+            pl.col("chartdate").str.to_date("%Y-%m-%d")
+        ])
+
+        return df
+
+    def get_final_notes(self) -> pl.DataFrame:
+        df = self.collected_global_event_df
+        
+        admissions = df.filter(pl.col("event_type") == "admissions").rename({
+            "admissions/hadm_id": "hadm_id"
+        })
+        notes = df.filter(pl.col("event_type") == "noteevents").rename({
+            "noteevents/hadm_id": "hadm_id"
+        })
+
+        df = (
+            notes
+            .join(admissions.select(["patient_id", "hadm_id", "admissions/hospital_expire_flag", "admissions/dischtime"]), on=["patient_id", "hadm_id"], how="left")
+        )
+        df = df.with_columns(
+          (pl.col("admissions/dischtime_right") - pl.col("noteevents/charttime"))
+            .dt
+            .total_days()
+            .alias("days_before_discharge")
+        )
+        df = df.filter(pl.col("days_before_discharge") > 0)
+        
+        df = df.select([
+            pl.col("hadm_id").alias("Adm_ID"),
+            pl.col("noteevents/row_id").cast(pl.Int32).alias("note_id"),
+            pl.col("noteevents/text").alias("text"),
+            pl.col("noteevents/chartdate").alias("chartdate"),
+            pl.col("noteevents/charttime").alias("charttime"),
+            pl.col("admissions/hospital_expire_flag_right").cast(pl.Int32).alias("Label")
+        ])
+        
+        return df
+
+if __name__ == "__main__":
+    ds = MortalityNotesDataset(
+        root="~/Downloads/Test",
+        dev=False
+    )
+    final = ds.get_final_notes().to_pandas()
+    vc = final.drop_duplicates(subset=['Adm_ID'])["Label"].value_counts()
+    print(vc)

--- a/pyhealth/unittests/test_datasets/test_mortality_notes.py
+++ b/pyhealth/unittests/test_datasets/test_mortality_notes.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+import tempfile
+import unittest
+import pandas as pd
+
+from pyhealth.datasets.mortality_notes import MortalityNotesDataset
+
+# To test locally I ran: PYTHONPATH="$PWD" pytest ./pyhealth/unittests/test_datasets/test_mortality_notes.py
+class TestMortalityNotesDatasetBasic(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp()
+        adm = pd.DataFrame([
+            # hadm_id, subject_id, dischtime, hospital_expire_flag
+            [1,  10, "2025-01-02 12:00:00", 1],
+            [2,  20, "2025-01-01 00:00:00", 0],
+        ], columns=["hadm_id","subject_id","dischtime","hospital_expire_flag"])
+        adm.to_csv(os.path.join(cls.tmp,"ADMISSIONS.csv"), index=False)
+
+        notes = pd.DataFrame([
+            # row_id, subject_id, hadm_id, chartdate, charttime, category, text
+            [100, 10, 1, "2025-01-01", "2025-01-0108:00:00", "Progress note",       "foo"],
+            [101, 10, 1, "2025-01-01",                 None, "Progress note",       "bar"], 
+            [200, 20, 2, "2025-01-01", "2025-01-0112:00:00", "Progress note",       "baz"],
+            [201, 10, 1, "2025-01-02", "2025-01-0207:00:00", "Discharge summary",  "qux"],
+        ], columns=["row_id","subject_id","hadm_id","chartdate","charttime","category","text"])
+        notes.to_csv(os.path.join(cls.tmp,"NOTEEVENTS.csv"), index=False)
+
+        cls.ds = MortalityNotesDataset(root=cls.tmp, dev=True)
+        cls.ds_dev = MortalityNotesDataset(root=cls.tmp, dev=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp)
+
+    def test_initialization(self):
+        self.assertEqual(self.ds.root, self.tmp)
+        self.assertEqual(self.ds.dataset_name, "mortality_notes")
+    
+    def test_get_final_notes_columns(self):
+        final = self.ds.get_final_notes()
+        expected = ["Adm_ID","note_id","text","chartdate","charttime","Label"]
+        self.assertListEqual(final.columns, expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Ryan Kupiec (rkupiec2)
- Dataset contribution
- I have provided a method to pull down the required dataset to run the code in "Time-Aware Transformer-based Network for Clinical Notes Series Prediction"
- To test implementation, you need to put the NOTEEVENTS and ADMISSIONS csvs from MIMIC-III in a folder and then point to that folder as your root argument. There is an example at the bottom of the script in the main section.

My paper, Time-Aware Transformer-based Network for Clinical Notes Series Prediction, was particularly difficult because the authors merged the NOTEEVENTS and ADMISSIONS dataset and applied transformations without providing the code. The merged data that was required was then fed into a preprocessing and a chunk_note script so it was essential to have the data preprocessed correctly before running those scripts. My addition handles all preprocessing, merging, and returns the data in a format that matches the expected one from the authors so users can then explore the scripts in the repository. All that is needed to run it is a folder containing both the NOTEEVENTS and ADMISSIONS csvs. 

Note: you may notice that the PR is pushed from Emily Parham. I am using my fiances computer because she has a strong mac so please reach out at rkupiec2@illinois.edu if you have any questions. 