### PR TITLE
tiny final update to badges

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,9 +18,6 @@ Build, test, and deploy healthcare machine learning models with ease. PyHealth m
 - Fast (3x faster than pandas) data processing for quick experimentation
 
 
-.. image:: https://app.readthedocs.org/projects/pyhealth/badge/?version=latest&style=flat
-   :target: https://pyhealth.readthedocs.io/en/latest/
-   :alt: Documentation status
 
 .. image:: https://img.shields.io/readthedocs/pyhealth?logo=readthedocs&label=docs&version=latest
    :target: https://pyhealth.readthedocs.io/en/latest/


### PR DESCRIPTION
This pull request makes a small documentation update by replacing the Read the Docs badge in the `docs/index.rst` file with a new version that uses the Shields.io service and includes a logo and label.

* Replaced the old Read the Docs badge with a Shields.io badge that includes the Read the Docs logo and a "docs" label in `docs/index.rst`.