### PR TITLE
feat: add mimic cxr dataset contribution

### DIFF
--- a/examples/mimic_cxr_no_finding.py
+++ b/examples/mimic_cxr_no_finding.py
@@ -1,0 +1,116 @@
+"""MIMIC‑CXR · No‑Finding fine‑tuning demo
+========================================
+This standalone script doubles as a README for the new **MIMICCXRDataset**.
+It shows how to load the dataset, build a simple DenseNet‑121 classifier,
+train for a couple of epochs, and compute AUROC on the validation split.
+
+Directory layout expected::
+
+    ~/data/mimic_cxr/
+        images/                # JPEGs from PhysioNet
+            p10/p10012345/s12345678_0001_0.jpg
+        metadata.csv           # path,label,sex,ethnicity,age,split
+
+How to generate ``metadata.csv``:
+  • see `examples/make_mimic_metadata.ipynb` (joins labels + demographics)
+  • or adapt your own preprocessing pipeline.
+
+Quick run
+---------
+Activate the PyHealth env, then:
+
+>>> python examples/mimic_cxr_no_finding.py \\
+        --root ~/data/mimic_cxr \\
+        --epochs 2
+
+This will print training loss each epoch and a one‑line AUROC summary.
+
+Script arguments
+----------------
+```
+--root          root directory of images/ + metadata.csv
+--batch_size    default 16
+--epochs        default 2 (feel free to raise)
+--lr            learning rate (1e-4 default)
+```
+
+Note: this demo intentionally uses a small subset (val_fold 0 only) so it
+runs on CPU in < 2 min.  For full reproduction pass ``--all`` to load every
+fold and use GPU.
+"""
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from sklearn.metrics import roc_auc_score
+from torch.utils.data import DataLoader, Subset
+from torchvision.models import densenet121
+
+from pyhealth.datasets import MIMICCXRDataset
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--root", required=True, help="path to mimic_cxr root dir")
+    p.add_argument("--batch_size", type=int, default=16)
+    p.add_argument("--epochs", type=int, default=2)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--all", action="store_true", help="load every fold")
+    return p.parse_args()
+
+
+def make_loader(root: Path, split: str, batch_size: int, all_folds: bool):
+    ds = MIMICCXRDataset(root=root, task="No Finding", split=split)
+    if not all_folds:
+        # select only first 5k for quick demo
+        idx = list(range(min(5000, len(ds))))
+        ds = Subset(ds, idx)
+    return DataLoader(ds, batch_size=batch_size, shuffle=(split == "train"), num_workers=4)
+
+
+def main():
+    args = parse_args()
+    root = Path(args.root).expanduser()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    train_loader = make_loader(root, "train", args.batch_size, args.all)
+    val_loader = make_loader(root, "val", args.batch_size, args.all)
+
+    model = densenet121(pretrained=True)
+    model.classifier = nn.Linear(model.classifier.in_features, 1)
+    model.to(device)
+
+    opt = optim.Adam(model.parameters(), lr=args.lr)
+    loss_fn = nn.BCEWithLogitsLoss()
+
+    for epoch in range(args.epochs):
+        model.train()
+        running = 0.0
+        for imgs, meta in train_loader:
+            imgs = imgs.to(device)
+            y = meta["label"].unsqueeze(1).to(device)
+            logits = model(imgs)
+            loss = loss_fn(logits, y)
+            opt.zero_grad(); loss.backward(); opt.step()
+            running += loss.item() * imgs.size(0)
+        print(f"epoch {epoch} train loss {(running/len(train_loader.dataset)):.4f}")
+
+    # ----- validation AUROC -----
+    model.eval()
+    ys, ps = [], []
+    with torch.no_grad():
+        for imgs, meta in val_loader:
+            imgs = imgs.to(device)
+            logits = model(imgs).cpu()
+            ps.append(torch.sigmoid(logits))
+            ys.append(meta["label"].unsqueeze(1))
+    y_true = torch.cat(ys).numpy().ravel()
+    y_prob = torch.cat(ps).numpy().ravel()
+    print("val AUROC:", roc_auc_score(y_true, y_prob))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -43,3 +43,4 @@ from .splitter import split_by_patient, split_by_sample, split_by_visit
 from .tuab import TUABDataset
 from .tuev import TUEVDataset
 from .utils import collate_fn_dict, collate_fn_dict_with_padding, get_dataloader
+from .mimic_cxr import MIMICCXRDataset

--- a/pyhealth/datasets/mimic_cxr.py
+++ b/pyhealth/datasets/mimic_cxr.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+from typing import Tuple, Dict, Any
+
+import pandas as pd
+import torch
+from torchvision import transforms
+from PIL import Image
+
+from pyhealth.datasets import BaseDataset
+
+class MIMICCXRDataset(BaseDataset):
+    """MIMIC‑CXR image dataset (No‑Finding, Pneumothorax, Fracture, …).
+
+    Expected directory layout::
+
+        root/
+            images/              # jpg or png
+                <studydir>/<img>.jpg
+            metadata.csv         # columns: path,label,sex,ethnicity,age,split
+
+    Parameters
+    ----------
+    root: str or Path
+        Path containing *images/* and *metadata.csv*.
+    task: str {"No Finding", "Pneumothorax", "Fracture"}
+        Target column in metadata.
+    transform: torchvision.transforms
+        Optional image transforms.
+    split: str {"train","val","test"}
+        Loads only rows where metadata["split"] == split.
+    """
+    def __init__(
+        self,
+        root: str | Path,
+        task: str = "No Finding",
+        split: str = "train",
+        transform: transforms.Compose | None = None,
+    ) -> None:
+        super().__init__(root)
+        self.root = Path(root)
+        self.task = task
+        self.split = split
+        self.transform = transform or transforms.Compose([
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                                 std=[0.229, 0.224, 0.225]),
+        ])
+
+        # load metadata
+        meta_path = self.root / "metadata.csv"
+        if not meta_path.exists():
+            raise FileNotFoundError(meta_path)
+        df = pd.read_csv(meta_path)
+        self.df = df[df["split"] == split].reset_index(drop=True)
+
+    def __len__(self) -> int:
+        return len(self.df)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, Dict[str, Any]]:
+        row = self.df.iloc[idx]
+        img_path = self.root / "images" / row["path"]
+        img = Image.open(img_path).convert("RGB")
+        img = self.transform(img)
+
+        label = torch.tensor(row[self.task], dtype=torch.float32)
+        sample = {
+            "path": row["path"],
+            "label": label,
+            "sex": row["sex"],
+            "ethnicity": row["ethnicity"],
+            "age": row["age"],
+        }
+        return img, sample
+
+    @property
+    def num_classes(self) -> int:  # required by some PyHealth models
+        return 1


### PR DESCRIPTION
Authors: George McAskill
Netids: georgem6
Paper: *Improving the Fairness of Chest X‑ray Classifiers* (CHIL 2022)  
Paper Link: https://arxiv.org/abs/2203.12609  

---

## Description

This PR adds a **new dataset class** named **`MIMICCXRDataset`**, wrapping the public MIMIC‑CXR v2.0.0 image corpus used in the paper above.

Added files / changes:

| File | Purpose |
|------|---------|
| `pyhealth/datasets/mimic_cxr.py` | Implements `MIMICCXRDataset` (inherits `BaseDataset`). |
| `examples/mimic_cxr_no_finding.py` | End‑to‑end example: fine‑tune DenseNet‑121 on the *No Finding* label and print AUROC. |

Unit‑style sanity tests (`pytest -q`) load 4 tiny mock images stored under `tests/test_data/mimic_cxr/` so CI does not need the full 400 GB dataset.

---

## Usage

```bash
# generate (or download) metadata.csv first — see README
from pyhealth.datasets import MIMICCXRDataset
ds = MIMICCXRDataset(root="~/data/mimic_cxr", task="No Finding", split="train")
print(len(ds))          # → ~230 k training images
img, meta = ds[0]       # 3×224×224 tensor + dict(label, sex, ethnicity, age)