### PR TITLE
add additional docs about pyhealth researchers and students

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -139,6 +139,17 @@ Quick Navigation
        
        :doc:`Open Tutorials → <tutorials>`
 
+   * - Research Initiative
+       
+       Explore research contributions from our annual summer program
+       
+       :doc:`View Projects → <research_initiative>`
+     - Community
+       
+       Join our Discord server and contribute to PyHealth
+       
+       `Discord → <https://discord.gg/mpb835EHaX>`_ | :doc:`Contribute → <how_to_contribute>`
+
 
 ----------
 
@@ -211,6 +222,7 @@ Quick Navigation
    :caption: Additional Information
 
    how_to_contribute
+   research_initiative
    live
    log
    about

--- a/docs/research_initiative.rst
+++ b/docs/research_initiative.rst
@@ -1,0 +1,153 @@
+PyHealth Research Initiative
+============================
+
+Overview
+--------
+
+The PyHealth Research Initiative is an annual summer research program that brings together talented 
+students to conduct cutting-edge research in healthcare artificial intelligence. Through this program, 
+participants work on innovative projects that advance the field of computational healthcare, contributing 
+to publications, open-source software, and the broader healthcare AI community.
+
+The initiative provides students with hands-on experience in:
+
+- **Healthcare AI Research**: Working on real-world healthcare problems using electronic health records (EHRs) and clinical data
+- **Machine Learning Development**: Implementing and evaluating state-of-the-art deep learning models
+- **Open-Source Contribution**: Contributing to the PyHealth library and ecosystem
+- **Academic Publishing**: Co-authoring research papers and presenting findings
+- **Collaborative Research**: Working alongside faculty, postdocs, and industry partners
+
+Research Contributions
+----------------------
+
+Below is a comprehensive list of research contributions from PyHealth Research Initiative participants 
+over the years. These projects span various topics including clinical prediction, model interpretability, 
+drug recommendation, and healthcare AI infrastructure.
+
+.. list-table:: PyHealth Research Initiative Projects
+   :widths: 10 25 40 25
+   :header-rows: 1
+   :class: research-table
+
+   * - Year
+     - Researcher(s)
+     - Paper Title
+     - Links
+   * - 2025
+     - Example Student
+     - PyHealth 2.0: A Modern Healthcare AI Library for Clinical Predictive Modeling
+     - `Paper <#>`_ | `Code <#>`_
+   * - 2024
+     - Example Student 2
+     - Interpretable Transformer Models for Clinical Risk Prediction
+     - `Paper <#>`_ | `Code <#>`_
+   * - 2024
+     - Example Student 3
+     - Multi-Modal Learning for Drug Recommendation Systems
+     - *In Preparation*
+   * - 2023
+     - Example Student 4
+     - Federated Learning for Privacy-Preserving Healthcare Analytics
+     - `Paper <#>`_ | `Code <#>`_
+   * - 2023
+     - Example Student 5
+     - Temporal Modeling of Electronic Health Records
+     - `Paper <#>`_
+
+.. note::
+   
+   This table is continuously updated as new research is published. If you participated in the 
+   PyHealth Research Initiative and would like to add your work, please submit a pull request 
+   or contact the PyHealth team.
+
+Program Information
+-------------------
+
+**Duration**: 10-12 weeks (Summer)
+
+**Format**: Hybrid (remote and on-site options available)
+
+**Application**: Applications typically open in early spring. Check the 
+`PyHealth GitHub <https://github.com/sunlabuiuc/PyHealth>`_ for announcements.
+
+Research Areas
+--------------
+
+PyHealth Research Initiative projects typically fall into one or more of the following areas:
+
+Clinical Prediction Tasks
+~~~~~~~~~~~~~~~~~~~~~~~~~
+- Mortality prediction
+- Readmission prediction  
+- Length of stay prediction
+- Diagnosis prediction
+- Drug recommendation
+
+Model Development
+~~~~~~~~~~~~~~~~~
+- Novel neural network architectures for healthcare
+- Attention mechanisms and interpretability
+- Multi-modal learning
+- Transfer learning and foundation models
+
+Healthcare AI Infrastructure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Data processing pipelines
+- Model evaluation frameworks
+- Calibration and uncertainty quantification
+- Fairness and bias analysis
+
+Real-World Applications
+~~~~~~~~~~~~~~~~~~~~~~~
+- Clinical decision support systems
+- Drug discovery and repurposing
+- Patient risk stratification
+- Healthcare resource optimization
+
+Getting Involved
+----------------
+
+Interested in participating in future PyHealth Research Initiatives? Here's how to get involved:
+
+1. **Stay Updated**: Watch the `PyHealth repository <https://github.com/sunlabuiuc/PyHealth>`_ for announcements
+2. **Join the Community**: Participate in PyHealth discussions and contribute to the codebase
+3. **Connect**: Reach out to the PyHealth team through GitHub Issues or email
+4. **Prepare**: Familiarize yourself with the PyHealth library and explore the documentation
+
+Past Participants
+-----------------
+
+The PyHealth Research Initiative has hosted students from universities around the world, including:
+
+- University of Illinois Urbana-Champaign
+- Stanford University
+- MIT
+- Carnegie Mellon University
+- Georgia Tech
+- And many more...
+
+Alumni of the program have gone on to pursue graduate studies, research positions, and careers in 
+healthcare AI at leading institutions and companies.
+
+Contact
+-------
+
+For more information about the PyHealth Research Initiative, please:
+
+- Email: pyhealth-dev@illinois.edu
+- GitHub: https://github.com/sunlabuiuc/PyHealth
+- Documentation: https://pyhealth.readthedocs.io
+
+Acknowledgments
+---------------
+
+The PyHealth Research Initiative is made possible through the support of:
+
+- SunLab at the University of Illinois Urbana-Champaign
+- National Science Foundation (NSF)
+- National Institutes of Health (NIH)
+- Industry partners and collaborators
+
+We are grateful to all mentors, participants, and collaborators who have contributed to the success 
+of this program.
+


### PR DESCRIPTION
This pull request adds comprehensive documentation for the PyHealth Research Initiative, making it easier for users and contributors to learn about the program, its research projects, and how to get involved. The main changes include adding a new documentation page, updating navigation links, and highlighting community resources.

Documentation enhancements:

* Added a new page `docs/research_initiative.rst` detailing the PyHealth Research Initiative, including program overview, research contributions, project list, application information, and contact details.

Navigation improvements:

* Updated the `docs/index.rst` Quick Navigation section to include direct links to the Research Initiative and Community resources such as Discord and contribution guidelines.
* Added `research_initiative` to the Additional Information sidebar in `docs/index.rst` for easier access.