### PR TITLE
[DL4H] Add New Example and Task for MIMIC-3 Discharge Notes Linked to Top-Level ICD-9 Categories

### DIFF
--- a/examples/discharge_notes_top_level_icd9_cats.py
+++ b/examples/discharge_notes_top_level_icd9_cats.py
@@ -1,0 +1,192 @@
+"""
+Author: Fabricio Brigagao (fb8)
+
+Purpose
+-------
+Creates a KeyClass-ready dataset from MIMIC-III discharge summaries, following the
+procedure described in *“Classifying Unstructured Clinical Notes via Automatic
+Weak Supervision”* (https://arxiv.org/abs/2206.12088).
+
+Highlights
+----------
+* Uses the custom task also created for this: ``MIMIC3DischargeNotesICD9Coding``.
+* **No TF-IDF filtering** is applied to the discharge-note text since 
+  the paper is unclear on this aspect (possible future improvement).
+* Each note is mapped to zero or more of the 19 top-level ICD-9 categories
+  based on the ICD-9 codes recorded in MIMIC-III.
+* Generates train/test splits and writes files in the exact layout expected by KeyClass:
+
+    ┌────────────────────┬─────────────────────────────────────────────────────┐
+    │ File               │ Contents                                            │
+    ├────────────────────┼─────────────────────────────────────────────────────┤
+    │ labels.txt         │ Names of the 19 ICD-9 top-level categories          │
+    │ train.txt          │ One discharge note per line (training)              │
+    │ train_labels.txt   │ 19-dim binary vectors for the training set          │
+    │ test.txt           │ One discharge note per line (test)                  │
+    │ test_labels.txt    │ 19-dim binary vectors for the test set              │
+    └────────────────────┴─────────────────────────────────────────────────────┘
+
+ICD-9 Top-Level Category Mappings
+-----------------------------------------------------------------------------------------
+Range (3-digit) | Code   | Description
+--------------- | ------ | --------------------------------------------------------------
+001 – 139       | cat:01 | Infectious and parasitic diseases
+140 – 239       | cat:02 | Neoplasms
+240 – 279       | cat:03 | Endocrine, nutritional and metabolic disorders
+280 – 289       | cat:04 | Diseases of the blood and blood-forming organs
+290 – 319       | cat:05 | Mental disorders
+320 – 359       | cat:06 | Diseases of the nervous system
+360 – 389       | cat:07 | Diseases of the sense organs
+390 – 459       | cat:08 | Diseases of the circulatory system
+460 – 519       | cat:09 | Diseases of the respiratory system
+520 – 579       | cat:10 | Diseases of the digestive system
+580 – 629       | cat:11 | Diseases of the genitourinary system
+630 – 679       | cat:12 | Pregnancy, childbirth and puerperium
+680 – 709       | cat:13 | Diseases of the skin and subcutaneous tissue
+710 – 739       | cat:14 | Diseases of the musculoskeletal system and connective tissue
+740 – 759       | cat:15 | Congenital anomalies
+760 – 779       | cat:16 | Certain conditions originating in the perinatal period
+800 – 999       | cat:17 | Injury and poisoning
+E-codes         | cat:18 | External causes of injury
+V-codes         | cat:19 | Supplementary factors influencing health status
+
+Before you run
+--------------
+Set the constant ``OUTPUT_DIR`` below to the directory where you want the generated files to be written.
+Set the constant ``MIMIC_DB_LOCATION`` with the location of the MIMIC database files.
+"""
+import sys
+sys.path.append("../PyHealth")
+from pyhealth.datasets import MIMIC3Dataset
+from pyhealth.tasks import MIMIC3DischargeNotesICD9Coding
+from pyhealth.datasets import split_by_sample
+import numpy as np
+import os
+import torch 
+
+# Directory to save the final dataset files
+OUTPUT_DIR = "example_output_dev"
+# Location of the MIMIC database files
+MIMIC_DB_LOCATION = "../mimicdatabase"
+
+def write_labels_file(label_file):
+    """ Writes the label.txt file with the names of the 19 top-level ICD-9 categories."""
+    with open(label_file, 'w') as f:
+        labels = [
+            "Infectious & parasitic",
+            "Neoplasms",
+            "Endocrine, nutritional and metabolic",
+            "Blood & blood-forming organs",
+            "Mental disorders",
+            "Nervous system",
+            "Sense organs",
+            "Circulatory system",
+            "Respiratory system",
+            "Digestive system",
+            "Genitourinary system",
+            "Pregnancy & childbirth complications",
+            "Skin & subcutaneous tissue",
+            "Musculoskeletal system & connective tissue",
+            "Congenital anomalies",
+            "Perinatal period conditions",
+            "Injury and poisoning",
+            "External causes of injury",
+            "Supplementary"
+        ]
+        for label in labels:
+            f.write(f"{label}\n")
+        print()
+
+def write_output_files(dataset, feature_filename, labels_filename):
+    """ Writes the train/test sets and respective labels to file."""
+
+    with open(feature_filename, 'w', encoding='utf-8') as f_text, \
+        open(labels_filename, 'w', encoding='utf-8') as f_labels:
+
+        for i, sample_dict in enumerate(dataset):
+
+            # 1. Extract and clean the discharge note text
+            text_feature = sample_dict.get('text', '')
+            # Replace newlines within the text with spaces for single-line output
+            text_line = text_feature.replace('\n', ' ').replace('\r', ' ').strip()
+
+            # 2. Process the label tensor (already computed by PyHealth)
+            label_tensor = sample_dict.get('top_level_icd9_cats')
+
+            if label_tensor is None:
+                print(f"Warning: Missing 'top_level_icd9_cats' tensor in sample {i}. Skipping label.")
+                return 1
+            elif not isinstance(label_tensor, torch.Tensor):
+                 print(f"Warning: 'top_level_icd9_cats' in sample {i} is not a tensor (type: {type(label_tensor)}). Skipping label.")
+                 label_string = ""
+                 return 1
+            else:
+                # Convert tensor elements (e.g., 1.0, 0.0) to integers (1, 0) and then to strings ('1', '0') and join them.
+                label_string = "".join(map(str, label_tensor.int().tolist()))
+
+            # 3. Write to the respective files
+            f_text.write(text_line + '\n')
+            f_labels.write(label_string + '\n')
+
+    print(f"Successfully wrote:")
+    print(f"- Features to: {feature_filename}")
+    print(f"- Labels to: {labels_filename}")
+
+
+def main():
+    """ Writes the train/test sets and respective labels to file."""
+
+    dataset = MIMIC3Dataset(
+        root=MIMIC_DB_LOCATION,
+        dataset_name="mimic3",
+        tables=[ "diagnoses_icd", "noteevents" ],
+        dev=True
+    )
+
+    #dataset.stats()
+
+    # Creates the new task for generating the MIMIC-derived KeyClass dataset
+    mimic3_discharge_notes_coding = MIMIC3DischargeNotesICD9Coding()
+    samples = dataset.set_task(mimic3_discharge_notes_coding)
+
+    # Print sample information
+    print(f"Total samples generated: {len(samples)}")
+    if len(samples) > 0:
+        print("First sample:")
+        print(f"  - Patient ID: {samples[0]['patient_id']}")
+        print(f"  - Text length: {len(samples[0]['text'])} characters")
+        print(f"  - Number of Top Level ICD9 Categories: {len(samples[0]['top_level_icd9_cats'])}")
+        if len(samples[0]['top_level_icd9_cats']) > 0:
+            print(f"  - Top-Level ICD9 Categories: {samples[0]['top_level_icd9_cats']}")
+
+    # KeyClass uses a 75%/25% with only training and test sets (no validation)
+    train_dataset, val_dataset, test_dataset = split_by_sample(
+        dataset=samples,
+        ratios=[0.75, 0, 0.25]
+    )
+
+    print(f"\nTrain dataset size: {len(train_dataset)}")
+    print(f"Validation dataset size: {len(val_dataset)}")
+    print(f"Test dataset size: {len(test_dataset)}")
+
+    print(train_dataset)
+
+    # Writing the dataset files in the format required by KeyClass
+
+    # Create output directory if it does not exist.
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    
+    # Define destination filenames
+    train_filename = os.path.join(OUTPUT_DIR, "train.txt")
+    train_labels_filename = os.path.join(OUTPUT_DIR, "train_labels.txt")
+    test_filename = os.path.join(OUTPUT_DIR, "test.txt")
+    test_labels_filename = os.path.join(OUTPUT_DIR, "test_labels.txt")
+    label_filename = os.path.join(OUTPUT_DIR, "labels.txt")
+
+    # Write the files
+    write_output_files(train_dataset, train_filename, train_labels_filename)
+    write_output_files(test_dataset, test_filename, test_labels_filename)
+    write_labels_file(label_filename)
+
+if __name__ == "__main__":
+    main()

--- a/examples/discharge_notes_top_level_icd9_cats.py
+++ b/examples/discharge_notes_top_level_icd9_cats.py
@@ -69,8 +69,14 @@ OUTPUT_DIR = "example_output_dev"
 # Location of the MIMIC database files
 MIMIC_DB_LOCATION = "../mimicdatabase"
 
-def write_labels_file(label_file):
-    """ Writes the label.txt file with the names of the 19 top-level ICD-9 categories."""
+def write_labels_file(label_file: str):
+    """ Writes the label.txt file with the names of the 19 top-level ICD-9 categories.
+        Will be called in `main()`.
+        Args:
+            label_file: a string with the target location to write the file to.
+        Returns:
+            No return
+    """
     with open(label_file, 'w') as f:
         labels = [
             "Infectious & parasitic",
@@ -98,7 +104,15 @@ def write_labels_file(label_file):
         print()
 
 def write_output_files(dataset, feature_filename, labels_filename):
-    """ Writes the train/test sets and respective labels to file."""
+    """ Writes the train/test sets and respective labels to file.
+        Will be called in `main()`.
+            Args:
+                dataset: PyHealth generated train/test split.
+                feature_filename: filename location where features will be written to.
+                labels_filename: filename location where labels will be written to.
+            Returns:
+                No return
+    """
 
     with open(feature_filename, 'w', encoding='utf-8') as f_text, \
         open(labels_filename, 'w', encoding='utf-8') as f_labels:
@@ -134,8 +148,10 @@ def write_output_files(dataset, feature_filename, labels_filename):
 
 
 def main():
-    """ Writes the train/test sets and respective labels to file."""
-
+    """ Main function to execute the example.
+        Args: None
+        Returns: None
+    """
     dataset = MIMIC3Dataset(
         root=MIMIC_DB_LOCATION,
         dataset_name="mimic3",

--- a/pyhealth/datasets/base_dataset.py
+++ b/pyhealth/datasets/base_dataset.py
@@ -353,7 +353,7 @@ class BaseDataset(ABC):
 
         # Determine number of workers
         if num_workers is None:
-            num_workers = min(16, os.cpu_count())
+            num_workers = min(8, os.cpu_count())
 
         logger.info(f"Generating samples with {num_workers} worker(s)...")
 

--- a/pyhealth/datasets/base_dataset.py
+++ b/pyhealth/datasets/base_dataset.py
@@ -353,7 +353,7 @@ class BaseDataset(ABC):
 
         # Determine number of workers
         if num_workers is None:
-            num_workers = min(8, os.cpu_count())
+            num_workers = min(16, os.cpu_count())
 
         logger.info(f"Generating samples with {num_workers} worker(s)...")
 

--- a/pyhealth/datasets/configs/mimic3.yaml
+++ b/pyhealth/datasets/configs/mimic3.yaml
@@ -54,6 +54,7 @@ tables:
           - "dischtime"
     timestamp: "dischtime"
     attributes:
+      - "hadm_id"
       - "icd9_code"
       - "seq_num"
 
@@ -123,3 +124,6 @@ tables:
       - "category"
       - "description"
       - "storetime"
+      - "hadm_id"
+      - "chartdate"
+      - "row_id"

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -24,6 +24,7 @@ from .length_of_stay_prediction import (
     length_of_stay_prediction_omop_fn,
 )
 from .medical_coding import MIMIC3ICD9Coding
+from .discharge_notes_coding import MIMIC3DischargeNotesICD9Coding
 from .medical_transcriptions_classification import MedicalTranscriptionsClassification
 from .mortality_prediction import (
     MortalityPredictionEICU,

--- a/pyhealth/tasks/discharge_notes_coding.py
+++ b/pyhealth/tasks/discharge_notes_coding.py
@@ -1,0 +1,217 @@
+# Author: Fabricio Brigagao
+# NetID: fb8
+# Description: Generates discharge notes associated with 19 top-level ICD-9 categories.
+# Reason: Used by the paper Classifying Unstructured Clinical Notes via Automatic Weak Supervision (https://arxiv.org/abs/2206.12088).
+
+import logging
+from dataclasses import field
+from datetime import datetime
+from typing import Dict, List
+
+import polars as pl
+
+from pyhealth.data.data import Patient
+
+from .base_task import BaseTask
+
+logger = logging.getLogger(__name__)
+
+class MIMIC3DischargeNotesICD9Coding(BaseTask):
+    """Medical Discharge Notes Task for MIMIC-III mapped to 19 Top-Level ICD-9 Categories.
+    
+    This task generates discharge notes associated with 19 Top-Level ICD-9 Categories used by the KeyClass paper:
+        - Classifying Unstructured Clinical Notes via Automatic Weak Supervision (https://arxiv.org/abs/2206.12088).
+    It builds upon the dataset generation from FasTag (used by KeyClass), mapping discharge notes to 19 top-level categories. 
+        https://github.com/rivas-lab/FasTag/blob/master/src/textPreprocessing/createAdmissionNoteTable.R
+    
+    ICD-9 top-level ICD9 Categories Mappings for KeyClass
+    Range (3-digit)   →   Cat code   →   Category name
+    ------------------------------------------------------------------------
+        001 to 139    →   cat:01     →   Infectious & parasitic diseases
+        140 to 239    →   cat:02     →   Neoplasms
+        240 to 279    →   cat:03     →   Endocrine, nutritional & metabolic
+        280 to 289    →   cat:04     →   Diseases of the blood & blood-forming organs
+        290 to 319    →   cat:05     →   Mental disorders
+        320 to 359    →   cat:06     →   Diseases of the nervous system
+        360 to 389    →   cat:07     →   Diseases of the sense organs
+        390 to 459    →   cat:08     →   Diseases of the circulatory system
+        460 to 519    →   cat:09     →   Diseases of the respiratory system
+        520 to 579    →   cat:10     →   Diseases of the digestive system
+        580 to 629    →   cat:11     →   Diseases of the genitourinary system
+        630 to 679    →   cat:12     →   Pregnancy, childbirth & puerperium
+        680 to 709    →   cat:13     →   Diseases of the skin & subcutaneous tissue
+        710 to 739    →   cat:14     →   Diseases of the musculoskeletal system & connective tissue
+        740 to 759    →   cat:15     →   Congenital anomalies
+        760 to 779    →   cat:16     →   Certain conditions originating in the perinatal period
+        800 to 999    →   cat:17     →   Injury & poisoning
+        E-codes       →   cat:18     →   External causes of injury
+        V-codes       →   cat:19     →   Supplementary factors influencing health status
+
+    Args:
+        task_name: Name of the task
+        input_schema: Definition of the input data schema
+        output_schema: Definition of the output data schema
+    """
+    task_name: str = "mimic3_discharge_notes_icd9_coding"
+    input_schema: Dict[str, str] = {"text": "text"}
+    output_schema: Dict[str, str] = {"top_level_icd9_cats": "multilabel"}
+
+    def pre_filter(self, df: pl.LazyFrame) -> pl.LazyFrame:
+        filtered_df = df.filter(
+            pl.col("patient_id").is_in(
+                df.filter(pl.col("event_type") == "noteevents")
+                .select("patient_id")
+                .unique()
+                .to_series()
+            )
+        )
+        return filtered_df
+    
+    def map_to_toplevel_ICD9(self, code: str):
+        """Return the top-level ICD-9 category for a raw ICD-9 code string."""
+        if code is None:
+            return None
+
+        icd9 = code.strip()
+        if not icd9:
+            return None
+
+        if icd9.startswith("E"):
+            return "cat:18" # "External causes of injury",
+        elif icd9.startswith("V"):
+            return "cat:19" # "Supplementary"
+
+        try:
+            num = int(icd9[:3])
+        except ValueError:
+            return None          # not a valid numeric code
+
+        if   1   <= num <= 139:  return "cat:01" # Infectious & parasitic"
+        elif 140 <= num <= 239:  return "cat:02" # "Neoplasms",
+        elif 240 <= num <= 279:  return "cat:03" # "Endocrine, nutritional and metabolic",
+        elif 280 <= num <= 289:  return "cat:04" # "Blood & blood-forming organs",
+        elif 290 <= num <= 319:  return "cat:05" # "Mental disorders",
+        elif 320 <= num <= 359:  return "cat:06" # "Nervous system",
+        elif 360 <= num <= 389:  return "cat:07" # "Sense organs",
+        elif 390 <= num <= 459:  return "cat:08" # "Circulatory system",
+        elif 460 <= num <= 519:  return "cat:09" # "Respiratory system",
+        elif 520 <= num <= 579:  return "cat:10" # "Digestive system",
+        elif 580 <= num <= 629:  return "cat:11" # "Genitourinary system",
+        elif 630 <= num <= 679:  return "cat:12" # "Pregnancy & childbirth complications",
+        elif 680 <= num <= 709:  return "cat:13" # "Skin & subcutaneous tissue",
+        elif 710 <= num <= 739:  return "cat:14" # "Musculoskeletal system & connective tissue",
+        elif 740 <= num <= 759:  return "cat:15" # "Congenital anomalies",
+        elif 760 <= num <= 779:  return "cat:16" # "Perinatal period conditions",
+        elif 800 <= num <= 999:  return "cat:17" # "Injury and poisoning",
+        else:
+            return None          # range not covered
+
+    
+    def __call__(self, patient: Patient) -> List[Dict]:
+        """Process a patient and extract discharge notes and ICD-9 codes.
+        
+        Args:
+            patient: Patient object containing events
+            
+        Returns:
+            List of samples, each containing the text of the discharge notes and associated top-level ICD-9 Categories.
+        """
+        samples = []
+        admissions = patient.get_events(event_type="admissions")
+
+        for admission in admissions:
+            
+            selected_note_event = None
+            notes_on_earliest_date = None
+            earliest_chartdate = None
+            noteevents = None
+
+            # For each admission look for DISCHARGE NOTES if they exist.
+            noteevents = patient.get_events(
+                event_type="noteevents",
+                filters = [ ("hadm_id", "==", admission.hadm_id), 
+                           ("category", "==", "Discharge summary"),
+                        ]
+            )
+
+            if noteevents and len(noteevents) > 0:
+
+                # If only 1 discharge note was returned.
+                if len(noteevents) == 1:         
+                    selected_note_event = noteevents[0]
+                else:
+                    
+                    # More than 1 discharge note was returned.
+                    # FasTag's preprocessing (used by KeyClass) maintains the one with min. discharge date.
+                    earliest_chartdate = min(ne.chartdate for ne in noteevents if ne.chartdate)
+                    notes_on_earliest_date = [ ne for ne in noteevents if ne.chartdate == earliest_chartdate ]
+                    
+                    # Following FasTag's and KeyClass's approach, keep the first record even if there are multiple discharge notes 
+                    # for the same HADM and on the minimum date. FasTag's does not elaborate on this.
+                    selected_note_event = notes_on_earliest_date[0]
+
+                if selected_note_event:
+
+                    icd_codes = set()
+                    icd_top_level_cats = set()
+
+                    # Get diagnoses ICDs for patient and admission.
+                    diagnoses_icd = patient.get_events(
+                        event_type="diagnoses_icd",
+                        filters = [ ("hadm_id", "==", str(admission.hadm_id)) ]
+                    )
+
+                    if len(diagnoses_icd) > 0:
+
+                        # Map ICD-9 codes to an array
+                        diagnoses_icd_codes = [event.icd9_code for event in diagnoses_icd]
+                        
+                        # Drop null/None values and deduplicate
+                        icd_codes = list({code for code in diagnoses_icd_codes if code not in (None, "", "nan")})
+                        # Get respective top-level ICD-9 category for each ICD-9 code assigned to the discharge notes.
+                        icd_top_level = [self.map_to_toplevel_ICD9(code) for code in icd_codes]
+                        # Keep only the unique values (removes None and duplicates).
+                        icd_top_level_cats = list({cat for cat in icd_top_level if cat not in (None, "", "nan")})
+
+                        if not selected_note_event.text.strip() or not icd_codes:
+                            continue    # skip samples with empty text OR no valid ICD-9 codes
+                        
+                        # Add sample to list
+                        samples.append({
+                            "patient_id": patient.patient_id,
+                            "text": selected_note_event.text,
+                            "top_level_icd9_cats": icd_top_level_cats
+                        })
+
+        return samples
+
+def main():
+    # Test case for MIMIC3DischargeNotesICD9Coding
+    from pyhealth.datasets import MIMIC3Dataset
+    
+    MIMIC_DB_LOCATION = "../mimicdatabase"
+    print("Testing MIMIC3DischargeNotesICD9Coding task...")
+    dataset = MIMIC3Dataset(
+        root=MIMIC_DB_LOCATION,
+        dataset_name="mimic3",  
+        tables=[
+        "diagnoses_icd",
+        "noteevents"
+        ],
+        dev=True,
+    )
+    mimic3_coding = MIMIC3DischargeNotesICD9Coding()
+    # print(len(mimic3_coding.samples))
+    samples = dataset.set_task(mimic3_coding)
+    # Print sample information
+    print(f"Total samples generated: {len(samples)}")
+    if len(samples) > 0:
+        print("First sample:")
+        print(f"  - Patient ID: {samples[0]['patient_id']}")
+        print(f"  - Text length: {len(samples[0]['text'])} characters")
+        print(f"  - Number of Top Level ICD9 Categories: {len(samples[0]['top_level_icd9_cats'])}")
+        if len(samples[0]['top_level_icd9_cats']) > 0:
+            print(f"  - Top-Level ICD9 Categories: {samples[0]['top_level_icd9_cats']}")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@ pandas>=1.3.2,<2
 pandarallel>=1.5.3
 mne>=1.0.3
 urllib3<=1.26.15
-numpy
+numpy==1.26.4
 tqdm
 polars
 transformers
+pydantic
+PyYaml


### PR DESCRIPTION
**Student:** Fabricio Brigagao (fb8@illinois.edu)
**Contribution:** Adds a new example and a new custom task for MIMIC-3 discharge notes.
**Paper Title:** Classifying Unstructured Clinical Notes via Automatic Weak Supervision (KeyClass)
**Paper Link:**  https://arxiv.org/abs/2206.12088

Adds a **new task and example** on how to create a dataset from MIMIC-III discharge summaries, following the procedure described in *“Classifying Unstructured Clinical Notes via Automatic Weak Supervision”*.

Highlights
----------
* Uses a **new custom task** created for to solve this problem: ``MIMIC3DischargeNotesICD9Coding``.
* Each discharge note is mapped to zero or more of the 19 top-level ICD-9 categories  based on the ICD-9 codes assigned to it in the MIMIC-3 database.
* Generates train/test splits and writes files in the layout expected by KeyClass:
  - labels.txt: Names of the 19 ICD-9 top-level categories
   - train.txt: One discharge note per line (training)
  - train_labels.txt: 19-dim binary vectors for the training set
  - test.txt: One discharge note per line (test)
  - test_labels.txt: 19-dim binary vectors for the test set.

**Limitation:** TF-IDF filtering is not applied to the discharge note's text since the paper was unclear on this aspect and did not provide the respective source code (possible future improvement).

Files to Review
----------
- `pyhealth/datasets/configs/mimic3.yaml`: Added needed fields from the `NOTEEVENTS` and `DIAGNOSES_ICD` tables.
- `pyhealth/tasks/discharge_notes_coding.py`: New task to generate the dataset.
- `pyhealth/tasks/__init__.py`: Added import for the new task.
- `examples/discharge_notes_top_level_icd9_cats.py`: New example using the new task to generate the final files.
- `requirements.txt`: Used latest dependencies provided by the instructor (https://github.com/sunlabuiuc/PyHealth/pull/380).

Testing
------------
The new task and dataset generation can be tested by running the `examples/discharge_notes_top_level_icd9_cats.py`. 

Both were tested on the full MIMIC database and generated the same number of records for train (39,541) and test (13,181) splits as listed on Table 2 of the paper.