### PR TITLE
fix mortality prediction tasks not considering patients may have hete…

### DIFF
--- a/pyhealth/tasks/mortality_prediction.py
+++ b/pyhealth/tasks/mortality_prediction.py
@@ -78,7 +78,7 @@ class MortalityPredictionMIMIC3(BaseTask):
             ]
     
             # Exclude visits without condition, procedure, or drug code
-            if len(conditions) * len(procedures_list) * len(drugs) == 0:
+            if len(conditions) + len(procedures_list) + len(drugs) == 0:
                 continue
             
             samples.append({
@@ -177,7 +177,7 @@ class MultimodalMortalityPredictionMIMIC3(BaseTask):
                 text += note.text
 
             # Exclude visits without condition, procedure, or drug code
-            if len(conditions) * len(procedures_list) * len(drugs) == 0:
+            if len(conditions) + len(procedures_list) + len(drugs) == 0:
                 continue
             
             samples.append({
@@ -291,7 +291,7 @@ class MortalityPredictionMIMIC4(BaseTask):
             ])
 
             # Exclude visits without condition, procedure, or drug code
-            if len(conditions) * len(procedures_list) * len(drugs) == 0:
+            if len(conditions) + len(procedures_list) + len(drugs) == 0:
                 continue
 
             samples.append({
@@ -500,7 +500,7 @@ class MultimodalMortalityPredictionMIMIC4(BaseTask):
                 except Exception as e:
                     print(f"Error processing X-ray image path: {e}")
             # Exclude visits without sufficient clinical data
-            if len(conditions) * len(procedures_list) * len(drugs) == 0:
+            if len(conditions) + len(procedures_list) + len(drugs) == 0:
                 continue
 
             samples.append({

--- a/pyhealth/unittests/test_mortality_prediction.py
+++ b/pyhealth/unittests/test_mortality_prediction.py
@@ -29,7 +29,7 @@ def test_mortality_prediction_mimic3():
     dataset = MIMIC3Dataset(
         root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
         tables=["diagnoses_icd", "procedures_icd", "prescriptions", "noteevents"],
-        dev=False
+        dev=True
     )
     from pyhealth.tasks.mortality_prediction import MortalityPredictionMIMIC3
     from pyhealth.datasets import split_by_patient, get_dataloader


### PR DESCRIPTION
…rogeneous profiles
This pull request updates the logic in the `MortalityPrediction` task to improve how visits with insufficient clinical data are excluded and modifies a test configuration for the `MortalityPredictionMIMIC3` task. The most important changes are grouped into logic updates and test configuration updates.

### Logic Updates:
* Updated the condition for excluding visits without sufficient clinical data in the `__call__` method of `pyhealth/tasks/mortality_prediction.py`. The condition now uses addition (`+`) instead of multiplication (`*`) to check if any of the `conditions`, `procedures_list`, or `drugs` lists are empty. This ensures that visits with any missing data are excluded. [[1]](diffhunk://#diff-ebd3238b3883b34504ddc3fc2cd965320197ca054777b7af9f3eeacccf615ea8L81-R81) [[2]](diffhunk://#diff-ebd3238b3883b34504ddc3fc2cd965320197ca054777b7af9f3eeacccf615ea8L180-R180) [[3]](diffhunk://#diff-ebd3238b3883b34504ddc3fc2cd965320197ca054777b7af9f3eeacccf615ea8L294-R294) [[4]](diffhunk://#diff-ebd3238b3883b34504ddc3fc2cd965320197ca054777b7af9f3eeacccf615ea8L503-R503)

### Test Configuration Updates:
* Changed the `dev` parameter in the `test_mortality_prediction_mimic3` test in `pyhealth/unittests/test_mortality_prediction.py` from `False` to `True` to enable development mode for the dataset. This likely facilitates faster testing with a smaller dataset.