### PR TITLE
Add Retina U-Net Model and Toy Dataset

### DIFF
--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -25,3 +25,4 @@ from .torchvision_model import TorchvisionModel
 from .transformer import Transformer, TransformerLayer
 from .transformers_model import TransformersModel
 from .vae import VAE
+from .retinaunet import RetinaUNet

--- a/pyhealth/models/retinaunet.py
+++ b/pyhealth/models/retinaunet.py
@@ -1,0 +1,71 @@
+import torch
+import torchvision.models as models
+import torch.nn as nn
+import torch.nn.functional as F
+from pyhealth.models import BaseModel
+
+class RetinaUNet(BaseModel):
+    """
+    Retina UNet model recreated from the paper
+    Retina U-Net: Embarrassingly Simple Exploitation of Segmentation Supervision for Medical Object Detection
+    https://arxiv.org/abs/1811.08661
+
+    This model uses an initial resnet model to encode input data as a base model. Resnet acts as an encoder that is followed by serveral convultion transsposers
+    and their own convolution layers. The result is an approximation of identifiable areas as a mask of the region.
+    The model aims to create more efficient
+    labeling from a small set of label data.
+
+    """  
+    def __init__(self):
+        super(RetinaUNet, self).__init__()
+        resnet = models.resnet18(pretrained=False)
+
+        # Encoder layers (for skip connections)
+        self.enc1 = nn.Sequential(resnet.conv1, resnet.bn1, resnet.relu)
+        self.enc2 = nn.Sequential(resnet.maxpool, resnet.layer1)
+        self.enc3 = resnet.layer2
+        self.enc4 = resnet.layer3
+        self.enc5 = resnet.layer4
+
+        # Decoder
+        self.upconv1 = nn.ConvTranspose2d(512, 256, kernel_size=2, stride=2)
+        self.conv1 = nn.Conv2d(256 + 256, 256, kernel_size=3, padding=1)
+
+        self.upconv2 = nn.ConvTranspose2d(256, 128, kernel_size=2, stride=2)
+        self.conv2 = nn.Conv2d(128 + 128, 128, kernel_size=3, padding=1)
+
+        self.upconv3 = nn.ConvTranspose2d(128, 64, kernel_size=2, stride=2)
+        self.conv3 = nn.Conv2d(64 + 64, 64, kernel_size=3, padding=1)
+
+        self.upconv4 = nn.ConvTranspose2d(64, 32, kernel_size=2, stride=2)
+        self.conv4 = nn.Conv2d(32 + 64, 32, kernel_size=3, padding=1)
+
+        self.final_conv = nn.Conv2d(32, 1, kernel_size=1)
+
+    def forward(self, x):
+        # Encoder with skip connections
+        x1 = self.enc1(x)
+        x2 = self.enc2(x1)
+        x3 = self.enc3(x2)
+        x4 = self.enc4(x3)
+        x5 = self.enc5(x4)
+
+        # Decoder with skip connections
+        x = self.upconv1(x5)
+        x = torch.cat([x, x4], dim=1)
+        x = F.relu(self.conv1(x))
+
+        x = self.upconv2(x)
+        x = torch.cat([x, x3], dim=1)
+        x = F.relu(self.conv2(x))
+
+        x = self.upconv3(x)
+        x = torch.cat([x, x2], dim=1)
+        x = F.relu(self.conv3(x))
+
+        x = self.upconv4(x)
+        x = torch.cat([x, x1], dim=1)
+        x = F.relu(self.conv4(x))
+
+        x = F.interpolate(x, size=(320, 320), mode='bilinear', align_corners=False)
+        return self.final_conv(x)

--- a/pyhealth/unittests/test_retinaunet.py
+++ b/pyhealth/unittests/test_retinaunet.py
@@ -1,0 +1,161 @@
+import torch
+from torch.utils.data import Dataset, DataLoader
+import numpy as np
+import random
+import matplotlib.pyplot as plt
+import cv2
+
+from pyhealth.models.retinaunet import RetinaUNet
+
+"""
+ToyDataset is based on the testing dataset used for Retina U-Net model by the paper's authors.
+It creates images with a randomly sized circle to imitate a labeled region on a medical image. Noise in introduced
+to prevent overfitting and create a more realistic approach. A mask image of the first image is also created for
+visual comparison during testing.
+"""
+class ToyDataset(Dataset):
+    def __init__(self, num_samples=1000, image_size=(320, 320), noise_factor=0.2, transform=None):
+        self.num_samples = num_samples
+        self.image_size = image_size
+        self.noise_factor = noise_factor
+        self.transform = transform
+
+    def __len__(self):
+        return self.num_samples
+
+    def __getitem__(self, idx):
+        # Create a blank image (black background)
+        image = np.zeros((320, 320, 3), dtype=np.uint8)
+
+        # Randomly choose shape type: 0 = circle, 1 = donut
+        shape_type = random.randint(0, 1)
+
+        # Random center and radius
+        center_x = random.randint(64, 256)
+        center_y = random.randint(64, 256)
+        radius = random.randint(20, 40)
+
+        # Define custom colors
+        color = (random.randint(0, 100), random.randint(100, 255), random.randint(200, 255))
+
+        # Draw the shape on the image
+        if shape_type == 0:
+            # Draw filled circle
+            cv2.circle(image, (center_x, center_y), radius, color, -1)
+        else:
+            # Draw ring
+            cv2.circle(image, (center_x, center_y), radius, color, 3)
+            cv2.circle(image, (center_x, center_y), radius - 10, (0, 0, 0), -1)
+
+        # Generate noise with a blue hue, but with a slightly darker blue background
+        noise = np.random.uniform(low=0, high=self.noise_factor, size=(320, 320, 3))
+
+        # Create a background that is a little darker than the circle's color
+        noise[..., 0] += np.random.uniform(0.0, 0.1, (320, 320))  # Slightly darker blue
+        noise[..., 1] += np.random.uniform(0.0, 0.2, (320, 320))  # Slight green variation
+        noise[..., 2] += np.random.uniform(0.1, 0.3, (320, 320))  # Slight red variation
+
+        # Clip the values to ensure they stay within the valid image range (0-255)
+        noisy_image = np.clip(image + noise * 255, 0, 255).astype(np.uint8)
+
+        # Create the mask (ground truth)
+        mask = np.zeros((320, 320), dtype=np.uint8)
+        if shape_type == 0:
+            # Circle mask
+            cv2.circle(mask, (center_x, center_y), radius, 255, -1)
+        else:
+            # Donut mask
+            cv2.circle(mask, (center_x, center_y), radius, 255, 3)
+            cv2.circle(mask, (center_x, center_y), radius - 10, 0, -1)
+
+
+        # Normalize image and mask
+        noisy_image = noisy_image.astype(np.float32) / 255.0
+        mask = mask.astype(np.float32) / 255.0
+
+        # Convert to tensors
+        noisy_image = torch.from_numpy(noisy_image.transpose((2, 0, 1)))
+        mask = torch.from_numpy(mask).unsqueeze(0)
+
+        return noisy_image, mask
+
+# Training loop
+def train(model, dataloader, optimizer, device, num_epochs=5, dropout_p=0.5):
+    model.train()
+    for epoch in range(num_epochs):
+        running_loss = 0.0
+        for batch_idx, (imgs, masks) in enumerate(dataloader):
+            imgs = imgs.to(device)
+            masks = masks.to(device)
+
+            # Apply input dropout
+            if dropout_p > 0:
+                imgs = F.dropout(imgs, p=dropout_p, training=True)
+
+            # Ensure proper mask dimensions
+            if masks.ndimension() == 3:
+                masks = masks.unsqueeze(1)
+
+            # Resize masks and predictions
+            masks_resized = F.interpolate(masks.float(), size=(320, 320), mode='nearest')
+            optimizer.zero_grad()
+            outputs = model(imgs)
+            outputs_resized = F.interpolate(outputs, size=(320, 320), mode='nearest')
+
+            # Compute and optimize loss
+            loss = criterion(outputs_resized, masks_resized)
+            loss.backward()
+            optimizer.step()
+
+            running_loss += loss.item()
+
+        print(f'>> Epoch {epoch+1}/{num_epochs}, Average Loss: {running_loss/len(dataloader):.4f}\n')
+
+
+# Evaluating the Dice Score between the Ground Truth Mask and the Model's Prediction
+def evaluate(model, loader, device):
+    model.eval()
+    dice_scores = []
+    with torch.no_grad():
+        for images, masks in loader:
+            images = images.to(device)
+            masks = masks.to(device).float()
+
+            outputs = model(images)
+            outputs = torch.sigmoid(outputs)
+            preds = (outputs > 0.5).float()
+
+            # Calculate Dice score for each sample
+            intersection = (preds * masks).sum(dim=(1,2,3))
+            union = preds.sum(dim=(1,2,3)) + masks.sum(dim=(1,2,3))
+            dice = (2. * intersection) / (union + 1e-8)
+            dice_scores.extend(dice.cpu().numpy())
+
+    # Compute average Dice score
+    mean_dice = sum(dice_scores) / len(dice_scores)
+    print(f"Mean Dice score: {mean_dice:.4f}")
+
+# Create full dataset
+full_dataset = ToyDataset(num_samples=1000)
+
+# Split into train/val
+train_size = int(0.8 * len(full_dataset))
+val_size = len(full_dataset) - train_size
+train_dataset, val_dataset = torch.utils.data.random_split(full_dataset, [train_size, val_size])
+
+# Create loaders
+train_loader = DataLoader(train_dataset, batch_size=10, shuffle=True)
+val_loader = DataLoader(val_dataset, batch_size=10, shuffle=False)
+
+# Create model
+model = RetinaUNet()
+# Choose device
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+print(f"Using device: {device}")
+model = model.to(device)
+# Set up optimizer and loss function
+optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+criterion = torch.nn.BCEWithLogitsLoss()
+# Run training, visualizing output and evaluation
+train(model, train_loader, optimizer, device, num_epochs=5, dropout_p=0.3)
+evaluate(model, val_loader, device)


### PR DESCRIPTION
# Add Retina U-Net Model and Toy Dataset
## Overview

**Paper**: Retina U-Net: Embarrassingly Simple Exploitation of Segmentation Supervision for Medical Object Detection  
**Source**: https://arxiv.org/abs/1811.08661
**Team**: Shlok Patel - _spate472_, Armando Soriano - _aus3_  
**Contribution Type**: Image based model

## Description
Used LLMs to help recreate the model created by the authors and the dataset used for testing.

### Files
- pyhealth\models\retinaunet.py -  **Model implementation**
- pyhealth\unittests\test_retinaunet.py - **Test and Toy dataset**