### PR TITLE
fix docs python version incompatibility

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,8 +1,0 @@
-# Read the Docs configuration file
-# Only change: use Python 3.10 instead of default
-
-version: 2
-
-build:
-  tools:
-    python: "3.10"

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 sphinx:
     configuration: docs/conf.py


### PR DESCRIPTION
This pull request updates the Python version used in the Read the Docs configuration to align with the project's current requirements. The changes ensure consistency across configuration files.

**Updates to Read the Docs configuration:**

* Removed the outdated `.readthedocs.yaml` file, which specified Python 3.10, as it is no longer needed.
* Updated the `readthedocs.yml` file to use Python 3.10 instead of Python 3.8 for the build environment.