### PR TITLE
init commit to enable users to extend their processing beyond initial…

### DIFF
--- a/pyhealth/processors/nested_sequence_processor.py
+++ b/pyhealth/processors/nested_sequence_processor.py
@@ -29,7 +29,7 @@ class NestedSequenceProcessor(FeatureProcessor):
         padding: Additional padding to add on top of the observed maximum inner
             sequence length. The actual padding length will be observed_max + padding.
             This ensures the processor can handle sequences longer than those in the
-            training data. Default: 20.
+            training data. Default: 0 (no extra padding).
 
     Examples:
         >>> processor = NestedSequenceProcessor()
@@ -39,12 +39,12 @@ class NestedSequenceProcessor(FeatureProcessor):
         ...     {"codes": [["F"]]}
         ... ]
         >>> processor.fit(samples, "codes")
-        >>> # Process nested sequence (observed_max=3, with padding=20, total=23)
+        >>> # Process nested sequence (observed_max=3, default padding=0, total=3)
         >>> result = processor.process([["A", "B"], ["C"]])
-        >>> result.shape  # (2, 23) - 2 visits, padded to observed_max + padding
+        >>> result.shape  # (2, 3) - 2 visits, padded to observed_max
     """
 
-    def __init__(self, padding: int = 20):
+    def __init__(self, padding: int = 0):
         # -1 for <unk> for ease of boolean arithmetic > 0, > -1, etc.
         self.code_vocab: Dict[Any, int] = {"<unk>": -1, "<pad>": 0}
         self._next_index = 1
@@ -163,7 +163,7 @@ class NestedFloatsProcessor(FeatureProcessor):
         padding: Additional padding to add on top of the observed maximum inner
             sequence length. The actual padding length will be observed_max + padding.
             This ensures the processor can handle sequences longer than those in the
-            training data. Default: 20.
+            training data. Default: 0 (no extra padding).
 
     Examples:
         >>> processor = NestedFloatsProcessor()
@@ -173,12 +173,12 @@ class NestedFloatsProcessor(FeatureProcessor):
         ...     {"values": [[6.0]]}
         ... ]
         >>> processor.fit(samples, "values")
-        >>> # Process nested sequence (observed_max=3, with padding=20, total=23)
+        >>> # Process nested sequence (observed_max=3, default padding=0, total=3)
         >>> result = processor.process([[1.0, 2.0], [3.0]])
-        >>> result.shape  # (2, 23) - 2 visits, padded to observed_max + padding
+        >>> result.shape  # (2, 3) - 2 visits, padded to observed_max
     """
 
-    def __init__(self, forward_fill: bool = True, padding: int = 20):
+    def __init__(self, forward_fill: bool = True, padding: int = 0):
         self._max_inner_len = 1  # Maximum length of inner sequences
         self.forward_fill = forward_fill
         self._padding = padding  # Additional padding beyond observed max

--- a/pyhealth/processors/stagenet_processor.py
+++ b/pyhealth/processors/stagenet_processor.py
@@ -27,7 +27,7 @@ class StageNetProcessor(FeatureProcessor):
         padding: Additional padding to add on top of the observed maximum nested 
             sequence length. The actual padding length will be observed_max + padding.
             This ensures the processor can handle sequences longer than those in the 
-            training data. Default: 20. Only applies to nested sequences.
+            training data. Default: 0 (no extra padding). Only applies to nested sequences.
 
     Returns:
         Tuple of (time_tensor, value_tensor) where time_tensor can be None
@@ -40,11 +40,11 @@ class StageNetProcessor(FeatureProcessor):
         >>> values.shape  # (3,) - sequence of code indices
         >>> time.shape    # (3,) - time intervals
 
-        >>> # Case 2: Nested codes with time (with custom padding)
-        >>> processor = StageNetProcessor(padding=50)
+        >>> # Case 2: Nested codes with time (with custom padding for extra capacity)
+        >>> processor = StageNetProcessor(padding=20)
         >>> data = ([0.0, 1.5], [["A", "B"], ["C"]])
         >>> time, values = processor.process(data)
-        >>> values.shape  # (2, observed_max + 50) - padded nested sequences
+        >>> values.shape  # (2, observed_max + 20) - padded nested sequences
         >>> time.shape    # (2,)
 
         >>> # Case 3: Codes without time
@@ -54,7 +54,7 @@ class StageNetProcessor(FeatureProcessor):
         >>> time          # None
     """
 
-    def __init__(self, padding: int = 20):
+    def __init__(self, padding: int = 0):
         self.code_vocab: Dict[Any, int] = {"<unk>": -1, "<pad>": 0}
         self._next_index = 1
         self._is_nested = None  # Will be determined during fit

--- a/tests/core/test_nested_sequence_processors.py
+++ b/tests/core/test_nested_sequence_processors.py
@@ -31,12 +31,12 @@ class TestNestedSequenceProcessor(unittest.TestCase):
         # Check vocabulary size (A, B, C, D, E, F + <unk>, <pad>)
         self.assertEqual(processor.vocab_size(), 8)
 
-        # Check max inner length (max is 3 from ["C", "D", "E"], with default padding=20, total=23)
-        self.assertEqual(processor._max_inner_len, 23)
+        # Check max inner length (max is 3 from ["C", "D", "E"], with default padding=0, total=3)
+        self.assertEqual(processor._max_inner_len, 3)
 
         # Test processing
         result = processor.process([["A", "B"], ["C"]])
-        self.assertEqual(result.shape, (2, 23))  # 2 visits, padded to length 23
+        self.assertEqual(result.shape, (2, 3))  # 2 visits, padded to length 3
         self.assertEqual(result.dtype, torch.long)
 
         # Check padding is applied (second visit should be padded)
@@ -147,12 +147,12 @@ class TestNestedSequenceFloatsProcessor(unittest.TestCase):
         ]
         processor.fit(samples, "values")
 
-        # Check max inner length (max is 3 from [3.0, 4.0, 5.0], with default padding=20, total=23)
-        self.assertEqual(processor._max_inner_len, 23)
+        # Check max inner length (max is 3 from [3.0, 4.0, 5.0], with default padding=0, total=3)
+        self.assertEqual(processor._max_inner_len, 3)
 
         # Test processing
         result = processor.process([[1.0, 2.0], [3.0]])
-        self.assertEqual(result.shape, (2, 23))  # 2 visits, padded to length 23
+        self.assertEqual(result.shape, (2, 3))  # 2 visits, padded to length 3
         self.assertEqual(result.dtype, torch.float)
 
         # Check values
@@ -297,9 +297,9 @@ class TestNestedSequencePaddingFeature(unittest.TestCase):
     """Tests for the padding parameter in NestedSequenceProcessor."""
 
     def test_nested_sequence_padding_default(self):
-        """Test NestedSequenceProcessor with default padding (20)."""
+        """Test NestedSequenceProcessor with default padding (0)."""
         processor = NestedSequenceProcessor()
-        self.assertEqual(processor._padding, 20)
+        self.assertEqual(processor._padding, 0)
 
         # Fit on nested codes with max length 3
         samples = [
@@ -308,12 +308,12 @@ class TestNestedSequencePaddingFeature(unittest.TestCase):
         ]
         processor.fit(samples, "codes")
 
-        # Check that max_inner_len = observed_max (3) + padding (20) = 23
-        self.assertEqual(processor._max_inner_len, 23)
+        # Check that max_inner_len = observed_max (3) + padding (0) = 3
+        self.assertEqual(processor._max_inner_len, 3)
 
         # Process a sample
         result = processor.process([["A", "B"], ["C"]])
-        self.assertEqual(result.shape[1], 23)  # Padded to 23
+        self.assertEqual(result.shape[1], 3)  # Padded to 3
 
     def test_nested_sequence_padding_custom(self):
         """Test NestedSequenceProcessor with custom padding."""
@@ -386,9 +386,9 @@ class TestNestedFloatsPaddingFeature(unittest.TestCase):
     """Tests for the padding parameter in NestedFloatsProcessor."""
 
     def test_nested_floats_padding_default(self):
-        """Test NestedFloatsProcessor with default padding (20)."""
+        """Test NestedFloatsProcessor with default padding (0)."""
         processor = NestedFloatsProcessor()
-        self.assertEqual(processor._padding, 20)
+        self.assertEqual(processor._padding, 0)
 
         # Fit on nested floats with max length 3
         samples = [
@@ -397,12 +397,12 @@ class TestNestedFloatsPaddingFeature(unittest.TestCase):
         ]
         processor.fit(samples, "values")
 
-        # Check that max_inner_len = observed_max (3) + padding (20) = 23
-        self.assertEqual(processor._max_inner_len, 23)
+        # Check that max_inner_len = observed_max (3) + padding (0) = 3
+        self.assertEqual(processor._max_inner_len, 3)
 
         # Process a sample
         result = processor.process([[1.0, 2.0], [3.0]])
-        self.assertEqual(result.shape[1], 23)  # Padded to 23
+        self.assertEqual(result.shape[1], 3)  # Padded to 3
 
     def test_nested_floats_padding_custom(self):
         """Test NestedFloatsProcessor with custom padding."""


### PR DESCRIPTION
This pull request introduces a configurable `padding` parameter to three sequence processing classes (`NestedSequenceProcessor`, `NestedFloatsProcessor`, and `StageNetProcessor`) to allow for additional padding beyond the observed maximum sequence length. This change ensures that the processors can handle sequences longer than those seen during training, improving robustness and flexibility. The documentation, example usage, and associated tests have been updated to reflect this new behavior.

**Core Feature Additions and Enhancements:**

* Added a `padding` argument to the constructors of `NestedSequenceProcessor`, `NestedFloatsProcessor`, and `StageNetProcessor`, allowing users to specify extra padding beyond the observed maximum inner sequence length. The default is set to 20 for all three processors. This padding is now included in the computed maximum inner length after fitting. [[1]](diffhunk://#diff-79178fd43714eb86abb339dcee9c8d37ce309534c8f6f0efb72e9e0e31938611L36-R52) [[2]](diffhunk://#diff-79178fd43714eb86abb339dcee9c8d37ce309534c8f6f0efb72e9e0e31938611L162-R184) [[3]](diffhunk://#diff-ef3b23505c4612489131270195c3a69846217493f6fd9ca8ccd9599d8bbd29fcL50-R62)
* Updated the `fit` methods in all three processors to add the user-specified padding to the observed maximum inner/nested sequence length, ensuring the processors can handle longer sequences than those present in the training data. [[1]](diffhunk://#diff-79178fd43714eb86abb339dcee9c8d37ce309534c8f6f0efb72e9e0e31938611L73-R83) [[2]](diffhunk://#diff-79178fd43714eb86abb339dcee9c8d37ce309534c8f6f0efb72e9e0e31938611L191-R209) [[3]](diffhunk://#diff-ef3b23505c4612489131270195c3a69846217493f6fd9ca8ccd9599d8bbd29fcL105-R117)

**Documentation and Example Updates:**

* Improved docstrings and example code for all three processors to explain the new `padding` parameter and demonstrate its effect on output tensor shapes. [[1]](diffhunk://#diff-79178fd43714eb86abb339dcee9c8d37ce309534c8f6f0efb72e9e0e31938611R28-R33) [[2]](diffhunk://#diff-79178fd43714eb86abb339dcee9c8d37ce309534c8f6f0efb72e9e0e31938611R163-R166) [[3]](diffhunk://#diff-ef3b23505c4612489131270195c3a69846217493f6fd9ca8ccd9599d8bbd29fcR26-R31) [[4]](diffhunk://#diff-ef3b23505c4612489131270195c3a69846217493f6fd9ca8ccd9599d8bbd29fcL37-R47)

**Testing Improvements:**

* Updated tests for both `NestedSequenceProcessor` and `NestedFloatsProcessor` to check the new default padding behavior (default 20), and to explicitly set `padding=0` for tests that expect no extra padding. This ensures that the new functionality is properly validated. [[1]](diffhunk://#diff-b214071ce0761867c4e7957d282a80558ad2bab293bbc1a5bfa100af71a4f334L34-R39) [[2]](diffhunk://#diff-b214071ce0761867c4e7957d282a80558ad2bab293bbc1a5bfa100af71a4f334L150-R155) [[3]](diffhunk://#diff-b214071ce0761867c4e7957d282a80558ad2bab293bbc1a5bfa100af71a4f334L48-R48) [[4]](diffhunk://#diff-b214071ce0761867c4e7957d282a80558ad2bab293bbc1a5bfa100af71a4f334L166-R166)

**Miscellaneous:**

* Updated `__repr__` methods for all three processors to include the `padding` value for easier debugging and inspection. [[1]](diffhunk://#diff-79178fd43714eb86abb339dcee9c8d37ce309534c8f6f0efb72e9e0e31938611L131-R141) [[2]](diffhunk://#diff-79178fd43714eb86abb339dcee9c8d37ce309534c8f6f0efb72e9e0e31938611L303-R321) [[3]](diffhunk://#diff-ef3b23505c4612489131270195c3a69846217493f6fd9ca8ccd9599d8bbd29fcL194-R211)… dataset visit lengths