### PR TITLE
crucial doc updates

### DIFF
--- a/docs/api/interpret.rst
+++ b/docs/api/interpret.rst
@@ -1,0 +1,11 @@
+Interpretability Module
+===============
+
+We implement the following interpretability techniques below:
+
+Help always needed in this direction.
+    
+.. toctree::
+    :maxdepth: 3
+
+    interpret/pyhealth.interpret.methods.chefer

--- a/docs/api/interpret/pyhealth.interpret.methods.chefer.rst
+++ b/docs/api/interpret/pyhealth.interpret.methods.chefer.rst
@@ -1,0 +1,10 @@
+pyhealth.interpret.methods.chefer
+===================================
+
+
+Transformer interpretability module. 
+
+.. autoclass:: pyhealth.interpret.methods.chefer
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/models/pyhealth.models.SDOH.rst
+++ b/docs/api/models/pyhealth.models.SDOH.rst
@@ -1,4 +1,4 @@
-pyhealth.models.TransformersModel
+pyhealth.models.sdoh
 ===================================
 
 

--- a/docs/how_to_contribute.rst
+++ b/docs/how_to_contribute.rst
@@ -160,6 +160,8 @@ Every contribution must include two types of test cases:
 
 **Note**: You can use frontier LLMs to help generate basic test cases, which we consider valid as long as they are reasonable and comprehensive.
 
+All unit tests should be placed in the `tests/` directory following the existing structure, with 'tests/core/' for core functionality tests.
+
 Pull Request Guidelines
 =======================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -314,6 +314,7 @@ GRASP                                 deep learning     ``pyhealth.models.GRASP`
    api/datasets
    api/tasks
    api/models
+   api/interpret
    api/trainer
    api/tokenizer
    api/metrics


### PR DESCRIPTION
This pull request primarily adds documentation for a new interpretability module, updates existing documentation for model references, and clarifies testing guidelines. The most significant changes are the addition of interpretability documentation and improvements to the organization and clarity of docs.

### Documentation improvements

* Added a new section for the interpretability module in `docs/api/interpret.rst`, including a toctree entry for the `chefer` method.
* Created detailed API documentation for `pyhealth.interpret.methods.chefer`, describing the transformer interpretability module and its class members.
* Updated the main documentation index in `docs/index.rst` to include a link to the new interpretability API section.

### Model documentation updates

* Renamed and updated the documentation for the SDOH model from `pyhealth.models.TransformersModel` to `pyhealth.models.sdoh` in `docs/api/models/pyhealth.models.SDOH.rst`.

### Contribution guidelines clarification

* Added instructions specifying that all unit tests should be placed in the `tests/` directory, with core functionality tests in `tests/core/`, to `docs/how_to_contribute.rst`.