### PR TITLE
feat(metrics): add Program Inconsistency Score (PIS) metric

### DIFF
--- a/pyhealth/metrics/__init__.py
+++ b/pyhealth/metrics/__init__.py
@@ -2,6 +2,7 @@ from .binary import binary_metrics_fn
 from .drug_recommendation import ddi_rate_score
 from .multiclass import multiclass_metrics_fn
 from .multilabel import multilabel_metrics_fn
+from .text_metrics import calculate_program_inconsistency_score
 
 # from .fairness import fairness_metrics_fn
 from .ranking import ranking_metrics_fn

--- a/pyhealth/metrics/text_metrics.py
+++ b/pyhealth/metrics/text_metrics.py
@@ -1,0 +1,57 @@
+# Author: Jingtong Xing (jxing11)
+# Email: jxing11@illinois.edu
+# Paper: Based on concepts learned from reproducing Uncertainty-Aware Text-to-Program for QA on Structured EHR (Kim et al., CHIL 2022)
+# Link: https://arxiv.org/abs/2203.06918
+# Description: Implements Program Inconsistency Score (PIS) metric using Levenshtein distance.
+
+import Levenshtein
+from typing import List
+import numpy as np
+
+def calculate_program_inconsistency_score(program_list: List[str]) -> float:
+    """
+    Calculates the Program Inconsistency Score (PIS) for a list of strings.
+
+    PIS is defined as the average pairwise normalized Levenshtein distance
+    between all unique pairs of items in the list. A higher score indicates
+    more inconsistency (diversity) among the items. This can be useful for
+    evaluating the diversity of outputs from generative models, for example.
+
+    The Levenshtein distance is normalized by the length of the longer string
+    in each pair, yielding a score between 0 (identical) and 1 (completely different)
+    for each pair. The PIS is the average of these normalized distances.
+
+    Args:
+        program_list: A list of strings.
+
+    Returns:
+        A float representing the PIS, ranging from 0.0 (all items identical
+        or fewer than two items) to 1.0 (all items maximally different, on average).
+    """
+    if not program_list or len(program_list) < 2:
+        return 0.0
+
+    total_normalized_distance = 0.0
+    num_comparisons = 0
+
+    for i in range(len(program_list)):
+        for j in range(i + 1, len(program_list)):
+            prog1 = program_list[i]
+            prog2 = program_list[j]
+
+            # Levenshtein distance
+            dist = Levenshtein.distance(prog1, prog2)
+
+            # Normalized by length of longer string
+            max_len = max(len(prog1), len(prog2))
+            # handle case where both are empty strings
+            if max_len == 0:  
+                normalized_dist = 0.0
+            else:
+                normalized_dist = dist / float(max_len)
+
+            total_normalized_distance += normalized_dist
+            num_comparisons += 1
+
+    # to avoid division by zero
+    return total_normalized_distance / float(num_comparisons) if num_comparisons > 0 else 0.0 

--- a/pyhealth/unittests/test_metrics/test_text_metrics.py
+++ b/pyhealth/unittests/test_metrics/test_text_metrics.py
@@ -1,0 +1,62 @@
+import unittest
+import numpy as np
+
+from pyhealth.metrics import calculate_program_inconsistency_score
+
+class TestTextMetrics(unittest.TestCase):
+
+    def test_calculate_program_inconsistency_score(self):
+        # Test case 1: Identical programs
+        programs_identical = [
+            "max_litset(gen_litset(table_name='labevents', literal_column='valuenum'))",
+            "max_litset(gen_litset(table_name='labevents', literal_column='valuenum'))"
+        ]
+        pis_identical = calculate_program_inconsistency_score(programs_identical)
+        self.assertEqual(pis_identical, 0.0, "PIS should be 0 for identical programs")
+
+        # Test case 2: Varied programs
+        programs_varied = [
+            "count_entset(gen_entset_equal(table_name='patients', column_name='gender', value='F'))",
+            "count_entset(gen_entset_equal(table_name='patients', column_name='gender', value='M'))",
+            "count_entset(gen_entset_all(table_name='admissions'))"
+        ]
+        pis_varied = calculate_program_inconsistency_score(programs_varied)
+        self.assertGreater(pis_varied, 0.0, "PIS should be > 0 for varied programs")
+
+        # Test case 3: Very different programs
+        programs_different = [
+            "filter_entset_comparison(source_entset_df=A, attribute_col='age', comparison_operator='>', comparison_value=65)",
+            "gen_entset_down(source_entset_df=B, target_table='diagnoses', desired_target_entity_col='icd_code')",
+            "min_litset(C)"
+        ]
+        pis_different = calculate_program_inconsistency_score(programs_different)
+        self.assertGreater(pis_different, pis_varied, "PIS should be higher for more different programs")
+
+        # Test case 4: Single program
+        program_single = [
+            "count_entset(gen_entset_equal(table_name='patients', column_name='gender', value='F'))"
+        ]
+        pis_single = calculate_program_inconsistency_score(program_single)
+        self.assertEqual(pis_single, 0.0, "PIS should be 0 for a single program")
+
+        # Test case 5: Empty list
+        programs_empty = []
+        pis_empty = calculate_program_inconsistency_score(programs_empty)
+        self.assertEqual(pis_empty, 0.0, "PIS should be 0 for an empty list")
+
+        # Test case 6: Programs including an empty string
+        programs_with_empty_str = [
+            "count_entset(gen_entset_equal(table_name='patients', column_name='gender', value='F'))",
+            "",
+            "count_entset(gen_entset_all(table_name='admissions'))"
+        ]
+        pis_with_empty_str = calculate_program_inconsistency_score(programs_with_empty_str)
+        self.assertGreater(pis_with_empty_str, 0.0, "PIS should be > 0 even with empty strings")
+
+        # Test case 7: Two empty strings
+        programs_two_empty = ["", ""]
+        pis_two_empty = calculate_program_inconsistency_score(programs_two_empty)
+        self.assertEqual(pis_two_empty, 0.0, "PIS should be 0 for two empty strings")
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ numpy
 tqdm
 polars
 transformers
+python-Levenshtein>=0.12.2


### PR DESCRIPTION
## Description

This PR introduces a new metric function, `calculate_program_inconsistency_score`, to `pyhealth.metrics`.

This metric calculates the Program Inconsistency Score (PIS), defined as the average pairwise normalized Levenshtein distance between strings in a list. It provides a quantitative measure of the diversity or inconsistency among a set of generated text sequences (e.g., program strings, sentences).

### Motivation

This metric was implemented as part of a course project (CS598 Deep Learning for Healthcare) involving the reproduction of concepts from the paper "Uncertainty-Aware Text-to-Program for Question Answering on Structured Electronic Health Records" (Kim et al., CHIL 2022) [1]. In that context, it was used to assess the diversity of program candidates generated by a T5 model using sampling, serving as an indicator of model uncertainty. It can be generally useful for evaluating generative models where assessing output diversity is relevant.

## Changes

- Added function `calculate_program_inconsistency_score` to a new file `pyhealth/metrics/text_metrics.py`.
- Updated `pyhealth/metrics/__init__.py` to make the function directly importable.
- Added unit tests in `pyhealth/unittests/test_metrics/test_text_metrics.py`.

### Dependencies

- This metric requires the `python-Levenshtein` package. This has been added to `requirements.txt`.

### Testing

- All unit tests, including the new `PyHealth/pyhealth/unittests/test_metrics/test_text_metrics.py` tests for this metric, pass locally.

**References:**

- [1] Kim, D., Bae, S., Kim, S., & Choi, E. (2022). Uncertainty-Aware Text-to-Program for Question Answering on Structured Electronic Health Records. In *Proceedings of the Conference on Health, Inference, and Learning (CHIL 2022)*. arXiv:2203.06918 \[cs.CL]. Retrieved from [https://arxiv.org/abs/2203.06918](https://arxiv.org/abs/2203.06918).

**Contributor:**

- Jingtong Xing (jxing11)
- jxing11@illinois.edu