### PR TITLE
small change to transformersmodel to not explicitly use a deprecated …

### DIFF
--- a/pyhealth/models/transformers_model.py
+++ b/pyhealth/models/transformers_model.py
@@ -9,8 +9,7 @@ from .base_model import BaseModel
 
 
 class TransformersModel(BaseModel):
-    """Transformers class for Huggingface models.
-    """
+    """Transformers class for Huggingface models."""
 
     def __init__(
         self,
@@ -22,11 +21,14 @@ class TransformersModel(BaseModel):
         )
         self.model_name = model_name
         self.model = AutoModel.from_pretrained(model_name)
-        assert len(self.feature_keys) == 1, "Only one feature key is supported if Transformers is initialized"
+        assert (
+            len(self.feature_keys) == 1
+        ), "Only one feature key is supported if Transformers is initialized"
         self.feature_key = self.feature_keys[0]
-        assert len(self.label_keys) == 1, "Only one label key is supported if RNN is initialized"
+        assert (
+            len(self.label_keys) == 1
+        ), "Only one label key is supported if RNN is initialized"
         self.label_key = self.label_keys[0]
-        self.mode = self.dataset.output_schema[self.label_key]
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
         output_size = self.get_output_size()
         hidden_dim = self.model.config.hidden_size


### PR DESCRIPTION
This pull request makes minor improvements to the `TransformersModel` class in `pyhealth/models/transformers_model.py`, primarily focused on code formatting and readability.

Formatting and readability improvements:

* Reformatted assertion statements in the `__init__` method to use multi-line formatting for better readability.
* Cleaned up the class docstring by removing an extra line break.…self.mode