### PR TITLE
legacy bug fix for the trainer assuming there exists a model.mode att…

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -4920,8 +4920,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: pyhealth
-  version: 1.2.0
-  sha256: 7e526b1e9af034d40575c581f63a3799623d76441b8ae574ba1ac7213a1350eb
+  version: '2.0'
+  sha256: e5192ad0df100bc95275b11d715b61fd22d47afc5ce34cc77e64d5f722e3b4fc
   requires_dist:
   - torch~=2.7.1
   - torchvision

--- a/pyhealth/models/base_model.py
+++ b/pyhealth/models/base_model.py
@@ -30,6 +30,8 @@ class BaseModel(ABC, nn.Module):
         # used to query the device of the model
         self._dummy_param = nn.Parameter(torch.empty(0))
 
+        self.mode = None  # legacy API for backward compatibility with the trainer.
+
     @property
     def device(self) -> torch.device:
         """
@@ -50,9 +52,9 @@ class BaseModel(ABC, nn.Module):
         Returns:
             int: The output size of the model.
         """
-        assert len(self.label_keys) == 1, (
-            "Only one label key is supported if get_output_size is called"
-        )
+        assert (
+            len(self.label_keys) == 1
+        ), "Only one label key is supported if get_output_size is called"
         output_size = self.dataset.output_processors[self.label_keys[0]].size()
         return output_size
 
@@ -69,9 +71,9 @@ class BaseModel(ABC, nn.Module):
         Returns:
             Callable: The default loss function.
         """
-        assert len(self.label_keys) == 1, (
-            "Only one label key is supported if get_loss_function is called"
-        )
+        assert (
+            len(self.label_keys) == 1
+        ), "Only one label key is supported if get_loss_function is called"
         label_key = self.label_keys[0]
         mode = self.dataset.output_schema[label_key]
         if mode == "binary":
@@ -106,9 +108,9 @@ class BaseModel(ABC, nn.Module):
         Returns:
             torch.Tensor: The predicted probability tensor.
         """
-        assert len(self.label_keys) == 1, (
-            "Only one label key is supported if get_loss_function is called"
-        )
+        assert (
+            len(self.label_keys) == 1
+        ), "Only one label key is supported if get_loss_function is called"
         label_key = self.label_keys[0]
         mode = self.dataset.output_schema[label_key]
         if mode in ["binary"]:


### PR DESCRIPTION
This pull request makes minor improvements to the `BaseModel` class in `pyhealth/models/base_model.py` to enhance backward compatibility and code readability. The main changes include adding a legacy API attribute and refactoring assertion statements for clarity.

Backward compatibility:

* Added a `mode` attribute to the `BaseModel` class to maintain compatibility with legacy trainer code.

Code readability:

* Refactored assertion statements in the `get_output_size`, `get_loss_function`, and `prepare_y_prob` methods to use a more readable multi-line format. [[1]](diffhunk://#diff-683e983b36e9f7a8bf5e28de0b77ab2e57494fe192771daa782a3d1a8b23b9c4L53-R57) [[2]](diffhunk://#diff-683e983b36e9f7a8bf5e28de0b77ab2e57494fe192771daa782a3d1a8b23b9c4L72-R76) [[3]](diffhunk://#diff-683e983b36e9f7a8bf5e28de0b77ab2e57494fe192771daa782a3d1a8b23b9c4L109-R113)…ribute when its not really required