### PR TITLE
more tasks, hopefully fix the lack of pages here

### DIFF
--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -13,11 +13,26 @@ We support various real-world healthcare predictive tasks defined by **function 
 
 (v) Sleep Staging [Yang et al. ArXiv 2021]
 
-Auto-generated API docs for all modules in ``pyhealth.tasks``:
-
-.. autosummary::
-    :toctree: tasks
-    :recursive:
-
-    pyhealth.tasks
+.. toctree::
+    :maxdepth: 3
+    
+    Base Task <tasks/pyhealth.tasks.BaseTask>
+    Readmission (30 Days, MIMIC-IV) <tasks/pyhealth.tasks.Readmission30DaysMIMIC4>
+    In-Hospital Mortality (MIMIC-IV) <tasks/pyhealth.tasks.InHospitalMortalityMIMIC4>
+    MIMIC-III ICD-9 Coding <tasks/pyhealth.tasks.MIMIC3ICD9Coding>
+    Cardiology Detection <tasks/pyhealth.tasks.cardiology_detect>
+    COVID-19 CXR Classification <tasks/pyhealth.tasks.COVID19CXRClassification>
+    Drug Recommendation <tasks/pyhealth.tasks.drug_recommendation>
+    EEG Abnormal <tasks/pyhealth.tasks.EEG_abnormal>
+    EEG Events <tasks/pyhealth.tasks.EEG_events>
+    Length of Stay Prediction <tasks/pyhealth.tasks.length_of_stay_prediction>
+    Medical Transcriptions Classification <tasks/pyhealth.tasks.MedicalTranscriptionsClassification>
+    Mortality Prediction (Next Visit) <tasks/pyhealth.tasks.mortality_prediction>
+    Patient Linkage (MIMIC-III) <tasks/pyhealth.tasks.patient_linkage_mimic3_fn>
+    Readmission Prediction <tasks/pyhealth.tasks.readmission_prediction>
+    Sleep Staging <tasks/pyhealth.tasks.sleep_staging>
+    Sleep Staging (SleepEDF) <tasks/pyhealth.tasks.SleepStagingSleepEDF>
+    Temple University EEG Tasks <tasks/pyhealth.tasks.temple_university_EEG_tasks>
+    Sleep Staging v2 <tasks/pyhealth.tasks.sleep_staging_v2>
+    Benchmark EHRShot <tasks/pyhealth.tasks.benchmark_ehrshot>
 

--- a/docs/api/tasks/pyhealth.tasks.benchmark_ehrshot.rst
+++ b/docs/api/tasks/pyhealth.tasks.benchmark_ehrshot.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.benchmark_ehrshot
+================================
+
+.. automodule:: pyhealth.tasks.benchmark_ehrshot
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/tasks/pyhealth.tasks.patient_linkage.rst
+++ b/docs/api/tasks/pyhealth.tasks.patient_linkage.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.patient_linkage
+=============================
+
+.. automodule:: pyhealth.tasks.patient_linkage
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/tasks/pyhealth.tasks.sleep_staging_v2.rst
+++ b/docs/api/tasks/pyhealth.tasks.sleep_staging_v2.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.sleep_staging_v2
+==============================
+
+.. automodule:: pyhealth.tasks.sleep_staging_v2
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This pull request improves the API documentation for the `pyhealth.tasks` module by replacing the auto-generated summary with a more detailed, task-oriented documentation structure. It also adds dedicated documentation pages for several specific tasks.

Documentation structure improvements:

* Replaced the auto-generated API documentation for all modules in `pyhealth.tasks` with a manual toctree listing individual task documentation pages for better clarity and navigation.

Added documentation for specific tasks:

* Added a new documentation page for the `benchmark_ehrshot` task in `pyhealth.tasks.benchmark_ehrshot`.
* Added a new documentation page for the `patient_linkage` task in `pyhealth.tasks.patient_linkage`.
* Added a new documentation page for the `sleep_staging_v2` task in `pyhealth.tasks.sleep_staging_v2`.