### PR TITLE
fix readthedoc dependency error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -24,3 +24,4 @@ google-cloud-storage==2.6.0
 oauth2client==4.1.3
 Jinja2==3.1.4
 flask==2.2.5
+pydantic


### PR DESCRIPTION
The doc strings aren't updating properly due to the pydantic import that doesn't exist when running the readthedocs pipeline.