### PR TITLE
Add a note about MIMIC-CXR-JPG in the MIMIC4CXRDataset loader

### DIFF
--- a/pyhealth/datasets/mimic4.py
+++ b/pyhealth/datasets/mimic4.py
@@ -121,6 +121,11 @@ class MIMIC4CXRDataset(BaseDataset):
     This class is responsible for loading and managing the MIMIC-CXR Chest X-ray dataset,
     which includes tables such as metadata, chexpert, and radiology.
 
+    NOTE: The loader is expected to work with the MIMIC-CXR-JPG variant of the Chest X-ray
+    dataset (i.e. data sourced from https://physionet.org/content/mimic-cxr-jpg/2.0.0) 
+    which contains X-ray images in .jpg format, instead of the original MIMIC-CXR
+    (https://physionet.org/content/mimic-cxr/2.0.0) which contains .dcm images.
+
     Attributes:
         root (str): The root directory where the dataset is stored.
         tables (List[str]): A list of tables to be included in the dataset.
@@ -168,7 +173,16 @@ class MIMIC4CXRDataset(BaseDataset):
             folder = subject_id[:3]
             study_id = "s" + x["study_id"]
             dicom_id = x["dicom_id"]
-            return os.path.join(root, "files", folder, subject_id, study_id, f"{dicom_id}.jpg")
+            
+            image_path = os.path.join(root, "files", folder, subject_id, study_id, f"{dicom_id}.jpg")
+            if not os.path.exists(image_path):
+                raise Exception("FileNotFound: %s," + 
+                    "WARN: The loader is expected to work with the MIMIC-CXR-JPG dataset " +
+                    "which contains X-ray images in .jpg format, instead of the original MIMIC-CXR" +
+                    "images in .dcm format." 
+                    % (image_path))
+            return image_path
+
         metadata["image_path"] = metadata.apply(process_image_path, axis=1)
 
         metadata.to_csv(os.path.join(root, "mimic-cxr-2.0.0-metadata-pyhealth.csv"), index=False)


### PR DESCRIPTION
While working on [Vision-Language Generative Model for View-Specific Chest X-Ray Generation](https://arxiv.org/abs/2302.12172) paper and skimming through [MIMIC-CXR-JPG](https://physionet.org/content/mimic-cxr-jpg/2.0.0/) dataset,
we found that the newly added `MIMIC4CXRDataset` already implements the said dataset and the loader would explicitly expect to read images from the JPG format instead of the DCM format used in the original variant of the dataset (MIMIC-CXR).

To avoid users from running into gotchas due to this, added a note and warning.

---

Contributor Name(s): Swarup Ghosh, Mick Enev
UIUC NetID: menev2, swarupg2.

cc: @jhnwu3, per thread: https://discord.com/channels/1359223185253597335/1359230031074820299/1369305683501256735

also, cc: @MickEnev
