### PR TITLE
MIMIC3 Initialize Test Case for Tests/Core

### DIFF
--- a/tests/core/test_mimic3.py
+++ b/tests/core/test_mimic3.py
@@ -11,26 +11,18 @@ from pyhealth.datasets import MIMIC3Dataset
 class TestMIMIC3Demo(unittest.TestCase):
     """Test MIMIC3 dataset with demo data downloaded from PhysioNet."""
 
-    # Class-level variables for shared dataset
-    temp_dir = None
-    demo_dataset_path = None
-    dataset = None
+    def setUp(self):
+        """Download and set up demo dataset for each test."""
+        self.temp_dir = tempfile.mkdtemp()
+        self._download_demo_dataset()
+        self._load_dataset()
 
-    @classmethod
-    def setUpClass(cls):
-        """Download demo dataset once for all tests."""
-        cls.temp_dir = tempfile.mkdtemp()
-        cls._download_demo_dataset()
-        cls._load_dataset()
+    def tearDown(self):
+        """Clean up downloaded dataset after each test."""
+        if self.temp_dir and os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
 
-    @classmethod
-    def tearDownClass(cls):
-        """Clean up downloaded dataset after all tests."""
-        if cls.temp_dir and os.path.exists(cls.temp_dir):
-            shutil.rmtree(cls.temp_dir)
-
-    @classmethod
-    def _download_demo_dataset(cls):
+    def _download_demo_dataset(self):
         """Download MIMIC-III demo dataset using wget."""
         download_url = "https://physionet.org/files/mimiciii-demo/1.4/"
 
@@ -42,7 +34,7 @@ class TestMIMIC3Demo(unittest.TestCase):
             "-c",
             "-np",
             "--directory-prefix",
-            cls.temp_dir,
+            self.temp_dir,
             download_url,
         ]
 
@@ -55,19 +47,17 @@ class TestMIMIC3Demo(unittest.TestCase):
 
         # Find the downloaded dataset path
         physionet_dir = (
-            Path(cls.temp_dir) / "physionet.org" / "files" / "mimiciii-demo" / "1.4"
+            Path(self.temp_dir) / "physionet.org" / "files" / "mimiciii-demo" / "1.4"
         )
         if physionet_dir.exists():
-            cls.demo_dataset_path = str(physionet_dir)
+            self.demo_dataset_path = str(physionet_dir)
         else:
             raise unittest.SkipTest("Downloaded dataset not found in expected location")
 
-    @classmethod
-    def _load_dataset(cls):
-        """Load the dataset once for all tests."""
+    def _load_dataset(self):
+        """Load the dataset for testing."""
         tables = ["diagnoses_icd", "procedures_icd", "prescriptions", "noteevents"]
-
-        cls.dataset = MIMIC3Dataset(root=cls.demo_dataset_path, tables=tables)
+        self.dataset = MIMIC3Dataset(root=self.demo_dataset_path, tables=tables)
 
     def test_stats(self):
         """Test .stats() method execution."""

--- a/tests/core/test_mimic3.py
+++ b/tests/core/test_mimic3.py
@@ -1,0 +1,95 @@
+import unittest
+import tempfile
+import shutil
+import subprocess
+import os
+from pathlib import Path
+
+from pyhealth.datasets import MIMIC3Dataset
+
+
+class TestMIMIC3Demo(unittest.TestCase):
+    """Test MIMIC3 dataset with demo data downloaded from PhysioNet."""
+
+    # Class-level variables for shared dataset
+    temp_dir = None
+    demo_dataset_path = None
+    dataset = None
+
+    @classmethod
+    def setUpClass(cls):
+        """Download demo dataset once for all tests."""
+        cls.temp_dir = tempfile.mkdtemp()
+        cls._download_demo_dataset()
+        cls._load_dataset()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up downloaded dataset after all tests."""
+        if cls.temp_dir and os.path.exists(cls.temp_dir):
+            shutil.rmtree(cls.temp_dir)
+
+    @classmethod
+    def _download_demo_dataset(cls):
+        """Download MIMIC-III demo dataset using wget."""
+        download_url = "https://physionet.org/files/mimiciii-demo/1.4/"
+
+        # Use wget to download the demo dataset recursively
+        cmd = [
+            "wget",
+            "-r",
+            "-N",
+            "-c",
+            "-np",
+            "--directory-prefix",
+            cls.temp_dir,
+            download_url,
+        ]
+
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as e:
+            raise unittest.SkipTest(f"Failed to download MIMIC-III demo dataset: {e}")
+        except FileNotFoundError:
+            raise unittest.SkipTest("wget not available - skipping download test")
+
+        # Find the downloaded dataset path
+        physionet_dir = (
+            Path(cls.temp_dir) / "physionet.org" / "files" / "mimiciii-demo" / "1.4"
+        )
+        if physionet_dir.exists():
+            cls.demo_dataset_path = str(physionet_dir)
+        else:
+            raise unittest.SkipTest("Downloaded dataset not found in expected location")
+
+    @classmethod
+    def _load_dataset(cls):
+        """Load the dataset once for all tests."""
+        tables = ["diagnoses_icd", "procedures_icd", "prescriptions", "noteevents"]
+
+        cls.dataset = MIMIC3Dataset(root=cls.demo_dataset_path, tables=tables)
+
+    def test_stats(self):
+        """Test .stats() method execution."""
+        try:
+            self.dataset.stats()
+        except Exception as e:
+            self.fail(f"dataset.stats() failed: {e}")
+
+    def test_get_events(self):
+        """Test get_patient and get_events methods with patient 10006."""
+        # Test get_patient method
+        patient = self.dataset.get_patient("10006")
+        self.assertIsNotNone(patient, msg="Patient 10006 should exist in demo dataset")
+
+        # Test get_events method
+        events = patient.get_events()
+        self.assertIsNotNone(events, msg="get_events() should not return None")
+        self.assertIsInstance(events, list, msg="get_events() should return a list")
+        self.assertGreater(
+            len(events), 0, msg="get_events() should not return an empty list"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new test suite for the `MIMIC3Dataset` class, ensuring its functionality with demo data from PhysioNet. The tests focus on verifying dataset statistics, patient retrieval, and event extraction, while also handling dataset setup and cleanup efficiently.

### New test suite for `MIMIC3Dataset`:

* **Setup and cleanup for demo dataset**:
  - Added methods to download the MIMIC-III demo dataset using `wget`, load it into `MIMIC3Dataset`, and clean up temporary files after tests. These operations are encapsulated in `setUpClass` and `tearDownClass` for efficient resource management.

* **Testing dataset functionality**:
  - Implemented tests for the `.stats()` method to ensure it executes without errors.
  - Added tests for `get_patient` and `get_events` methods to validate patient retrieval and event extraction, including checks for non-empty and correctly typed results.