### PR TITLE
MIMIC CXR Dataset

### DIFF
--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -1,28 +1,49 @@
 class BaseEHRDataset:
     """This class is deprecated and should not be used."""
+
     def __init__(self, *args, **kwargs):
         import warnings
-        warnings.warn("The BaseEHRDataset class is deprecated and will be removed in a future version.", DeprecationWarning)
+
+        warnings.warn(
+            "The BaseEHRDataset class is deprecated and will be removed in a future version.",
+            DeprecationWarning,
+        )
+
 
 class BaseSignalDataset:
     """This class is deprecated and should not be used."""
+
     def __init__(self, *args, **kwargs):
         import warnings
-        warnings.warn("The BaseSignalDataset class is deprecated and will be removed in a future version.", DeprecationWarning)
+
+        warnings.warn(
+            "The BaseSignalDataset class is deprecated and will be removed in a future version.",
+            DeprecationWarning,
+        )
 
 
 class SampleEHRDataset:
     """This class is deprecated and should not be used."""
+
     def __init__(self, *args, **kwargs):
         import warnings
-        warnings.warn("The SampleEHRDataset class is deprecated and will be removed in a future version.", DeprecationWarning)
+
+        warnings.warn(
+            "The SampleEHRDataset class is deprecated and will be removed in a future version.",
+            DeprecationWarning,
+        )
 
 
 class SampleSignalDataset:
     """This class is deprecated and should not be used."""
+
     def __init__(self, *args, **kwargs):
         import warnings
-        warnings.warn("The SampleSignalDataset class is deprecated and will be removed in a future version.", DeprecationWarning)
+
+        warnings.warn(
+            "The SampleSignalDataset class is deprecated and will be removed in a future version.",
+            DeprecationWarning,
+        )
 
 
 from .base_dataset import BaseDataset
@@ -34,6 +55,7 @@ from .isruc import ISRUCDataset
 from .medical_transcriptions import MedicalTranscriptionsDataset
 from .mimic3 import MIMIC3Dataset
 from .mimic4 import MIMIC4CXRDataset, MIMIC4Dataset, MIMIC4EHRDataset, MIMIC4NoteDataset
+from .mimic_cxr import MIMICCXRDataset
 from .mimicextract import MIMICExtractDataset
 from .omop import OMOPDataset
 from .sample_dataset import SampleDataset

--- a/pyhealth/datasets/configs/mimic_cxr.yaml
+++ b/pyhealth/datasets/configs/mimic_cxr.yaml
@@ -1,0 +1,47 @@
+version: "2.1.0"
+tables:
+  provider:
+    file_path: "cxr-provider-list.csv.gz"
+    study_id: "study_id"
+    timestamp: null
+    attributes:
+      - "study_id"
+      - "ordering_provider_id"
+      - "attending_provider_id"
+      - "resident_provider_id"
+
+  record:
+    file_path: "cxr-record-list.csv.gz"
+    patient_id: "subject_id"
+    study_id: "study_id"
+    timestamp: null
+    join:
+      - file_path: "cxr-provider-list.csv.gz"
+        on: ["study_id"]
+        how: "left"
+        columns:
+          - "ordering_provider_id"
+          - "attending_provider_id"
+          - "resident_provider_id"
+    attributes:
+      - "subject_id"
+      - "study_id"
+      - "dicom_id"
+      - "path"
+
+  study:
+    file_path: "cxr-study-list.csv.gz"
+    patient_id: "subject_id"
+    study_id: "study_id"
+    timestamp: null
+    join:
+      - file_path: "cxr-record-list.csv.gz"
+        on: ["subject_id", "study_id"]
+        how: "inner"
+        columns:
+          - "dicom_id"
+          - "path"
+    attributes:
+      - "subject_id"
+      - "study_id"
+      - "path"

--- a/pyhealth/datasets/mimic_cxr.py
+++ b/pyhealth/datasets/mimic_cxr.py
@@ -1,0 +1,92 @@
+import os
+import logging
+import pandas as pd
+from typing import List, Optional
+from .base_dataset import BaseDataset
+
+logger = logging.getLogger(__name__)
+
+
+class MIMICCXRDataset(BaseDataset):
+    """
+    MIMIC-CXR dataset implementation.
+
+    This class handles loading and processing of the MIMIC-CXR dataset including:
+    - Provider information
+    - Record-level metadata (DICOM images)
+    - Study-level information (reports)
+    """
+
+    def __init__(
+        self,
+        root: str,
+        tables: List[str],
+        dataset_name: str = "mimic_cxr",
+        config_path: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        Initialize the MIMIC-CXR dataset.
+
+        Args:
+            root: Root directory containing the dataset files
+            tables: List of tables to load (provider, record, study)
+            dataset_name: Name for this dataset instance
+            config_path: Path to custom config file
+        """
+        if config_path is None:
+            config_path = os.path.join(
+                os.path.dirname(__file__), "configs", "mimic_cxr.yaml"
+            )
+            logger.info(f"Using default CXR config: {config_path}")
+
+        super().__init__(
+            root=root,
+            tables=tables,
+            dataset_name=dataset_name,
+            config_path=config_path,
+            **kwargs,
+        )
+
+        # Rename path columns to be more explicit
+        self.rename_path_columns()
+
+    def rename_path_columns(self) -> None:
+        """Rename path columns to be more explicit about their purpose."""
+        if "record" in self.tables:
+            if "path" in self.tables["record"].columns:
+                self.tables["record"] = self.tables["record"].rename(
+                    columns={"path": "image_path"}
+                )
+                # Add existence check
+                self.tables["record"]["image_exists"] = self.tables["record"][
+                    "image_path"
+                ].apply(lambda x: os.path.exists(os.path.join(self.root, x)))
+
+        if "study" in self.tables:
+            if "path" in self.tables["study"].columns:
+                self.tables["study"] = self.tables["study"].rename(
+                    columns={"path": "report_path"}
+                )
+                # Add existence check
+                self.tables["study"]["report_exists"] = self.tables["study"][
+                    "report_path"
+                ].apply(lambda x: os.path.exists(os.path.join(self.root, x)))
+
+    def get_image_table(self) -> pd.DataFrame:
+        """Get the image table with existence verification."""
+        if "record" not in self.tables:
+            raise ValueError("Record table not loaded")
+
+        return self.tables["record"][
+            ["subject_id", "study_id", "dicom_id", "image_path", "image_exists"]
+        ].copy()
+
+    def get_report_table(self) -> pd.DataFrame:
+        """Get the report table with existence verification."""
+        if "study" not in self.tables:
+            raise ValueError("Study table not loaded")
+
+        return self.tables["study"][
+            ["subject_id", "study_id", "report_path", "report_exists"]
+        ].copy()

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -48,3 +48,4 @@ from .sleep_staging import (
 )
 from .sleep_staging_v2 import SleepStagingSleepEDF
 from .temple_university_EEG_tasks import EEG_events_fn, EEG_isAbnormal_fn
+from .mimic_cxr_processing import MIMICCXRImageReportPairs

--- a/pyhealth/tasks/mimic_cxr_processing.py
+++ b/pyhealth/tasks/mimic_cxr_processing.py
@@ -5,7 +5,6 @@ from dataclasses import field
 
 import pandas as pd
 import polars as pl
-import tempfile
 from pathlib import Path
 from pyhealth.datasets import MIMICCXRDataset
 from pyhealth.data.data import Patient
@@ -97,15 +96,14 @@ class MIMICCXRImageReportPairs(BaseTask):
 
         # Create samples for each valid pair
         for _, row in valid_pairs.iterrows():
-            if row["subject_id"] == patient.patient_id:
-                samples.append(
-                    {
-                        "subject_id": row["subject_id"],
-                        "study_id": row["study_id"],
-                        "image_path": os.path.join(self.root_path, row["image_path"]),
-                        "report_path": os.path.join(self.root_path, row["report_path"]),
-                    }
-                )
+            samples.append(
+                {
+                    "subject_id": row["subject_id"],
+                    "study_id": row["study_id"],
+                    "image_path": os.path.join(self.root_path, row["image_path"]),
+                    "report_path": os.path.join(self.root_path, row["report_path"]),
+                }
+            )
 
         return samples
 

--- a/pyhealth/tasks/mimic_cxr_processing.py
+++ b/pyhealth/tasks/mimic_cxr_processing.py
@@ -1,0 +1,191 @@
+import os
+import logging
+from typing import Dict, List
+from dataclasses import field
+
+import pandas as pd
+import polars as pl
+import tempfile
+from pathlib import Path
+from pyhealth.datasets import MIMICCXRDataset
+from pyhealth.data.data import Patient
+from .base_task import BaseTask
+
+
+logger = logging.getLogger(__name__)
+
+
+class MIMICCXRImageReportPairs(BaseTask):
+    """Task to pair MIMIC-CXR images with their corresponding reports.
+
+    This task creates pairs of chest X-ray images and their corresponding radiology reports.
+
+    Args:
+        task_name: Name of the task
+        input_schema: Definition of the input data schema
+        output_schema: Definition of the output data schema
+    """
+
+    task_name: str = "mimic_cxr_image_report_pairs"
+    input_schema: Dict[str, str] = field(
+        default_factory=lambda: {"subject_id": "str", "study_id": "str"}
+    )
+    output_schema: Dict[str, str] = field(
+        default_factory=lambda: {"image_path": "str", "report_path": "str"}
+    )
+
+    def __init__(self, root_path: str, tables: list = None, **kwargs):
+        """
+        Initialize the MIMIC-CXR image-report pairing task.
+
+        Args:
+            root_path: Root directory containing MIMIC-CXR data
+            tables: List of tables to load from the dataset
+        """
+        super().__init__(**kwargs)
+        self.root_path = root_path
+        self.tables = tables or ["provider", "record", "study"]
+
+    def pre_filter(self, df: pl.LazyFrame) -> pl.LazyFrame:
+        """Filter patients who have both images and reports."""
+        filtered_df = df.filter(
+            pl.col("patient_id").is_in(
+                df.filter(pl.col("image_exists") == True)
+                .select("patient_id")
+                .unique()
+                .to_series()
+            )
+            & pl.col("patient_id").is_in(
+                df.filter(pl.col("report_exists") == True)
+                .select("patient_id")
+                .unique()
+                .to_series()
+            )
+        )
+        return filtered_df
+
+    def __call__(self, patient: Patient) -> List[Dict]:
+        """Process a patient and extract valid image-report path pairs.
+
+        Args:
+            patient: Patient object containing events
+
+        Returns:
+            List of samples, each containing image and report paths
+        """
+        samples = []
+
+        # Initialize dataset for this patient (could be optimized)
+        dataset = MIMICCXRDataset(
+            root=self.root_path,
+            tables=self.tables,
+            dataset_name="mimic_cxr",
+        )
+
+        # Get merged image-report pairs
+        merged_df = pd.merge(
+            dataset.tables["record"],
+            dataset.tables["study"],
+            on=["subject_id", "study_id"],
+            how="inner",
+        )
+
+        # Filter for existing images and reports
+        valid_pairs = merged_df[
+            (merged_df["image_exists"] == True) & (merged_df["report_exists"] == True)
+        ]
+
+        # Create samples for each valid pair
+        for _, row in valid_pairs.iterrows():
+            if row["subject_id"] == patient.patient_id:
+                samples.append(
+                    {
+                        "subject_id": row["subject_id"],
+                        "study_id": row["study_id"],
+                        "image_path": os.path.join(self.root_path, row["image_path"]),
+                        "report_path": os.path.join(self.root_path, row["report_path"]),
+                    }
+                )
+
+        return samples
+
+
+def main():
+    """Comprehensive test of the MIMIC-CXR image-report pairing task."""
+
+    # Test configuration
+    test_config = {
+        "root_path": "/srv/local/data/physionet.org/files/mimic-cxr/2.1.0",
+    }
+
+    # Create a test logger
+    test_logger = logging.getLogger("test_logger")
+    test_logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s - %(message)s"))
+    test_logger.addHandler(handler)
+
+    def run_test_case(test_name, test_func):
+        test_logger.info(f"Running test case: {test_name}")
+        try:
+            test_func()
+            test_logger.info("PASSED\n")
+        except Exception as e:
+            test_logger.error(f"FAILED: {str(e)}\n")
+            raise
+
+    # Test Case 1: Basic functionality test
+    def test_basic_functionality():
+        task = MIMICCXRImageReportPairs(root_path=test_config["root_path"])
+        dataset = MIMICCXRDataset(
+            root=test_config["root_path"],
+            tables=["provider", "record", "study"],
+            dataset_name="mimic_cxr",
+        )
+
+        samples = dataset.set_task(task)
+        assert len(samples) > 0, "No samples generated"
+
+        sample = samples[0]
+        assert Path(sample["image_path"]).exists(), "Image path does not exist"
+        assert Path(sample["report_path"]).exists(), "Report path does not exist"
+        assert isinstance(sample["subject_id"], str), "Subject ID should be string"
+        assert isinstance(sample["study_id"], str), "Study ID should be string"
+
+    # Test Case 2: Missing tables test
+    def test_missing_tables():
+        task = MIMICCXRImageReportPairs(
+            root_path=test_config["root_path"],
+            tables=["record"],  # Only load record table
+        )
+        dataset = MIMICCXRDataset(
+            root=test_config["root_path"],
+            tables=["record"],
+            dataset_name="mimic_cxr",
+        )
+
+        samples = dataset.set_task(task)
+        assert len(samples) == 0, "Should return empty list when missing study table"
+
+    # Run all test cases
+    test_logger.info("Starting MIMICCXRImageReportPairs test suite...\n")
+
+    test_cases = [
+        ("Basic Functionality", test_basic_functionality),
+        ("Missing Tables", test_missing_tables),
+    ]
+
+    for test_name, test_func in test_cases:
+        run_test_case(test_name, test_func)
+
+    test_logger.info("All test cases completed successfully!")
+
+
+if __name__ == "__main__":
+    # Configure basic logging for the main execution
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler()],
+    )
+    main()


### PR DESCRIPTION
## **Name:** 
Hong Wu, Yinzhe Luo
## **NetID:** 
hwu69, yinzhel3
## **Paper:** 
Reproducing and Analyzing Baselines for Chest X-Ray Report Generation:
Insights and Challenges
## **Citation to Original Paper:** 
Boag, W., Hsu, T. M., McDermott, M., Berner, G.,
Alsentzer, E., & Szolovits, P. (2020). Baselines for Chest X-
Ray Report Generation. Proceedings of Machine Learning
Research, 116, 126-140. ML4H at NeurIPS 2019.
## **Link:** 
Paper: https://github.com/hwu5542/cxr-baselines/blob/master/RaABfCXRGIaC.pdf
Cited Paper: https://proceedings.mlr.press/v116/boag20a/boag20a.pdf
## **Description:** 
We added the class to process the [MIMIC-CXR](https://physionet.org/content/mimic-cxr/2.1.0/) dataset. Imported three tables from the csv files: provider, record and study. Renaming the path columns in record and study tables to make them more explicit about their purpose. And let user use the get function to take out only the record or the study table.
We also added the task to utilize the dataset. The MIMICCXRImageReportPairs task make use of the base_dataset functions. Allowed user to call set_task with the MIMICCXRImageReportPairs task to extract the entire list of image path paired with their reports.