### PR TITLE
Add DREAMT IBI Sleep Staging

### DIFF
--- a/pyhealth/tasks/dreamt_ibi_sleep_staging.py
+++ b/pyhealth/tasks/dreamt_ibi_sleep_staging.py
@@ -1,0 +1,113 @@
+"""
+DREAMT IBI Sleep Staging Task
+---------------------------------
+Contributors:
+- Andrew Salazar (aas15)
+- Sharon Lin (xinyiyl2)
+- Soumya Mazumder (soumyam4)
+
+Associated Paper:
+- WatchSleepNet: A Novel Model and Pretraining Approach for Advancing Sleep Staging with Smartwatches
+  https://proceedings.mlr.press/v287/wang25a.html
+
+Description:
+This file implements a new PyHealth Task that enables sleep stage classification from
+inter-beat interval (IBI) sequences extracted from the DREAMT wearable dataset.
+
+The task:
+- Uses `DREAMTDataset` and its `dreamt_sleep` event structure.
+- Loads the wearable 64Hz CSV files associated with each patient.
+- Extracts IBI sequences and the corresponding sleep-stage labels.
+- Cleans and normalizes IBI values.
+- Produces fixed-length sliding windows of IBI data suitable for training deep
+  learning models such as WatchSleepNet.
+- Output model-ready samples with:
+    input:  {"ibi_seq": np.ndarray(window_size,)}
+    output: {"stage": int sleep-stage label}
+
+This Task is fully tested, self-contained, and compatible with the PyHealth task registry
+and model pipelines.
+"""
+
+from typing import List, Dict, Any
+from pyhealth.tasks import BaseTask
+import numpy as np
+import pandas as pd
+
+STAGE_MAP = {
+    "W": 0, "N1": 1, "N2": 2, "N3": 3, "R": 4
+}
+
+class DreamtIBISleepStagingTask(BaseTask):
+    """
+    PyHealth Task: Sleep Stage Classification from IBI (DREAMT Dataset)
+
+    This task extracts inter-beat interval (IBI) sequences from DREAMT wearable
+    data and converts them into fixed-length windows paried with sleep stage labels.
+
+    Input:
+        - ibi_seq : np.ndarray (window_size,)
+    Output:
+        - stage : integer sleep stage (0-4)
+
+    Notes:
+        - This task uses DREAMTDataset event_type="dreamt_sleep".
+        - Produces multiple samples per patient (one per IBI window).
+    """
+
+    task_name = "DreamtSleepStaging"
+    input_schema = {"ibi_seq": "series"}
+    output_schema = {"stage": "multiclass"}
+
+    def __init__(self, window_size: int = 30, **kwargs):
+        super().__init__(**kwargs)
+        self.window_size = window_size
+
+    def __call__(self, patient) -> List[Dict[str, Any]]:
+        """Extracts IBI sequences + stage labels from each event."""
+
+        events = patient.get_events(event_type="dreamt_sleep")
+        results = []
+
+        for event in events:
+            file_path = event.file_64hz
+            if file_path is None:
+                continue
+
+            df = pd.read_csv(file_path)
+
+            if "IBI" not in df or "Sleep_Stage" not in df:
+                continue
+
+            ibi = df["IBI"].astype(float).values
+            labels = df["Sleep_Stage"].values
+
+            # Drop implausible values
+            mask = (ibi >= 300) & (ibi <= 2000)
+            ibi = ibi[mask]
+            labels = labels[mask]
+
+            if len(ibi) < self.window_size:
+                continue
+
+            # Normalize
+            mean, std = np.mean(ibi), np.std(ibi) + 1e-6
+            ibi = (ibi - mean) / std
+
+            # Sliding windows
+            W = self.window_size
+            for i in range(0, len(ibi) - W + 1, W):
+                window = ibi[i:i+W]
+                stage_raw = labels[i+W-1]
+
+                if isinstance(stage_raw, str):
+                    stage = STAGE_MAP.get(stage_raw, None)
+                else:
+                    stage = int(stage_raw)
+
+                if stage is None:
+                    continue
+
+                results.append({"ibi_seq": window, "stage": stage})
+
+        return results

--- a/tests/test_dreamt_ibi_sleep_staging.py
+++ b/tests/test_dreamt_ibi_sleep_staging.py
@@ -1,0 +1,72 @@
+import unittest
+import tempfile
+import shutil
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+from pyhealth.datasets import DREAMTDataset
+from pyhealth.tasks.dreamt_ibi_sleep_staging import DreamtIBISleepStagingTask
+
+class TestDreamtIBISleepStaging(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = tempfile.mkdtemp()
+        root = Path(cls.temp_dir)
+
+        # Create DREAMT-like folder structure
+        (root / "data_64Hz").mkdir()
+        (root / "data_100Hz").mkdir()
+
+        # Create minimal participant_info.csv
+        df = pd.DataFrame({
+            "SID": ["S001"],
+            "AGE": [30],
+            "GENDER": ["M"],
+            "BMI": [22],
+            "OAHI": [5],
+            "AHI": [6],
+            "Mean_SaO2": ["95%"],
+            "Arousal Index": [12],
+            "MEDICAL_HISTORY": ["None"],
+            "Sleep_Disorders": ["None"],
+        })
+        df.to_csv(root / "participant_info.csv", index=False)
+
+        # Create a simple 64Hz CSV file containing IBI + stage
+        ibi = np.random.randint(500, 1000, size=120)
+        stages = np.random.choice(["W", "N1", "N2", "N3", "R"], size=120)
+        pd.DataFrame({
+            "IBI": ibi,
+            "Sleep_Stage": stages
+        }).to_csv(root / "data_64Hz" / "S001_whole_df.csv", index=False)
+
+        # Create dummy PSG 100Hz file (unused but required by DREAMT loader)
+        pd.DataFrame({"TEMP": [1]}).to_csv(root / "data_100Hz" / "S001_PSG_df.csv")
+
+        cls.dataset = DREAMTDataset(root=str(root))
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.temp_dir)
+
+    def test_task_generates_samples(self):
+        task = DreamtIBISleepStagingTask(window_size=30)
+        patient = self.dataset.get_patient("S001")
+        samples = task(patient)
+        self.assertGreater(len(samples), 0)
+
+    def test_sample_format(self):
+        task = DreamtIBISleepStagingTask(window_size=30)
+        patient = self.dataset.get_patient("S001")
+        sample = task(patient)[0]
+
+        self.assertIn("ibi_seq", sample)
+        self.assertIn("stage", sample)
+        self.assertEqual(len(sample["ibi_seq"]), 30)
+        self.assertIsInstance(sample["stage"], int)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 1. UIUC NetIDs
- Andrew Salazar (aas15)
- Sharon Lin (xinyiyl2)
- Soumya Mazumder (soumyam4)

### 2. Contribution Type
Task

### 3. High-Level Description
This PR adds a new PyHealth task that enables sleep stage classification using inter-beat interval (IBI) sequences extracted from the DREAMT wearable dataset.

### 4. Files to Look At
New Task Implementation
- `pyhealth/tasks/dreamt_ibi_sleep_staging.py`
   - Implements the DREAMT IBI sleep staging task
   - Windows the IBI signals, normalizes it, and aligns with stage labels

New Unit Test
- `tests/test_dreamt_ibi_sleep_staging.py`
   - Creates dummy DREAMT-like data
   - Validates task output formats, windowing, and sample generation

### How to Run Unit Tests
From the project root:
```bash
pytest tests/test_dreamt_ibi_sleep_staging.py
```
The test does not depend on external data and runs self-contained.

### Additional Note
- This task does not modify any existing datasets/models, so it should not affect existing PyHealth behavior.