### PR TITLE
[CS598] Add WESADDataset Class

### DIFF
--- a/gen_mock_data.py
+++ b/gen_mock_data.py
@@ -1,0 +1,34 @@
+import os
+import pickle
+import numpy as np
+
+for sid in range(2, 17):
+    if sid in (1, 12):
+        continue
+    subject_id = f"S{sid}"
+    subject_dir = os.path.join("test_data/wesad", subject_id)
+    os.makedirs(subject_dir, exist_ok=True)
+
+    # Fake sensor data
+    signal = {
+        "chest": {
+            "ACC": np.random.rand(10).tolist(),
+            "ECG": np.random.rand(10).tolist(),
+            "EMG": np.random.rand(10).tolist(),
+        },
+        "wrist": {
+            "ACC": np.random.rand(10).tolist(),
+            "EDA": np.random.rand(10).tolist(),
+            "TEMP": np.random.rand(10).tolist(),
+        }
+    }
+    labels = [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]
+
+    data = {
+        "subject": subject_id,
+        "signal": signal,
+        "label": labels
+    }
+
+    with open(os.path.join(subject_dir, f"{subject_id}.pkl"), "wb") as f:
+        pickle.dump(data, f)

--- a/pyhealth/datasets/configs/wesad.yaml
+++ b/pyhealth/datasets/configs/wesad.yaml
@@ -1,0 +1,23 @@
+version: "1.0"
+tables:
+  wesad:
+    file_path: "*.pkl"
+    patient_id: "patient_id"
+    timestamp: "timestamp"
+    attributes:
+      # Label (0=undefined, 1=baseline, 2=stress, 3=amusement)
+      - "label"
+
+      # Chest sensors
+      - "chest_acc"
+      - "chest_ecg"
+      - "chest_emg"
+      - "chest_eda"
+      - "chest_resp"
+      - "chest_temp"
+
+      # Wrist sensors
+      - "wrist_acc"
+      - "wrist_bvp"
+      - "wrist_eda"
+      - "wrist_temp"

--- a/pyhealth/datasets/wesad.py
+++ b/pyhealth/datasets/wesad.py
@@ -1,0 +1,115 @@
+import os
+import pickle
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import polars as pl
+import numpy as np
+
+from ..data import Patient
+from .base_dataset import BaseDataset
+
+logger = logging.getLogger(__name__)
+
+class WESADDataset(BaseDataset):
+    """
+    Custom dataset class for the WESAD dataset in the PyHealth framework.
+    This class handles the loading and parsing of the physiological and 
+    contextual data from the WESAD dataset.
+
+    Attributes:
+        dataset_name (str): Name of the dataset.
+        root_dir (str): Path to the root directory of the dataset.
+        subjects (List[str]): List of subject IDs to include.
+    """
+
+    def __init__(
+        self,
+        root: str,
+        tables: Optional[List[str]] = None,
+        dataset_name: Optional[str] = "WESAD",
+        config_path: Optional[str] = None,
+        dev: bool = False,
+    ):
+        """
+        Initializes the WESADDataset object.
+
+        Args:
+            dataset_name (str): Name to assign to the dataset instance.
+            root_dir (str): Path to the WESAD dataset directory.
+            subjects (Optional[List[str]]): List of subject IDs to include. If None, include all.
+
+        Returns:
+            None
+
+        Description:
+            Loads and prepares the WESAD dataset for downstream processing. Filters subjects
+            if provided.
+
+        Example:
+            dataset = WESADDataset("wesad", "/path/to/data", subjects=["S2", "S3"])
+        """
+        self.subject_ids = [f"S{sid}" for sid in range(2, 17) if sid not in (1, 12)]
+        self.pkl_files = [
+            os.path.join(root, f"{subj}", f"{subj}.pkl") for subj in self.subject_ids
+        ]
+        self.pkl_files = [f for f in self.pkl_files if os.path.exists(f)]
+
+        logger.info(f"Found {len(self.pkl_files)} WESAD pkl files.")
+
+        super().__init__(root, tables or ["wesad"], dataset_name, config_path, dev)
+
+    def load_data(self) -> pl.LazyFrame:
+        """
+        Loads and parses WESAD .pkl data into a LazyFrame for further processing.
+
+        Returns:
+            pl.LazyFrame: Lazy-loaded DataFrame containing sensor readings and labels.
+
+        Description:
+            For each .pkl file corresponding to a subject:
+            - Load data with pickle
+            - Extract labels and sensor signals (from chest and wrist)
+            - Convert each time step into a data row with sensor values and timestamp
+        """
+        data_rows = []
+        for pkl_path in self.pkl_files:
+            with open(pkl_path, "rb") as f:
+                data = pickle.load(f, encoding="latin1")
+            
+            # Accessing subject, label, and signal data
+            subject = data.get("subject", "Unknown")
+            label_array = data.get("label", [])
+            signal = data.get("signal", {})
+
+            # Access chest and wrist signal data safely
+            chest_data = signal.get("chest", {})
+            wrist_data = signal.get("wrist", {})
+
+            sample_count = len(label_array)
+            for i in range(sample_count):
+                row = {
+                    "patient_id": str(subject),
+                    "timestamp": i,  # simple index-based timestamp
+                    "event_type": "wesad",
+                    "label": int(label_array[i]),
+                }
+
+                # Add features from chest data
+                for key, arr in chest_data.items():
+                    row[f"chest_{key}"] = arr[i] if len(arr) > i else np.nan
+
+                # Add features from wrist data
+                for key, arr in wrist_data.items():
+                    row[f"wrist_{key}"] = arr[i] if len(arr) > i else np.nan
+
+                data_rows.append(row)
+
+        # Convert data into Polars LazyFrame
+        df = pl.DataFrame(data_rows)
+        return df.lazy()
+
+    def preprocess_wesad(self, df: pl.LazyFrame) -> pl.LazyFrame:
+        """Optional preprocessing if needed."""
+        return df  # placeholder — extend with filtering/label mapping if needed

--- a/wesad_test.py
+++ b/wesad_test.py
@@ -1,0 +1,46 @@
+import os
+import unittest
+import polars as pl
+
+from pyhealth.datasets.wesad import WESADDataset  # Adjust this import based on your actual path
+
+class TestWESADDataset(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up paths and load the dataset once for all tests."""
+        cls.test_root = "test_data/wesad"  # Replace with actual test data dir
+        cls.dataset = WESADDataset(root=cls.test_root, config_path="pyhealth/datasets/configs/wesad.yaml")
+
+    def test_initialization(self):
+        """Test that the dataset initializes with correct number of .pkl files."""
+        self.assertIsInstance(self.dataset.pkl_files, list)
+        self.assertGreater(len(self.dataset.pkl_files), 0, "No valid .pkl files found.")
+
+    def test_load_data_returns_lazyframe(self):
+        """Test that load_data returns a Polars LazyFrame."""
+        df_lazy = self.dataset.load_data()
+        self.assertIsInstance(df_lazy, pl.LazyFrame)
+
+    def test_load_data_content(self):
+        """Check the presence of expected columns in the DataFrame."""
+        df_lazy = self.dataset.load_data()
+        df = df_lazy.collect()
+        required_columns = {"patient_id", "timestamp", "event_type", "label"}
+        self.assertTrue(required_columns.issubset(set(df.columns)))
+
+    def test_label_values(self):
+        """Test that label column contains expected value types (integers)."""
+        df_lazy = self.dataset.load_data()
+        df = df_lazy.select("label").collect()
+        self.assertTrue(df["label"].dtype in [pl.Int8, pl.Int16, pl.Int32, pl.Int64])
+
+    def test_sample_row_validity(self):
+        """Test that at least one row has non-NaN sensor values."""
+        df_lazy = self.dataset.load_data()
+        df = df_lazy.collect()
+        sensor_cols = [col for col in df.columns if "chest_" in col or "wrist_" in col]
+        any_non_nan = df.select(sensor_cols).drop_nulls().height > 0
+        self.assertTrue(any_non_nan, "All sensor values are NaN.")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Authors: Matthew Riley, Sam Briley
Netids: mrriley2, sbriley2
Paper: *Simulation of Health Time Series with Nonstationarity*
Paper Link: https://proceedings.mlr.press/v248/toye24a.html

## Description
This PR contains a new dataset class called WESADDataset. This based on the [WESAD](https://uni-siegen.sciebo.de/s/HGdUkoNlW1Ub0Gx) dataset used in the *Simulation of Health Time Series with Nonstationarity* paper. Included are the files `wesad.py` and `wesad.yaml`. These files, respectively, define the `WESADDateset` class and how the dataset is configured.

Additionally, this PR includes two files `gen_mock_data.py` and `wesad_test.py`. The first file `gen_mock_data.py` creates directory of mock data stored in pickle files. This is necessary because the actual dataset is over 2GB in size. The second file contains a few unit tests that read in the mock data and create instances of the WESADDataset class.

## Usage
Running the first file will create a directory of mock data. 
```
$ python gen_mock_data.py
```
This data is structured as shown below.
```
Pyhealth
|- test_data/wesad
  |- S2
     |- S2.pkl
.
.
.
  |- S16
    |- S16.pkl
```

The second file contains 5 unittests that read in the data. To run the file use the command shown below.
```
$ python wesad_test.py
```
Doing so locally generated the following output.
```
Found 14 WESAD pkl files.
Initializing WESAD dataset from test_data/wesad (dev mode: False)
.....
----------------------------------------------------------------------
Ran 5 tests in 0.081s

OK
```
**NOTE**: For the unittests to work the file needs to be in the same directory as `gen_mock_data.py`.