### PR TITLE
create interpret autodocs module

### DIFF
--- a/docs/api/interpret.rst
+++ b/docs/api/interpret.rst
@@ -1,0 +1,11 @@
+Interpret Module 
+
+PyHealth provides specialized tools for interpreting deep models post-hoc. 
+===============
+
+.. toctree::
+    :maxdepth: 3
+
+    interpret/pyhealth.interpret.methods.chefer
+    
+

--- a/docs/api/interpret/pyhealth.datasets.interpret.methods.chefer.rst
+++ b/docs/api/interpret/pyhealth.datasets.interpret.methods.chefer.rst
@@ -1,0 +1,17 @@
+pyhealth.interpret.methods.chefer
+===================================
+This method implements the Chefer et al. for interpreting transformer models in PyHealth.
+
+Paper is available at https://arxiv.org/abs/2012.09838.
+
+
+.. autoclass:: pyhealth.interpret.methods.chefer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+   
+
+   
+   
+   

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -319,7 +319,7 @@ GRASP                                 deep learning     ``pyhealth.models.GRASP`
    api/metrics
    api/medcode
    api/calib
-
+   api/interpret
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This pull request adds documentation for the new `interpret` module in PyHealth, which provides tools for interpreting deep models post-hoc. The changes include updates to the main documentation index and the addition of detailed documentation for the `pyhealth.interpret.methods.chefer` method.

### Updates to Documentation:

* [`docs/api/interpret.rst`](diffhunk://#diff-e9ada7cda77b2687e795798a02995511b89a1b50013a7a8d11752e80587676f8R1-R11): Added a new section for the `Interpret` module, introducing its purpose and linking to the `pyhealth.interpret.methods.chefer` documentation.

* [`docs/api/interpret/pyhealth.datasets.interpret.methods.chefer.rst`](diffhunk://#diff-8af3cf792363fa19d7465afc22670f37662a800f2efdb737f6c31f2880bdad49R1-R17): Added detailed documentation for the `pyhealth.interpret.methods.chefer` method, including a description of its purpose (interpreting transformer models), a reference to the associated research paper, and an autogenerated class reference.

### Changes to Index:

* [`docs/index.rst`](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L322-R322): Updated the main documentation index to include the new `api/interpret` section.