### PR TITLE
Add MMTM Model

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -33,3 +33,4 @@ We implement the following models for supporting multiple healthcare predictive 
     models/pyhealth.models.GAN
     models/pyhealth.models.VAE
     models/pyhealth.models.SDOH
+    models/pyhealth.models.MMTM

--- a/docs/api/models/pyhealth.models.MMTM.rst
+++ b/docs/api/models/pyhealth.models.MMTM.rst
@@ -1,0 +1,45 @@
+pyhealth.models.MMTM
+===================================
+
+MMTM: Multimodal Transfer Module for Electronic Health Records.
+
+Paper: Hamid Reza Vaezi Joze, Amirreza Shaban, Michael L Iuzzolino, and Kazuhito Koishida. 2020.
+*Multimodal Transfer Module for CNN Fusion*. 
+In IEEE Conference on Computer Vision and Pattern Recognition (CVPR), 2020.
+https://arxiv.org/abs/1911.08670
+
+MMTM is a lightweight and effective module for multimodal fusion.  
+It computes cross-modal channel-wise attention to enhance information
+exchange between modalities without requiring large parameter growth.
+
+In the context of Electronic Health Records (EHR), modalities may include:
+- Diagnosis codes
+- Procedure codes
+- Medication codes
+- Laboratory results
+- Clinical note embeddings
+
+This PyHealth module provides two components:
+
+- **MMTMLayer**: A standalone multimodal attention block for fusing
+  two embeddings via shared channel-wise importance.
+- **MMTM**: A full PyHealth model that embeds two modalities,
+  pools patient-level representations, performs MMTM fusion,
+  and predicts clinical outcomes.
+
+The MMTM fusion mechanism is especially useful when modalities have
+different levels of predictive signal and complementary latent structure,
+as it allows cross-modal exchange of importance weights in a parameter-efficient way.
+
+This implementation is adapted from the concepts in the original CVPR 2020 paper
+and integrated into the PyHealth modeling interface for EHR tasks.
+
+.. autoclass:: pyhealth.models.MMTMLayer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pyhealth.models.MMTM
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -27,3 +27,4 @@ from .transformer import Transformer, TransformerLayer
 from .transformers_model import TransformersModel
 from .vae import VAE
 from .sdoh import SdohClassifier
+from .mmtm import MMTM, MMTMLayer

--- a/pyhealth/models/mmtm.py
+++ b/pyhealth/models/mmtm.py
@@ -1,0 +1,235 @@
+"""
+MMTM: Multimodal Transfer Module for EHR Representation Learning.
+
+Paper:
+    Joze et al. "MMTM: Multimodal Transfer Module for CNN Fusion."
+    CVPR 2020. (https://arxiv.org/abs/1911.08670)
+
+This PyHealth implementation adapts the MMTM module for multimodal
+Electronic Health Records (EHR) fusion. MMTM is a lightweight module
+that exchanges channel-wise attention between two modalities, enabling
+parameter-efficient cross-modal representation enhancement.
+
+MMTM can be used independently (via `MMTMLayer`) or within the broader
+PyHealth modeling ecosystem (via `MMTM`).
+
+-----------------------------------------------------------------------
+Examples (Layer):
+
+    >>> layer = MMTMLayer(64, 128)
+    >>> a = torch.randn(8, 64)
+    >>> b = torch.randn(8, 128)
+    >>> a_hat, b_hat = layer(a, b)
+
+Examples (Model):
+
+    >>> dataset = SampleDataset(...)
+    >>> model = MMTM(dataset)
+    >>> out = model(**batch)
+    >>> out["loss"].backward()
+"""
+
+from typing import Dict, Tuple
+import torch
+import torch.nn as nn
+
+from pyhealth.models import BaseModel
+from pyhealth.models.utils import get_last_visit
+from pyhealth.models import EmbeddingModel
+from pyhealth.datasets import SampleDataset
+
+__all__ = ["MMTMLayer", "MMTM"]
+
+class MMTMLayer(nn.Module):
+    """Multimodal Transfer Module (MMTM).
+
+    Paper:
+        Joze et al. "Multimodal Transfer Module for CNN Fusion."
+        CVPR 2020.
+
+    MMTM computes channel-wise importance weights for each modality and
+    enhances each representation with modality-specific attention derived
+    from a shared bottleneck.
+
+    Args:
+        dim_a: Feature dimension of modality A.
+        dim_b: Feature dimension of modality B.
+        reduction: Reduction factor for bottleneck (default: 4).
+
+    Examples:
+        >>> layer = MMTMLayer(64, 128)
+        >>> a = torch.randn(4, 64)
+        >>> b = torch.randn(4, 128)
+        >>> a_out, b_out = layer(a, b)
+    """
+
+    def __init__(self, dim_a: int, dim_b: int, reduction: int = 4):
+        super().__init__()
+        bottleneck_size = max(8, (dim_a + dim_b) // reduction)
+
+        # Squeeze step
+        self.fc_squeeze = nn.Sequential(
+            nn.Linear(dim_a + dim_b, bottleneck_size),
+            nn.ReLU(inplace=True),
+        )
+
+        # Excitation for each modality
+        self.fc_a = nn.Sequential(nn.Linear(bottleneck_size, dim_a), nn.Sigmoid())
+        self.fc_b = nn.Sequential(nn.Linear(bottleneck_size, dim_b), nn.Sigmoid())
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        joint = torch.cat([a, b], dim=-1)  # (B, Da+Db)
+        z = self.fc_squeeze(joint)
+
+        w_a = self.fc_a(z)  # (B, Da)
+        w_b = self.fc_b(z)  # (B, Db)
+
+        return a * w_a, b * w_b
+
+
+class MMTM(BaseModel):
+    """PyHealth multimodal fusion model using MMTM.
+
+    This model:
+        1. Embeds two modalities with PyHealth EmbeddingModel
+        2. Pools patient-level representations with `get_last_visit`
+        3. Applies MMTM fusion module
+        4. Predicts labels via a classifier
+
+    MMTM expects EXACTLY TWO feature modalities in the dataset.
+
+    Args:
+        dataset: PyHealth SampleDataset with two input modalities.
+        embedding_dim: Embedding size for each modality (default: 128).
+        reduction: Bottleneck reduction factor for MMTM.
+
+    Examples:
+        >>> model = MMTM(dataset, embedding_dim=128)
+        >>> results = model(**batch)
+        >>> results["loss"].backward()
+    """
+
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        embedding_dim: int = 128,
+        reduction: int = 4,
+    ):
+        super().__init__(dataset=dataset)
+
+        assert len(self.feature_keys) == 2, \
+            f"MMTM requires exactly 2 input modalities, got {self.feature_keys}"
+
+        self.feature_a, self.feature_b = self.feature_keys
+        self.label_key = self.label_keys[0]
+
+        # Embedding model shared by both modalities
+        self.embedding_model = EmbeddingModel(dataset, embedding_dim)
+
+        # MMTM fusion layer
+        self.mmtm = MMTMLayer(
+            dim_a=embedding_dim,
+            dim_b=embedding_dim,
+            reduction=reduction,
+        )
+
+        # Classifier after fusion
+        output_dim = self.get_output_size()
+        self.fc = nn.Linear(embedding_dim * 2, output_dim)
+
+    def _mask_and_pool(self, x: torch.Tensor) -> torch.Tensor:
+        """Applies mask for padded timesteps and returns last valid visit."""
+        mask = (x.sum(dim=-1) != 0).int()
+        return get_last_visit(x, mask)
+
+    def forward(self, **kwargs) -> Dict[str, torch.Tensor]:
+        # ----- 1. Run through embedding model -----
+        embedded = self.embedding_model({
+            self.feature_a: kwargs[self.feature_a],
+            self.feature_b: kwargs[self.feature_b],
+        })
+
+        # Extract embeddings
+        a = embedded[self.feature_a]  # (B, T, D)
+        b = embedded[self.feature_b]  # (B, T, D)
+
+        # ----- 2. Pool last valid visit -----
+        a_last = self._mask_and_pool(a)  # (B, D)
+        b_last = self._mask_and_pool(b)  # (B, D)
+
+        # ----- 3. Fuse using MMTM -----
+        a_fused, b_fused = self.mmtm(a_last, b_last)
+        patient_emb = torch.cat([a_fused, b_fused], dim=-1)
+
+        # ----- 4. Classifier -----
+        logits = self.fc(patient_emb)
+
+        y_true = kwargs[self.label_key].to(self.device)
+        loss_fn = self.get_loss_function()
+        loss = loss_fn(logits, y_true)
+        y_prob = self.prepare_y_prob(logits)
+
+        return {
+            "loss": loss,
+            "y_prob": y_prob,
+            "y_true": y_true,
+            "logit": logits,
+        }
+
+if __name__ == "__main__":
+    from pyhealth.datasets import SampleDataset, get_dataloader
+
+    samples = [
+        {
+            "patient_id": "p0",
+            "visit_id": "v0",
+            "codes": [
+                "250.01",     
+                "414.01",     
+                "272.4",      
+            ],
+            "procedures": [
+                "36.15",      
+                "99.04",      
+                "88.72",      
+            ],
+            "label": 1,
+        },
+        {
+            "patient_id": "p0",
+            "visit_id": "v1",
+            "codes": [
+                "518.81",     
+                "038.9",      
+            ],
+            "procedures": [
+                "96.71",      
+                "93.90",     
+            ],
+            "label": 0,
+        },
+    ]
+
+
+    # Use simple processors for clarity
+    dataset = SampleDataset(
+        samples=samples,
+        input_schema={
+            "codes": "sequence",
+            "procedures": "sequence",
+        },
+        output_schema={"label": "binary"},
+        dataset_name="mmtm_example",
+    )
+
+    loader = get_dataloader(dataset, batch_size=2)
+
+    model = MMTM(dataset, embedding_dim=64)
+
+    batch = next(iter(loader))
+    results = model(**batch)
+
+    print("y_prob:", results["y_prob"])
+    print("loss:", results["loss"])
+
+    results["loss"].backward()

--- a/tests/core/test_mmtm.py
+++ b/tests/core/test_mmtm.py
@@ -1,0 +1,111 @@
+"""Unit tests for the MMTM model and MMTMLayer."""
+
+import unittest
+import torch
+
+from pyhealth.datasets import SampleDataset, get_dataloader
+from pyhealth.models import MMTM, MMTMLayer
+
+
+class TestMMTMLayer(unittest.TestCase):
+    """Tests for standalone MMTMLayer."""
+
+    def test_layer_forward(self):
+        dim_a, dim_b = 64, 128
+        layer = MMTMLayer(dim_a, dim_b)
+
+        a = torch.randn(4, dim_a)
+        b = torch.randn(4, dim_b)
+
+        a_out, b_out = layer(a, b)
+
+        self.assertEqual(a_out.shape, (4, dim_a))
+        self.assertEqual(b_out.shape, (4, dim_b))
+
+
+class TestMMTMModel(unittest.TestCase):
+    """Tests for the MMTM model."""
+
+    def setUp(self):
+        """Construct a minimal realistic EHR dataset with 2 modalities."""
+        samples = [
+            {
+                "patient_id": "p1",
+                "visit_id": "v1",
+                "codes": ["250.01", "414.01"],
+                "procedures": ["36.15", "88.72"],
+                "label": 1,
+            },
+            {
+                "patient_id": "p1",
+                "visit_id": "v2",
+                "codes": ["518.81"],
+                "procedures": ["96.71"],
+                "label": 0,
+            },
+        ]
+
+        self.dataset = SampleDataset(
+            samples=samples,
+            input_schema={
+                "codes": "sequence",
+                "procedures": "sequence",
+            },
+            output_schema={"label": "binary"},
+            dataset_name="test_mmtm",
+        )
+
+        # Use the correct PyHealth loader
+        loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        self.batch = next(iter(loader))
+
+    def test_initialization(self):
+        """Model should initialize correctly with 2 modalities."""
+        model = MMTM(self.dataset, embedding_dim=32)
+
+        self.assertIsInstance(model, MMTM)
+        self.assertEqual(len(model.feature_keys), 2)
+        self.assertTrue(hasattr(model, "mmtm"))
+        self.assertTrue(hasattr(model, "embedding_model"))
+        self.assertTrue(hasattr(model, "fc"))
+
+    def test_forward_output_structure(self):
+        """Forward pass should return loss, y_prob, y_true, logit."""
+        model = MMTM(self.dataset, embedding_dim=32)
+        outputs = model(**self.batch)
+
+        self.assertIn("loss", outputs)
+        self.assertIn("y_prob", outputs)
+        self.assertIn("y_true", outputs)
+        self.assertIn("logit", outputs)
+
+        self.assertIsInstance(outputs["loss"], torch.Tensor)
+        self.assertEqual(outputs["logit"].shape[0], 2)
+
+    def test_backward(self):
+        """Loss should be backpropagatable."""
+        model = MMTM(self.dataset, embedding_dim=32)
+        outputs = model(**self.batch)
+
+        loss = outputs["loss"]
+        loss.backward()
+
+        any_grad = any(
+            p.grad is not None for p in model.parameters() if p.requires_grad
+        )
+        self.assertTrue(any_grad)
+
+    def test_model_parameters(self):
+        """Model should have trainable parameters."""
+        model = MMTM(self.dataset, embedding_dim=32)
+        total_params = sum(p.numel() for p in model.parameters())
+        self.assertGreater(total_params, 0)
+
+    def test_device_property(self):
+        """BaseModel exposes device properly."""
+        model = MMTM(self.dataset)
+        self.assertIsInstance(model.device, torch.device)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Add MMTM (Multimodal Transfer Module) Model and MMTMLayer for Multimodal EHR Fusion

This PR adds MMTM (Multimodal Transfer Module) and MMTMLayer to the PyHealth model library.
MMTM is a lightweight, effective cross-modal channel-attention fusion module, originally introduced in:
```
Joze et al., “Multimodal Transfer Module for CNN Fusion,” CVPR 2020
```
[https://arxiv.org/abs/1911.08670](https://arxiv.org/abs/1911.08670)

Although developed for computer vision, MMTM provides a strong baseline for multimodal Electronic Health Records (EHR), enabling efficient fusion between:

- diagnosis codes
- procedure codes
- medications
- lab measurements
- clinical note embeddings
or any two modalities with embedding vectors

This PR adapts MMTM to PyHealth’s BaseModel API in a way that is clean, reusable, and fully compatible with PyHealth datasets and processors.

## Motivation

MMTM is increasingly used in recent multimodal EHR work, including as a baseline in:

CTPD: Cross-Modal Temporal Pattern Discovery for Enhanced Multimodal EHR Analysis (2024)
Used as a fusion baseline for multimodal clinical time-series + notes.

By adding MMTM to PyHealth, this PR:

- expands the library’s multimodal modeling capabilities
- enables reproducible baselines for multimodal fusion studies
- supports EHR benchmarks where complementary modalities must be fused
- aligns with PyHealth’s goal of enabling reproducible AI4Health research

## What’s Included

1. MMTMLayer
A standalone fusion layer that performs:

- joint squeeze (dim_a + dim_b → bottleneck)
- modality-specific excitation
- channel-wise attention across both modalities
- returns fused representations

Works for any tensor pair shaped (batch, feature_dim).

2. MMTM model (BaseModel subclass)

A full PyHealth model that:

- embeds two input modalities with EmbeddingModel
- pools patient-level features with get_last_visit
- fuses both modalities via MMTMLayer
- performs classification using a final linear head

MMTM enforces exactly two modalities, matching typical multimodal EHR settings.

## Unit Tests (test_mmtm.py)

Tests include:

- layer forward behavior
- correct model initialization
- forward output format (loss, y_prob, y_true, logit)
- gradient propagation
- model parameters
- dataset integration
- device handling

All tests pass locally.

## Example Usage

Included at the bottom of mmtm.py under if __name__ == "__main__"::
minimal dataset with "codes" and "procedures"
creation of MMTM model
forward + backward demonstration

##  Impact

This PR adds a widely used multimodal fusion mechanism, enabling PyHealth users to:

- run CTPD baselines directly
- benchmark multimodal EHR models
- perform efficient two-modality fusion
- expand multimodal research using a known CVPR-level baseline

MMTM is simple, fast, and improves the reproducibility of multimodal EHR research inside PyHealth.