### PR TITLE
CS598DLH - Add CFVAE model and test

### DIFF
--- a/examples/test_cfvae.py
+++ b/examples/test_cfvae.py
@@ -1,0 +1,55 @@
+import numpy as np
+import torch
+from datetime import datetime, timedelta
+from pyhealth.datasets import SampleDataset
+from pyhealth.models import CFVAE
+
+# ----- Step 1: Create Dummy Time Series Data -----
+samples = []
+for i in range(8):  # 8 samples
+    # Generate 5 time points (1 hour apart)
+    timestamps = [datetime(2024, 1, 1, 0, 0) + timedelta(hours=j) for j in range(5)]
+    values = np.random.rand(5, 784).astype(np.float32)  # shape (T=5, F=784)
+
+    samples.append({
+        "patient_id": f"p{i}",
+        "visit_id": f"v{i}",
+        "image": (timestamps, values),   # 👈 format expected by timeseries processor
+        "label": np.random.randint(0, 2)
+    })
+
+input_schema = {"image": "timeseries"}
+output_schema = {"label": "binary"}
+
+# ----- Step 2: Wrap in SampleDataset -----
+dataset = SampleDataset(
+    samples=samples,
+    input_schema=input_schema,
+    output_schema=output_schema,
+    dataset_name="DummyTimeSeries",
+    task_name="cfvae_test"
+)
+
+# ----- Step 3: Initialize CFVAE Model -----
+model = CFVAE(
+    dataset=dataset,
+    feat_dim=784,
+    emb_dim1=128,
+    _mlp_dim1=0, _mlp_dim2=0, _mlp_dim3=0,
+    mlp_inpemb=64,
+    f_dim1=32,
+    f_dim2=16
+)
+
+model.eval()
+
+# ----- Step 4: Forward Pass -----
+with torch.no_grad():
+    batch = [dataset[i] for i in range(4)]
+    output = model(batch)
+
+# ----- Step 5: Inspect Output -----
+print("Logits shape:", output["logits"].shape)
+print("Reconstruction shape:", output["reconstruction"].shape)
+print("Mu shape:", output["mu"].shape)
+print("Log var shape:", output["log_var"].shape)

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -25,3 +25,4 @@ from .torchvision_model import TorchvisionModel
 from .transformer import Transformer, TransformerLayer
 from .transformers_model import TransformersModel
 from .vae import VAE
+from .cfvae import CFVAE

--- a/pyhealth/models/cfvae.py
+++ b/pyhealth/models/cfvae.py
@@ -1,0 +1,92 @@
+from typing import List, Dict, Tuple
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from pyhealth.models import BaseModel  # Adjust this import path as needed
+
+
+features = 32
+
+
+class CFVAE(BaseModel):
+    def __init__(
+        self,
+        dataset,
+        feat_dim: int,
+        emb_dim1: int,
+        _mlp_dim1: int,
+        _mlp_dim2: int,
+        _mlp_dim3: int,
+        mlp_inpemb: int,
+        f_dim1: int,
+        f_dim2: int,
+    ):
+        super(CFVAE, self).__init__(dataset=dataset)
+
+        # VAE branch
+        self.enc1 = nn.Linear(in_features=feat_dim, out_features=emb_dim1)
+        self.enc2 = nn.Linear(in_features=emb_dim1, out_features=features * 2)
+
+        self.dec1 = nn.Linear(in_features=features, out_features=emb_dim1)
+        self.dec2 = nn.Linear(in_features=emb_dim1, out_features=feat_dim)
+
+        # MLP branch
+        self.word_embeddings = nn.Linear(feat_dim, mlp_inpemb)
+        self.ln1 = nn.LayerNorm(mlp_inpemb)
+
+        self.fc1 = nn.Linear(mlp_inpemb, f_dim1)
+        self.ln2 = nn.LayerNorm(f_dim1)
+
+        self.fc2 = nn.Linear(f_dim1, f_dim2)
+
+        self.scorelayer = nn.Linear(f_dim2, 1)
+        self.pred = nn.Linear(1, self.get_output_size())  # From BaseModel
+
+    def reparameterize(self, mu: torch.Tensor, log_var: torch.Tensor) -> torch.Tensor:
+        std = torch.exp(0.5 * log_var)
+        eps = torch.randn_like(std)
+        return mu + eps * std
+
+    def forward(self, samples: List[Dict]) -> Dict[str, torch.Tensor]:
+        """
+        Args:
+            samples (List[Dict]): A batch of samples from the dataset
+
+        Returns:
+            Dict[str, torch.Tensor]: Includes 'logits' and optionally 'reconstruction', 'mu', 'log_var'
+        """
+        # Combine input tensors from feature keys
+        x = torch.stack([
+            torch.cat([sample[k] for k in self.feature_keys], dim=-1)
+            for sample in samples
+        ])
+
+        # VAE
+        enc = F.relu(self.enc1(x))
+        enc = self.enc2(enc).view(-1, 2, features)
+
+        mu = enc[:, 0, :]
+        log_var = enc[:, 1, :]
+        z = self.reparameterize(mu, log_var)
+
+        dec = F.relu(self.dec1(z))
+        reconstruction = self.dec2(dec)
+
+        # MLP
+        embeds = self.word_embeddings(reconstruction)
+        embeds = self.ln1(embeds)
+
+        out1 = F.relu(self.fc1(embeds))
+        out1 = self.ln2(out1)
+        out2 = F.relu(self.fc2(out1))
+
+        out3 = self.scorelayer(out2)
+        logits = self.pred(out3)
+
+        return {
+            "logits": logits,
+            "reconstruction": reconstruction,
+            "mu": mu,
+            "log_var": log_var
+        }


### PR DESCRIPTION
Zubair Lalani - zubairl2
Ammara Akhtar - aashra5

Paper: Explaining a machine learning decision to physicians via counterfactuals
Paper Link: https://arxiv.org/pdf/2306.06325

This PR introduces the CFVAE model, designed to generate counterfactual explanations for clinical prediction tasks. CFVAE combines a Variational Autoencoder (VAE) branch for reconstructing patient features with an MLP classifier for outcome prediction. By learning a structured latent space, the model enables the generation of minimally altered inputs (counterfactuals) that flip the model's prediction—supporting interpretability and transparency in clinical decision-making.