### PR TITLE
fix doc requirements breaking from incompatibilities with numpy

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@ sphinxcontrib-httpdomain==1.8.0
 sphinx_copybutton
 sphinx_toggleprompt
 pandas-bokeh==0.5.5
-bokeh==3.0.1
+bokeh>=3.5.2
 gspread==5.6.2
 google-cloud-storage==2.6.0
 oauth2client==4.1.3


### PR DESCRIPTION
This pull request updates a dependency version in the `docs/requirements.txt` file to ensure compatibility with other packages.

Dependency update:

* Updated the `bokeh` library version requirement from `3.0.1` to `>=3.5.2` to allow for newer versions and maintain compatibility. (`[docs/requirements.txtL21-R21](diffhunk://#diff-2c9c11d26b09b8afde329980309d967121543a456e4592c76886a20b5cf56c90L21-R21)`)