### PR TITLE
Uncertainty awareness zero shot transformer implementation 

### DIFF
--- a/examples/uncertainty_aware_transformer.ipynb
+++ b/examples/uncertainty_aware_transformer.ipynb
@@ -1,0 +1,430 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4055c874-fd3e-46a3-a333-705c1bf4e6d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.chdir(\"/workspace/PyHealth\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f7a10243-04b7-4d68-afef-cad27ad6b6f3",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# !pip install -r requirements.txt\n",
+    "# !pip install tqdm pydantic typing_extensions>=4.5.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42668440-b728-4d02-b862-fe2c7b239991",
+   "metadata": {},
+   "source": [
+    "## This script loads in the medical transcription dataset, defines the prompt template for labeling, initializes uncertainty aware, and runs batch predications"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12e17d3f-4b10-4c55-8c46-2fc179f26c95",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No config path provided, using default config\n",
+      "Initializing medical_transcriptions dataset from . (dev mode: False)\n",
+      "Scanning table: mtsamples from /workspace/PyHealth/mtsamples.csv\n",
+      "Setting task MedicalTranscriptionsClassification for medical_transcriptions base dataset...\n",
+      "Collecting global event dataframe...\n",
+      "Collected dataframe with shape: (4999, 8)\n",
+      "Generating samples with 8 worker(s)...\n",
+      "Generating samples for MedicalTranscriptionsClassification\n",
+      "Label medical_specialty vocab: {' Allergy / Immunology': 0, ' Autopsy': 1, ' Bariatrics': 2, ' Cardiovascular / Pulmonary': 3, ' Chiropractic': 4, ' Consult - History and Phy.': 5, ' Cosmetic / Plastic Surgery': 6, ' Dentistry': 7, ' Dermatology': 8, ' Diets and Nutritions': 9, ' Discharge Summary': 10, ' ENT - Otolaryngology': 11, ' Emergency Room Reports': 12, ' Endocrinology': 13, ' Gastroenterology': 14, ' General Medicine': 15, ' Hematology - Oncology': 16, ' Hospice - Palliative Care': 17, ' IME-QME-Work Comp etc.': 18, ' Lab Medicine - Pathology': 19, ' Letters': 20, ' Nephrology': 21, ' Neurology': 22, ' Neurosurgery': 23, ' Obstetrics / Gynecology': 24, ' Office Notes': 25, ' Ophthalmology': 26, ' Orthopedic': 27, ' Pain Management': 28, ' Pediatrics - Neonatal': 29, ' Physical Medicine - Rehab': 30, ' Podiatry': 31, ' Psychiatry / Psychology': 32, ' Radiology': 33, ' Rheumatology': 34, ' SOAP / Chart / Progress Notes': 35, ' Sleep Medicine': 36, ' Speech - Language': 37, ' Surgery': 38, ' Urology': 39}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing samples: 100%|██████████| 4966/4966 [00:00<00:00, 117494.93it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 4966 samples for task MedicalTranscriptionsClassification\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Sliding Window Attention is enabled but not implemented for `eager`; unexpected results may be encountered.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eae44ab618384af1bed9e76dbcdf2fc2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Zero-shot generate:  49%|████▉     | 49/100 [02:35<02:41,  3.17s/it]"
+     ]
+    }
+   ],
+   "source": [
+    "from pyhealth.datasets import MedicalTranscriptionsDataset\n",
+    "from pyhealth.models.uncertainty_aware_transformer import UncertaintyAwareZeroShotClassifier\n",
+    "\n",
+    "ds = MedicalTranscriptionsDataset(root=\".\")\n",
+    "ds = ds.set_task()               # any classification task works\n",
+    "\n",
+    "prompt = (\n",
+    "            \"System: You are a medical text classifier.\\n\"\n",
+    "            \"User: Classify the following clinical note into **one** most likely matching label \"\n",
+    "            \"from the list below and reply with only that label and nothing else.\\n\\n\"\n",
+    "            \"Possible labels:\\n{labels}\\n\\n\"\n",
+    "            \"Clinical note:\\n{text}\\n\\n\"\n",
+    "            \"Answer:\"\n",
+    "        )\n",
+    "\n",
+    "uazs = UncertaintyAwareZeroShotClassifier(ds, model_name=\"Qwen/Qwen2.5-3B-Instruct\", batch_size=16, cache_dir = \"./.hf_cache\", prompt_template = prompt)\n",
+    "\n",
+    "uazs.predict_dataset(max_batches=100)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bdcc644-dba9-487f-8735-697c5889fba8",
+   "metadata": {},
+   "source": [
+    "## This retrieves model prediction and computes intial accuracy "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9e4e4916-3d54-4084-b17d-a95b1476406c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial Accuracy: 0.2150)\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = uazs.results\n",
+    "results_acc = sum(x[\"prediction\"] == x[\"gt\"] for x in results) / len(results)\n",
+    "\n",
+    "print(f\"Initial Accuracy: {results_acc:.4f})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85eab145-50f7-4527-acd8-eb648722abe9",
+   "metadata": {},
+   "source": [
+    "## This section selects top 10% most uncertain predictions, computes accuracy on uncertain ones and remaining ones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1c48149d-c8e5-460a-8a66-4aae98e05d15",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top-k Uncertain Accuracy: 0.1938\n",
+      "Remaining Accuracy: 0.2174\n"
+     ]
+    }
+   ],
+   "source": [
+    "frac = .1\n",
+    "top_samples, remaining_samples = uazs.get_uncertain(k=frac) # % most uncertain\n",
+    "\n",
+    "# Accuracy for top uncertain samples\n",
+    "top_acc = sum(x[\"prediction\"] == x[\"gt\"] for x in top_samples) / len(top_samples)\n",
+    "\n",
+    "# Accuracy for remaining samples\n",
+    "rest_acc = sum(x[\"prediction\"] == x[\"gt\"] for x in remaining_samples) / len(remaining_samples)\n",
+    "\n",
+    "print(f\"Top-k Uncertain Accuracy: {top_acc:.4f}\")\n",
+    "print(f\"Remaining Accuracy: {rest_acc:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e03cbb4a-bf38-4e5e-aba4-4c3d19fa1982",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "random_dataset_subset, random_rest, sm_idx, bg_idx = uazs.get_random_datasets(k=frac) # randomly sampled for control\n",
+    "uncertain_dataset, uncertain_rest = uazs.get_uncertain_datasets(k=frac) # % most uncertain"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14e6f530-1b20-46fd-b429-9c6f0b1ebe39",
+   "metadata": {},
+   "source": [
+    "# Control:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f700700-f769-48e5-b6c2-952a66dd93a3",
+   "metadata": {},
+   "source": [
+    "## Initialize new uncertainty aware classifier on random control subset, calculate accuracy on cheaper and more expensive model, get the blended accuracy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ac99bfad-3ebf-4884-81a2-4055d0b7718f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "49b51f5432414499a3aa05ad45abc64c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Zero-shot generate: 100%|██████████| 40/40 [00:41<00:00,  1.05s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "uazs_random = UncertaintyAwareZeroShotClassifier(random_dataset_subset, model_name=\"Qwen/Qwen2.5-7B-Instruct\", batch_size=4, cache_dir = \"./.hf_cache\", prompt_template = prompt)\n",
+    "\n",
+    "uazs_random.predict_dataset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "217d6b70-46b6-4077-b9e2-7e848b6ee0db",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "eb0d42ef-168e-426d-8e42-f5b9bb17cb68",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Random Subset Expensive Model Accuracy: 0.3063\n",
+      "Remainder Cheap Model Accuracy: 0.2104\n"
+     ]
+    }
+   ],
+   "source": [
+    "results_random = uazs_random.results\n",
+    "\n",
+    "results_acc_random = sum(x[\"prediction\"] == x[\"gt\"] for x in results_random) / len(results_random)\n",
+    "rest_acc_random  = sum(r[\"prediction\"] == r[\"gt\"] for r in bg_idx) / len(bg_idx)\n",
+    "\n",
+    "print(f\"Random Subset Expensive Model Accuracy: {results_acc_random:.4f}\")\n",
+    "print(f\"Remainder Cheap Model Accuracy: {rest_acc_random:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e8db2c64-8c89-48e6-b836-81bc73f25a66",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Blended accuracy: 0.2200\n"
+     ]
+    }
+   ],
+   "source": [
+    "subset_idx = {r[\"index\"] for r in uazs_random.results}\n",
+    "\n",
+    "correct_big   = sum(r[\"prediction\"] == r[\"gt\"] for r in uazs_random.results)\n",
+    "correct_rest  = sum(r[\"prediction\"] == r[\"gt\"] for r in bg_idx)\n",
+    "\n",
+    "blended_acc = (correct_big + correct_rest) / len(uazs.results)\n",
+    "print(f\"Blended accuracy: {blended_acc:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6fe7fb7-8de9-4dfa-9fa3-b9a68bfffcfa",
+   "metadata": {},
+   "source": [
+    "# Uncertainty Aware:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b340f506-df45-4c0f-baf0-3bee331a72db",
+   "metadata": {},
+   "source": [
+    "## Initialize new uncertainty aware classifier on uncertain dateset, runs cheaper and more expensive model, get blended accuracy  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c6420909-94f0-4cae-89e0-b35051361c90",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "84406a0282394a94850634f756e9017f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Zero-shot generate: 100%|██████████| 20/20 [00:43<00:00,  2.19s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "uazs_big = UncertaintyAwareZeroShotClassifier(uncertain_dataset, model_name=\"Qwen/Qwen2.5-7B-Instruct\", batch_size=8, cache_dir = \"./.hf_cache\", prompt_template = prompt)\n",
+    "\n",
+    "uazs_big.predict_dataset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f8c36bfb-ad09-4f6d-87cc-d1fd2bbafc2c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original Model Accuracy on Originally Uncertain Samples: 0.1938\n",
+      "Expensive Model Accuracy on Originally Uncertain Samples: 0.3187\n"
+     ]
+    }
+   ],
+   "source": [
+    "results_big = uazs_big.results\n",
+    "\n",
+    "results_acc_big = sum(x[\"prediction\"] == x[\"gt\"] for x in results_big) / len(results_big)\n",
+    "\n",
+    "print(f\"Original Model Accuracy on Originally Uncertain Samples: {top_acc:.4f}\")\n",
+    "print(f\"Expensive Model Accuracy on Originally Uncertain Samples: {results_acc_big:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "87117f9c-6192-4fd7-a2f6-5ce499ca169a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Blended Uncertainty Aware Accuracy: 0.2275)\n"
+     ]
+    }
+   ],
+   "source": [
+    "blended_acc = (results_acc_big * len(results_big) + rest_acc * len(remaining_samples)) / (len(results_big) + len(remaining_samples))\n",
+    "print(f\"Blended Uncertainty Aware Accuracy: {blended_acc:.4f})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a82b53e-e806-4d65-95b6-490750a598b3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/uncertainty_aware_transformer.ipynb
+++ b/examples/uncertainty_aware_transformer.ipynb
@@ -210,7 +210,7 @@
    "id": "7f700700-f769-48e5-b6c2-952a66dd93a3",
    "metadata": {},
    "source": [
-    "## Initialize new uncertainty aware classifier on random control subset, calculate accuracy on cheaper and more expensive model, get the blended accuracy"
+    "## Initialize new uncertainty aware classifier on random control subset, calculate accuracy more expensive model, get the blended accuracy"
    ]
   },
   {
@@ -246,14 +246,6 @@
     "\n",
     "uazs_random.predict_dataset()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "217d6b70-46b6-4077-b9e2-7e848b6ee0db",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/pyhealth/models/uncertainty_aware_transformer.py
+++ b/pyhealth/models/uncertainty_aware_transformer.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import random, re, string
+from copy import deepcopy
+from itertools import islice
+from typing import Dict, List, Tuple, Union, Optional
+import torch
+import torch, torch.nn.functional as F
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from pyhealth.datasets import SampleDataset, get_dataloader
+from pyhealth.models.base_model import BaseModel
+
+from copy import deepcopy
+
+
+class FrozenSampleDataset(SampleDataset):
+    """Clone of SampleDataset that reuses existing processors/vocabs."""
+
+    def __init__(
+        self,
+        samples,
+        input_schema,
+        output_schema,
+        input_processors,
+        output_processors,
+        dataset_name: str = "",
+        task_name: str = "",
+    ):
+        # shallow attributes
+        self.samples, self.input_schema, self.output_schema = samples, input_schema, output_schema
+        self.input_processors, self.output_processors = input_processors, output_processors
+        self.dataset_name, self.task_name = dataset_name, task_name
+
+        # quick lookup tables (optional)
+        self.patient_to_index, self.record_to_index = {}, {}
+        for i, s in enumerate(samples):
+            if (pid := s.get("patient_id")) is not None:
+                self.patient_to_index.setdefault(pid, []).append(i)
+            if (rid := s.get("record_id", s.get("visit_id"))) is not None:
+                self.record_to_index.setdefault(rid, []).append(i)
+
+
+class UncertaintyAwareZeroShotClassifier(BaseModel):
+    """Zero-shot text classifier with entropy-based uncertainty sampling."""
+
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        model_name: str = "johnsnowlabs/JSL-MedLlama-3-8B-v2.0",
+        prompt_template: str | None = None,
+        batch_size: int = 2,
+        similarity_threshold: float = 0.0,
+        cache_dir: str | None = None,
+        my_device: Optional[str] = None,
+    ):
+        super().__init__(dataset)
+
+        # label vocab
+        proc = next(iter(dataset.output_processors))
+        self.output_processor = dataset.output_processors[proc]
+        self.id2label = {i: n.strip() for n, i in self.output_processor.label_vocab.items()}
+        self.label2id = {v: k for k, v in self.id2label.items()}
+        self.labels = [self.id2label[i] for i in range(len(self.id2label))]
+
+        # settings
+        self.batch_size = batch_size
+        self.sim_thresh = similarity_threshold
+        self.my_device = my_device or ("cuda" if torch.cuda.is_available() else "cpu")
+
+        # model + tokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            cache_dir=cache_dir,
+            torch_dtype=torch.bfloat16 if self.my_device == "cuda" else torch.float32,
+        ).to(self.my_device).eval()
+        if self.tokenizer.pad_token_id is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.model.config.pad_token_id = self.model.generation_config.pad_token_id = self.tokenizer.pad_token_id
+
+        self.prompt_template = prompt_template
+
+        self.results: List[Dict[str, Union[int, float, str]]] = []
+
+    @staticmethod
+    def _norm(t: str) -> str:
+        return re.sub(f"[{re.escape(string.punctuation)}]", "", t.lower()).strip()
+
+    def _fuzzy_match(self, raw: str) -> str | None:
+        raw_n = self._norm(raw)
+        best, best_len = None, 0
+        for lab in self.labels:
+            lab_n = self._norm(lab)
+            for i in range(len(raw_n)):
+                if (l := len(sub := raw_n[i : i + best_len + 1])) <= best_len:
+                    continue
+                if sub and sub in lab_n:
+                    best, best_len = lab, l
+        return best
+
+    @torch.inference_mode()
+    def _gen_answer(self, note: str) -> Tuple[str, float]:
+        prompt = self.prompt_template.format(labels=", ".join(self.labels), text=note.strip())
+        inp = self.tokenizer(prompt, return_tensors="pt").to(self.my_device)
+        gen = self.model.generate(
+            **inp,
+            min_new_tokens=2,
+            max_new_tokens=6,
+            output_scores=True,
+            do_sample=True,
+            return_dict_in_generate=True,
+            eos_token_id=self.tokenizer.eos_token_id,
+            pad_token_id=self.tokenizer.pad_token_id,
+        )
+        ans_tok = gen.sequences[0][inp.input_ids.size(-1) :]
+        raw = self.tokenizer.decode(ans_tok, skip_special_tokens=True).rstrip(".").strip()
+
+        max_ent = max(
+            float(-(F.softmax(s[0], dim=-1) * F.log_softmax(s[0], dim=-1)).sum())
+            for s in gen.scores
+        ) if gen.scores else float("nan")
+        
+        return raw, max_ent
+
+    def predict_dataset(
+        self,
+        max_batches: int | None = None,
+        text_key: str = "transcription",
+        label_key: str = "medical_specialty",
+    ):
+        """Run zero-shot prediction on the dataset and cache results."""
+        self.results.clear()
+        loader = get_dataloader(self.dataset, batch_size=self.batch_size, shuffle=True)
+        total = len(loader) if max_batches in (None, -1) else max_batches
+        for b, batch in enumerate(
+            tqdm(islice(loader, max_batches), total=total, desc="Zero-shot generate")
+        ):
+            for i, note in enumerate(batch[text_key]):
+                raw, ent = self._gen_answer(note)
+                pred = self.label2id.get(self._fuzzy_match(raw), -1)
+                self.results.append(
+                    dict(
+                        index=b * self.batch_size + i,
+                        prediction=pred,
+                        gt=int(batch[label_key][i]),
+                        entropy=ent,
+                        raw_answer=raw,
+                    )
+                )
+
+    def _split(self, k: int | float) -> Tuple[List, List]:
+        if not self.results:
+            raise RuntimeError("Run predict_dataset() first")
+        # sort *descending* so highest entropy (most uncertain) comes first
+        ordered = sorted(self.results, key=lambda r: r["entropy"], reverse=True)
+        if isinstance(k, float):
+            if not 0 < k <= 1:
+                raise ValueError("k must be in (0,1]")
+            k = int(k * len(ordered))
+        return ordered[:k], ordered[k:]
+
+    def get_uncertain(self, k: int | float):
+        """Return (most-uncertain, remaining) result dicts."""
+        return self._split(k)
+
+    # freeze helper to help copy PyHealth datasets correctly
+    def _freeze(self, idx) -> FrozenSampleDataset:
+        s = [deepcopy(self.dataset.samples[i]) for i in idx]
+        return FrozenSampleDataset(
+            s,
+            self.dataset.input_schema,
+            self.dataset.output_schema,
+            self.dataset.input_processors,
+            self.dataset.output_processors,
+            self.dataset.dataset_name,
+            self.dataset.task_name,
+        )
+
+    def get_uncertain_datasets(self, k: int | float):
+        """Return (uncertain_ds, certain_ds) where uncertain_ds contains the k most-uncertain samples."""
+        u, c = self.get_uncertain(k)
+        u_idx = {r["index"] for r in u}
+        c_idx = [i for i in range(len(self.dataset.samples)) if i not in u_idx]
+        return self._freeze(u_idx), self._freeze(c_idx)
+
+    def get_random(self, k: int | float):
+        """Return (random_subset, remaining) result dicts, randomly selected from processed results."""
+        if not self.results:
+            raise RuntimeError("Run predict_dataset() first so there is a processed subset to sample from.")
+        
+        results_copy = self.results.copy()
+        random.shuffle(results_copy)
+        
+        if isinstance(k, float):
+            if not 0 < k <= 1:
+                raise ValueError("k must be in (0,1] for float input.")
+            k = int(k * len(results_copy))
+    
+        return results_copy[:k], results_copy[k:]
+
+    def get_random_datasets(self, k: int | float):
+        """Randomly split the processed results using `get_random`"""
+        if not self.results:
+            raise RuntimeError("Run predict_dataset() first so there is a processed subset to sample from.")
+    
+        selected, remaining = self.get_random(k)
+        selected_idx = {r["index"] for r in selected}
+        remaining_idx = {r["index"] for r in remaining}
+    
+        return (
+            self._freeze(selected_idx),
+            self._freeze(remaining_idx),
+            selected,
+            remaining,
+        )


### PR DESCRIPTION
This PR adds to PyHealth a zero shot text classification with built in uncertainty estimation. Drawing from methods by “Uncertainty-Aware Text-to-Program for Question Answering on Structured Electronic Health Records” ;  I leverage qwen to take free-form medical text and put it into discrete labels while qualifying how confident the model is in its predications. 

The portion of the paper that I am reproducing is the uncertainty awareness applied to a transformer model. Uncertainty can be estimated by taking entropy over token probabilities - the paper recommends using the maximum of the entropy across the generation. Uncertainty awareness is useful in practical situations - for example, in the paper they gave more uncertain questions more tries. 

The example in this PR implements a simplified version of the uncertainty awareness approach of the paper and applies it to the PyHealth medical transcription dataset/classification problem. This example uses max entropy from a single small sequence to sequence transformer model (similar to approach in the paper) to pick apart high uncertainty and low uncertainty questions. Instead of giving the uncertain questions more tries from the same model like in the paper, we can instead give the uncertain questions to a larger model.

Uncertainty awareness is thus useful - it could help control costs by only using large models for harder problems.

**Changes**  
- Added uncertainty_aware_transformer.py 
- Added uncertainty_aware_transformer.ipynb

**References**  
- Paper: “Uncertainty-Aware Text-to-Program for Question Answering on Structured Electronic Health Records”