### PR TITLE
Adding MURA dataset

### DIFF
--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -34,6 +34,7 @@ from .isruc import ISRUCDataset
 from .medical_transcriptions import MedicalTranscriptionsDataset
 from .mimic3 import MIMIC3Dataset
 from .mimic4 import MIMIC4CXRDataset, MIMIC4Dataset, MIMIC4EHRDataset, MIMIC4NoteDataset
+from .mura import MURADataset
 from .mimicextract import MIMICExtractDataset
 from .omop import OMOPDataset
 from .sample_dataset import SampleDataset

--- a/pyhealth/datasets/configs/mura.yaml
+++ b/pyhealth/datasets/configs/mura.yaml
@@ -1,0 +1,10 @@
+version: "1.0"
+tables:
+  mura:
+    file_path: "mura-metadata-pyhealth.csv"
+    patient_id: "patient_id"
+    visit_id: "visit_id"
+    timestamp: null
+    attributes:
+      - "path"
+      - "label"

--- a/pyhealth/datasets/mura.py
+++ b/pyhealth/datasets/mura.py
@@ -1,0 +1,107 @@
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+# from ..tasks import MURAClassification  # You need to implement this
+from .base_dataset import BaseDataset
+
+logger = logging.getLogger(__name__)
+
+
+class MURADataset(BaseDataset):
+    """MURA Dataset for musculoskeletal radiographs.
+
+    Dataset is available at:
+    https://stanfordmlgroup.github.io/competitions/mura/
+
+    The dataset contains 7 anatomical regions:
+        - ELBOW, FINGER, FOREARM, HAND, HUMERUS, SHOULDER, WRIST
+
+    Each study is labeled as either positive (abnormal, label=1) or negative (normal, label=0).
+
+    Args:
+        root: Root directory of the MURA dataset (should contain MURA-v1.1/...).
+        split: One of ["train", "valid", "all"].
+        dataset_name: Optional name of the dataset. Defaults to "mura".
+        config_path: Optional path to the configuration file. Defaults to "configs/mura.yaml".
+
+    Example:
+        >>> dataset = MURADataset(root="/path/to/MURA-v1.1", split="train")
+        >>> dataset.stats()
+        >>> samples = dataset.set_task()
+    """
+
+    def __init__(
+        self,
+        root: str,
+        dataset_name: Optional[str] = None,
+        config_path: Optional[str] = None,
+        dev : Optional[bool] = False
+    ) -> None:
+        # self.split = split
+        if config_path is None:
+            config_path = Path(__file__).parent / "configs" / "mura.yaml"
+
+        if not os.path.exists(os.path.join(root, "mura-metadata-pyhealth.csv")):
+            self.prepare_metadata(root)
+
+        super().__init__(
+            root=root,
+            tables=["mura"],
+            dataset_name=dataset_name or "mura",
+            config_path=config_path,
+            dev = dev
+        )
+
+        # Apply split filtering
+        # if self.split in ["train", "valid"]:
+        #     split_prefix = os.path.join(root, self.split)
+        #     self.tables["mura"].df = self.tables["mura"].df[
+        #         self.tables["mura"].df["path"].str.startswith(split_prefix)
+        #     ]
+        # elif self.split != "all":
+        #     raise ValueError("split must be one of ['train', 'valid', 'all']")
+
+    def prepare_metadata(self, root: str) -> None:
+        """Generate mura-metadata-pyhealth.csv from raw CSVs."""
+
+        def read_study_labels(file_path):
+            df = pd.read_csv(os.path.join(root, file_path), header=None)
+            df.columns = ["study_path", "label"]
+            return dict(zip(df.study_path.str.strip(), df.label))
+
+        def build_df(image_path_file, label_dict):
+            df = pd.read_csv(os.path.join(root, image_path_file), header=None)
+            df.columns = ["path"]
+            df["study_path"] = df["path"].apply(lambda x: os.path.dirname(x).strip() + '/')
+            df["label"] = df["study_path"].map(label_dict)
+            df = df.dropna()
+
+            df["patient_id"] = df["path"].apply(lambda x: x.split("/")[2])
+            df["visit_id"] = df["path"].apply(lambda x: x.split("/")[3])
+            df["path"] = df["path"].apply(lambda x: x.replace("MURA-v1.1/", "", 1))
+            df["path"] = df["path"].apply(lambda x: str(Path(root) / Path(x)))
+
+            return df[["path", "label", "patient_id", "visit_id"]]
+
+        train_labels = read_study_labels("train_labeled_studies.csv")
+        valid_labels = read_study_labels("valid_labeled_studies.csv")
+        train_df = build_df("train_image_paths.csv", train_labels)
+        valid_df = build_df("valid_image_paths.csv", valid_labels)
+
+        full_df = pd.concat([train_df, valid_df], ignore_index=True)
+
+        for path in full_df["path"]:
+            assert os.path.isfile(path), f"Missing file: {path}"
+
+        metadata_path = os.path.join(root, "mura-metadata-pyhealth.csv")
+        full_df.to_csv(metadata_path, index=False)
+        logger.info(f"Saved MURA metadata to {metadata_path}")
+
+    # @property
+    # def default_task(self) -> MURAClassification:
+    #     """Returns the default classification task."""
+    #     return MURAClassification()


### PR DESCRIPTION
# MURA Dataset Integration for PyHealth

**Author:** Haoan Wang  
**GitHub:** [@haoanw2](https://github.com/haoanw2)  

## 📖 Dataset Overview

**Source:** [Stanford ML Group – MURA](https://stanfordmlgroup.github.io/competitions/mura/)

MURA (Musculoskeletal Radiographs) is a large dataset of radiographic images collected from clinical cases at the Stanford Hospital between 2001 and 2012. It includes:

- **14,863 studies** from **12,173 patients**
- **40,561 images** across **7 anatomical regions**:  
  *Elbow, Finger, Forearm, Hand, Humerus, Shoulder, Wrist*
- Each study is manually labeled by board-certified radiologists as **normal (0)** or **abnormal (1)**.

## 💻 Usage Example

```python
from pyhealth.datasets import MURADataset

DATA_ROOT = r"D:\Downloads\muramskxrays\MURA-v1.1\MURA-v1.1"

# Load dataset and auto-generate metadata if needed
dataset = MURADataset(root=DATA_ROOT)

print(f"Number of patients: {len(dataset.unique_patient_ids)}")
print(dataset.stats())
```

## 📂 Files Required

Make sure the following CSVs are available in the root path (included in the original dataset download):

- `train_image_paths.csv`
- `train_labeled_studies.csv`
- `valid_image_paths.csv`
- `valid_labeled_studies.csv`

These should match the official MURA release format and point to the correct relative image paths under `MURA-v1.1/`.

## 📝 Notes

- `MURADataset` automatically parses the metadata and generates a `mura-metadata-pyhealth.csv` file for PyHealth compatibility.
- The static YAML config file `mura.yaml` must be placed in `pyhealth/datasets/configs/`.

## 📚 Citation

If you use the MURA dataset, please cite:

> Rajpurkar, Pranav, et al.  
> "**MURA: Large Dataset for Abnormality Detection in Musculoskeletal Radiographs.**"  
> arXiv preprint arXiv:1712.06957 (2017).  
> [https://arxiv.org/abs/1712.06957](https://arxiv.org/abs/1712.06957)
