### PR TITLE
Extend MIMIC4CXRDataset with Bias Metadata Extraction Task, In-Memory Metadata Processing, and Configurable Table Support

### DIFF
--- a/pyhealth/datasets/mimic3.py
+++ b/pyhealth/datasets/mimic3.py
@@ -42,8 +42,8 @@ class MIMIC3Dataset(BaseDataset):
         if config_path is None:
             logger.info("No config path provided, using default config")
             config_path = Path(__file__).parent / "configs" / "mimic3.yaml"
-        default_tables = ["patients", "admissions", "icustays"]
-        tables = default_tables + tables
+            default_tables = ["patients", "admissions", "icustays"]
+            tables = default_tables + tables
         if "prescriptions" in tables:
             warnings.warn(
                 "Events from prescriptions table only have date timestamp (no specific time). "

--- a/pyhealth/datasets/mimic4.py
+++ b/pyhealth/datasets/mimic4.py
@@ -52,10 +52,11 @@ class MIMIC4EHRDataset(BaseDataset):
         if config_path is None:
             config_path = os.path.join(os.path.dirname(__file__), "configs", "mimic4_ehr.yaml")
             logger.info(f"Using default EHR config: {config_path}")
+            default_tables = ["patients", "admissions", "icustays"]
+            tables = tables + default_tables
 
         log_memory_usage(f"Before initializing {dataset_name}")
-        default_tables = ["patients", "admissions", "icustays"]
-        tables = tables + default_tables
+
         super().__init__(
             root=root,
             tables=tables,

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -47,3 +47,4 @@ from .sleep_staging import (
 )
 from .sleep_staging_v2 import SleepStagingSleepEDF
 from .temple_university_EEG_tasks import EEG_events_fn, EEG_isAbnormal_fn
+from .cxr_bias_mitigation import CXRBiasMitigationSamplingTask

--- a/pyhealth/tasks/cxr_bias_mitigation.py
+++ b/pyhealth/tasks/cxr_bias_mitigation.py
@@ -1,0 +1,131 @@
+from typing import Any, Dict, List
+from .base_task import BaseTask
+import polars as pl
+
+
+class CXRBiasMitigationSamplingTask(BaseTask):
+    """
+    A task that performs sampling of chest X-ray metadata and associated patient information,
+    targeting bias mitigation by filtering for the availability of demographic data.
+    """
+    task_name: str = "CXRBiasMitigationSamplingTask"
+    input_schema: Dict[str, str] = {"path": "image"}
+    output_schema: Dict[str, str] = {
+        "dicom_id": "raw",
+        "subject_id": "raw",
+        "study_id": "raw",
+        "ViewPosition": "raw",
+        "path": "raw",
+        "gender": "raw",
+        "insurance": "raw",
+        "ethnicity": "raw",
+        "marital_status": "raw",
+        "Atelectasis": "binary",
+        "Cardiomegaly": "binary",
+        "Consolidation": "binary",
+        "Edema": "binary",
+        "Enlarged Cardiomediastinum": "binary",
+        "Fracture": "binary",
+        "Lung Lesion": "binary",
+        "Lung Opacity": "binary",
+        "No Finding": "binary",
+        "Pleural Effusion": "binary",
+        "Pleural Other": "binary",
+        "Pneumonia": "binary",
+        "Pneumothorax": "binary",
+        "Support Devices": "binary"
+    }
+
+    def __init__(self):
+        self.allowed_view_positions = ["PA", "AP"]
+
+    def pre_filter(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Filters the input DataFrame to retain only patients who have both gender, race, and
+        insurance information available.
+        """
+        patients_with_gender = (
+            df.filter((pl.col("event_type") == "patients") & pl.col("patients/gender").is_not_null())
+            .select("patient_id").unique().get_column("patient_id").to_list()
+        )
+
+        patients_with_race = (
+            df.filter((pl.col("event_type") == "admissions") & pl.col("admissions/insurance").is_not_null())
+            .select("patient_id").unique().get_column("patient_id").to_list()
+        )
+
+        patients_with_insurance = (
+            df.filter((pl.col("event_type") == "admissions") & pl.col("admissions/race").is_not_null())
+            .select("patient_id").unique().get_column("patient_id").to_list()
+        )
+
+        valid_ids = set(patients_with_gender) & set(patients_with_race) & set(patients_with_insurance)
+
+        return df.filter(pl.col("patient_id").is_in(valid_ids))
+
+    def __call__(self, patient: Any) -> List[Dict[str, Any]]:
+        """
+        Extracts and merges bias-related metadata for a given patient,
+        returning the processed data as a list of dictionaries.
+        """
+        md_df = patient.get_events(event_type="metadata", return_df=True)
+        pt_df = patient.get_events(event_type="patients", return_df=True)
+        ad_df = patient.get_events(event_type="admissions", return_df=True)
+        lb_df = patient.get_events(event_type="chexpert", return_df=True)
+
+        # Exit early if no metadata exits
+        if md_df.is_empty():
+            return []
+
+        md_df = md_df.filter(pl.col("metadata/viewposition").is_in(self.allowed_view_positions))
+
+        # Again exit if no metadata exists after filtering
+        if md_df.is_empty():
+            return []
+
+        base = md_df.select([
+            pl.col("metadata/dicom_id").alias("dicom_id"),
+            pl.col("patient_id").alias("subject_id"),
+            pl.col("metadata/study_id").alias("study_id"),
+            pl.col("metadata/viewposition").alias("ViewPosition"),
+            pl.col("metadata/image_path").alias("path")
+        ])
+        base = base.with_columns(pl.lit(patient.patient_id).alias("subject_id"))
+
+        # Join gender data from patient info if available
+        if not pt_df.is_empty():
+            pt_df = pt_df.select([
+                pl.lit(patient.patient_id).alias("subject_id"),
+                pl.col("patients/gender").alias("gender")
+            ])
+            base = base.join(pt_df, on="subject_id", how="left")
+
+        # Join insurance, ethnicity, and marital status from admission data if available
+        if not ad_df.is_empty():
+            ad_df = (
+                ad_df.select([
+                    pl.lit(patient.patient_id).alias("subject_id"),
+                    pl.col("admissions/insurance").alias("insurance"),
+                    pl.col("admissions/race").alias("ethnicity"),
+                    pl.col("admissions/marital_status").alias("marital_status")
+                ])
+                .unique(subset=["subject_id"], keep="last")
+            )
+            base = base.join(ad_df, on="subject_id", how="left")
+
+        # Join CheXpert labels if available
+        if not lb_df.is_empty():
+            label_cols = [
+                "atelectasis", "cardiomegaly", "consolidation", "edema",
+                "enlarged cardiomediastinum", "fracture", "lung lesion",
+                "lung opacity", "no finding", "pleural effusion",
+                "pleural other", "pneumonia", "pneumothorax", "support devices"
+            ]
+            rename_map = {f"chexpert/{c}": c.title() for c in label_cols}
+            lb_df = lb_df.rename(rename_map)
+
+            base = base.join(lb_df, left_on="dicom_id", right_on="chexpert/dicom_id", how="left")
+        selected_keys = list(self.output_schema.keys())
+        base = base.select([k for k in selected_keys if k in base.columns])
+
+        return base.to_dicts()

--- a/pyhealth/unittests/test_cxr_bias_mitigation.py
+++ b/pyhealth/unittests/test_cxr_bias_mitigation.py
@@ -1,0 +1,133 @@
+import unittest
+import polars as pl
+from pyhealth.tasks.cxr_bias_mitigation import CXRBiasMitigationSamplingTask
+
+
+class DummyPatient:
+    def __init__(self, patient_id, metadata=None, patients=None, admissions=None, chexpert=None):
+        self.patient_id = patient_id
+        self._data = {
+            "metadata": metadata if metadata is not None else pl.DataFrame(),
+            "patients": patients if patients is not None else pl.DataFrame(),
+            "admissions": admissions if admissions is not None else pl.DataFrame(),
+            "chexpert": chexpert if chexpert is not None else pl.DataFrame()
+        }
+
+    def get_events(self, event_type, return_df=False):
+        return self._data.get(event_type, pl.DataFrame())
+
+
+class TestCXRBiasMitigationSamplingTask(unittest.TestCase):
+    def setUp(self):
+        self.task = CXRBiasMitigationSamplingTask()
+
+    def test_pre_filter(self):
+        data = [
+            # ✅ Patient A
+            {"event_type": "patients", "patient_id": 101, "patients/gender": "M"},
+            {"event_type": "admissions", "patient_id": 101, "admissions/race": "White"},
+            {"event_type": "admissions", "patient_id": 101, "admissions/insurance": "Medicare"},
+
+            # ❌ Patient B
+            {"event_type": "patients", "patient_id": 102, "patients/gender": None},
+            {"event_type": "admissions", "patient_id": 102, "admissions/race": "Black"},
+            {"event_type": "admissions", "patient_id": 102, "admissions/insurance": "Medicaid"},
+
+            # ❌ Patient C
+            {"event_type": "patients", "patient_id": 103, "patients/gender": "F"},
+            {"event_type": "admissions", "patient_id": 103, "admissions/insurance": "Private"},
+
+            # ✅ Patient D
+            {"event_type": "patients", "patient_id": 104, "patients/gender": "F"},
+            {"event_type": "admissions", "patient_id": 104, "admissions/race": "Asian"},
+            {"event_type": "admissions", "patient_id": 104, "admissions/insurance": "Private"}
+        ]
+        df = pl.DataFrame(data)
+        filtered = self.task.pre_filter(df)
+        patient_ids = set(filtered["patient_id"].to_list())
+
+        expected_ids = {101, 104}
+        self.assertEqual(patient_ids, expected_ids)
+
+    def test_call_no_metadata(self):
+        patient = DummyPatient(patient_id=1)
+        result = self.task(patient)
+        self.assertEqual(result, [])
+
+    def test_call_filters_viewposition(self):
+        metadata = pl.DataFrame({
+            "metadata/viewposition": ["LL", "PA"],
+            "metadata/dicom_id": ["x", "y"],
+            "metadata/study_id": ["s1", "s2"],
+            "metadata/image_path": ["p1", "p2"],
+            "patient_id": [1, 1]
+        })
+        patient = DummyPatient(patient_id=1, metadata=metadata)
+        result = self.task(patient)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["ViewPosition"], "PA")
+
+    def test_call_merges_metadata(self):
+        metadata = pl.DataFrame({
+            "metadata/viewposition": ["PA"],
+            "metadata/dicom_id": ["d1"],
+            "metadata/study_id": ["s1"],
+            "metadata/image_path": ["p1"],
+            "patient_id": [1]
+        })
+
+        patients = pl.DataFrame({
+            "patients/gender": ["F"]
+        })
+
+        admissions = pl.DataFrame({
+            "admissions/insurance": ["Private"],
+            "admissions/race": ["Asian"],
+            "admissions/marital_status": ["Married"]
+        })
+
+        patient = DummyPatient(patient_id=1, metadata=metadata, patients=patients, admissions=admissions)
+        result = self.task(patient)
+        self.assertEqual(result[0]["gender"], "F")
+        self.assertEqual(result[0]["insurance"], "Private")
+        self.assertEqual(result[0]["ethnicity"], "Asian")
+        self.assertEqual(result[0]["marital_status"], "Married")
+
+    def test_call_joins_chexpert(self):
+        metadata = pl.DataFrame({
+            "metadata/viewposition": ["PA"],
+            "metadata/dicom_id": ["d1"],
+            "metadata/study_id": ["s1"],
+            "metadata/image_path": ["img"],
+            "patient_id": [1]
+        })
+
+        chexpert = pl.DataFrame({
+            "chexpert/dicom_id": ["d1"],
+            "chexpert/atelectasis": [1],
+            "chexpert/cardiomegaly": [0],
+            "chexpert/consolidation": [1],
+            "chexpert/edema": [0],
+            "chexpert/enlarged cardiomediastinum": [0],
+            "chexpert/fracture": [0],
+            "chexpert/lung lesion": [0],
+            "chexpert/lung opacity": [1],
+            "chexpert/no finding": [0],
+            "chexpert/pleural effusion": [1],
+            "chexpert/pleural other": [0],
+            "chexpert/pneumonia": [1],
+            "chexpert/pneumothorax": [0],
+            "chexpert/support devices": [1]
+        })
+
+        patient = DummyPatient(patient_id=1, metadata=metadata, chexpert=chexpert)
+        result = self.task(patient)
+
+        self.assertEqual(result[0]["Atelectasis"], 1)
+        self.assertEqual(result[0]["Cardiomegaly"], 0)
+        self.assertEqual(result[0]["Pneumonia"], 1)
+        self.assertEqual(result[0]["Support Devices"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**NetId:** bwg2  
**Type of contribution:** Task + Other / Feature Enhancement  

**Description:**
- Updated `mimic3`/`mimic4` datasets to support overwriting default tables when utilizing a custom config.
- Modified `MIMIC4CXRDataset`'s metadata process to eliminate the need for disk I/O when creating derived metadata columns.
  - Original file is processed on init with Polars lazy-values configured for `filepath` and `studytime`, returned through an implementation of `load_table`.
    - **Files to look at:** `mimic3.py`, `mimic4.py`
- Added a task to extract bias-related metadata for MIMIC-CXR, supporting downstream fairness and bias mitigation workflows.
  - **Files to look at:** `cxr_bias_mitigation.py`, `test_cxr_bias_mitigation.py`
- This PR builds off of [PR #354](https://github.com/sunlabuiuc/PyHealth/pull/354).
