### PR TITLE
fixed dependency errors in building autodocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -25,3 +25,6 @@ oauth2client==4.1.3
 Jinja2==3.1.4
 flask==2.2.5
 pydantic
+# Core scientific packages - compatible versions for Python 3.10
+numpy>=1.22.0,<2.4.0
+pandas>=2.0.0,<2.4.0


### PR DESCRIPTION
This pull request updates the `docs/requirements.txt` file to include specific versions of core scientific packages compatible with Python 3.10.

Dependency updates:

* Added `numpy` with version constraints `>=1.22.0,<2.4.0` to ensure compatibility with Python 3.10.
* Added `pandas` with version constraints `>=2.0.0,<2.4.0` to ensure compatibility with Python 3.10.