### PR TITLE
Fix/model force dataset features

### DIFF
--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -13,24 +13,11 @@ We support various real-world healthcare predictive tasks defined by **function 
 
 (v) Sleep Staging [Yang et al. ArXiv 2021]
 
-.. toctree::
-    :maxdepth: 3
-    
-    tasks/pyhealth.tasks.BaseTask
-    tasks/pyhealth.tasks.Readmission30DaysMIMIC4
-    tasks/pyhealth.tasks.InHospitalMortalityMIMIC4
-    tasks/pyhealth.tasks.MIMIC3ICD9Coding
-    tasks/pyhealth.tasks.cardiology_detect
-    tasks/pyhealth.tasks.COVID19CXRClassification
-    tasks/pyhealth.tasks.drug_recommendation
-    tasks/pyhealth.tasks.EEG_abnormal
-    tasks/pyhealth.tasks.EEG_events
-    tasks/pyhealth.tasks.length_of_stay_prediction
-    tasks/pyhealth.tasks.MedicalTranscriptionsClassification
-    tasks/pyhealth.tasks.mortality_prediction
-    tasks/pyhealth.tasks.patient_linkage_mimic3_fn
-    tasks/pyhealth.tasks.readmission_prediction
-    tasks/pyhealth.tasks.sleep_staging
-    tasks/pyhealth.tasks.SleepStagingSleepEDF
-    tasks/pyhealth.tasks.temple_university_EEG_tasks
+Auto-generated API docs for all modules in ``pyhealth.tasks``:
+
+.. autosummary::
+    :toctree: tasks
+    :recursive:
+
+    pyhealth.tasks
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,8 @@ toggleprompt_offset_right = 35
 
 ogp_site_url = "https://pyhealth.readthedocs.io/en/latest/"
 ogp_image = (
-    "https://pyhealth.readthedocs.io/en/latest/pyhealth_logos/_static/pyhealth-logo.png"
+    "https://pyhealth.readthedocs.io/en/latest/pyhealth_logos/_static/"
+    "pyhealth-logo.png"
 )
 
 # Add any paths that contain templates here, relative to this directory.
@@ -104,7 +105,7 @@ autodoc_member_order = "bysource"
 napoleon_google_docstring = True  # for pytorch lightning
 napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
-napoleon_use_rtype = True  # having a separate entry generally helps readability
+napoleon_use_rtype = True  # separate entry generally helps readability
 napoleon_use_param = True
 napoleon_custom_sections = [("Params", "Parameters")]
 todo_include_todos = False
@@ -115,6 +116,15 @@ myst_enable_extensions = [
     "dollarmath",
     "amsmath",
 ]
+
+# Make autodoc include imported members so tasks re-exported at package level
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": True,
+    "inherited-members": True,
+    "show-inheritance": True,
+    "imported-members": True,
+}
 
 # The master toctree document.
 master_doc = "index"
@@ -130,7 +140,10 @@ intersphinx_mapping = dict(
     sklearn=("https://scikit-learn.org/stable/", None),
     torch=("https://pytorch.org/docs/master/", None),
     scanpy=("https://scanpy.readthedocs.io/en/stable/", None),
-    pytorch_lightning=("https://pytorch-lightning.readthedocs.io/en/stable/", None),
+    pytorch_lightning=(
+        "https://pytorch-lightning.readthedocs.io/en/stable/",
+        None,
+    ),
     pyro=("http://docs.pyro.ai/en/stable/", None),
     pymde=("https://pymde.org/", None),
     flax=("https://flax.readthedocs.io/en/latest/", None),

--- a/pyhealth/models/base_model.py
+++ b/pyhealth/models/base_model.py
@@ -25,8 +25,11 @@ class BaseModel(ABC, nn.Module):
         """
         super(BaseModel, self).__init__()
         self.dataset = dataset
-        self.feature_keys = list(dataset.input_schema.keys())
-        self.label_keys = list(dataset.output_schema.keys())
+        self.feature_keys = []
+        self.label_keys = []
+        if dataset:
+            self.feature_keys = list(dataset.input_schema.keys())
+            self.label_keys = list(dataset.output_schema.keys())
         # used to query the device of the model
         self._dummy_param = nn.Parameter(torch.empty(0))
 

--- a/pyhealth/models/base_model.py
+++ b/pyhealth/models/base_model.py
@@ -16,7 +16,7 @@ class BaseModel(ABC, nn.Module):
             information such as the set of all tokens.
     """
 
-    def __init__(self, dataset: SampleDataset):
+    def __init__(self, dataset: SampleDataset = None):
         """
         Initializes the BaseModel.
 


### PR DESCRIPTION
This pull request focuses on improving the documentation generation for the `pyhealth.tasks` module and makes a minor update to the `BaseModel` class constructor. The main changes include switching to an auto-generated API documentation approach for tasks, enhancing Sphinx autodoc settings, and making the `BaseModel` constructor more flexible.

**Documentation improvements:**

* Switched the API documentation for `pyhealth.tasks` in `tasks.rst` to use `autosummary` with recursive generation, replacing the previous hardcoded toctree. This ensures all tasks are documented automatically.
* Updated Sphinx configuration in `conf.py` to include imported members in autodoc output, ensuring re-exported tasks are documented at the package level.
* Minor improvements to Sphinx config: split the logo image URL for clarity, clarified a comment about `napoleon_use_rtype`, and formatted the intersphinx mapping for readability. [[1]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L77-R78) [[2]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L107-R108) [[3]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L133-R146)

**Codebase improvement:**

* Updated the `BaseModel` constructor in `base_model.py` to allow `dataset` to be optional (defaulting to `None`), and safely initialize `feature_keys` and `label_keys` only if a dataset is provided. This makes the base model more flexible and robust. [[1]](diffhunk://#diff-683e983b36e9f7a8bf5e28de0b77ab2e57494fe192771daa782a3d1a8b23b9c4L19-R19) [[2]](diffhunk://#diff-683e983b36e9f7a8bf5e28de0b77ab2e57494fe192771daa782a3d1a8b23b9c4R28-R30)