### PR TITLE
feat(models): Add BERT and BioBERT models for healthcare text classif…

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -15,6 +15,7 @@ We implement the following models for supporting multiple healthcare predictive 
     models/pyhealth.models.GNN
     models/pyhealth.models.Transformer
     models/pyhealth.models.TransformersModel
+    models/pyhealth.models.BERT
     models/pyhealth.models.RETAIN
     models/pyhealth.models.GAMENet
     models/pyhealth.models.MICRON

--- a/docs/api/models/pyhealth.models.BERT.rst
+++ b/docs/api/models/pyhealth.models.BERT.rst
@@ -1,0 +1,101 @@
+pyhealth.models.BERT
+===================================
+
+BERT and BioBERT models for healthcare text classification.
+
+This module provides BERT-based models specifically designed for healthcare NLP tasks.
+It supports the following pre-trained models:
+
+- Standard BERT (bert-base-uncased, bert-base-cased)
+- BioBERT (dmis-lab/biobert-v1.1) - Pre-trained on PubMed abstracts
+- Any other HuggingFace BERT-compatible model
+
+Features
+--------
+
+- **Multiple pooling strategies**: CLS token, mean pooling, max pooling
+- **Fine-tuning control**: Freeze entire encoder or specific layers
+- **Differential learning rates**: Apply different LR to encoder vs classifier
+
+Available Model Aliases
+-----------------------
+
+The following model aliases can be used with the ``model_name`` parameter:
+
+- ``"bert-base-uncased"`` → ``bert-base-uncased``
+- ``"bert-base-cased"`` → ``bert-base-cased``
+- ``"biobert"`` → ``dmis-lab/biobert-v1.1``
+
+Example Usage
+-------------
+
+Basic binary classification:
+
+.. code-block:: python
+
+    from pyhealth.datasets import SampleDataset, get_dataloader
+    from pyhealth.models import BERT
+    from pyhealth.trainer import Trainer
+
+    # Create dataset
+    samples = [
+        {"patient_id": "p0", "visit_id": "v0", "note": "Chest pain...", "label": 1},
+        {"patient_id": "p1", "visit_id": "v1", "note": "Wellness visit...", "label": 0},
+    ]
+    dataset = SampleDataset(
+        samples=samples,
+        input_schema={"note": "text"},
+        output_schema={"label": "binary"},
+        dataset_name="demo",
+    )
+
+    # Create BERT model
+    model = BERT(
+        dataset=dataset,
+        model_name="bert-base-uncased",
+        pooling="cls",
+    )
+
+    # Train
+    trainer = Trainer(model=model, metrics=["accuracy", "f1"])
+    trainer.train(train_dataloader, val_dataloader, epochs=5)
+
+Using BioBERT for medical NLP:
+
+.. code-block:: python
+
+    model = BERT(
+        dataset=dataset,
+        model_name="biobert",  # Uses dmis-lab/biobert-v1.1
+        pooling="cls",
+        freeze_layers=6,  # Freeze bottom 6 layers
+    )
+
+BERTLayer
+---------
+
+The standalone BERT encoder layer that can be used in custom architectures.
+
+.. autoclass:: pyhealth.models.BERTLayer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+BERT Model
+----------
+
+The complete BERT model for text classification.
+
+.. autoclass:: pyhealth.models.BERT
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Biomedical Model Registry
+-------------------------
+
+Dictionary mapping model aliases to HuggingFace model identifiers.
+
+.. autodata:: pyhealth.models.BIOMEDICAL_MODELS
+    :annotation:
+

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -1,6 +1,7 @@
 from .adacare import AdaCare, AdaCareLayer
 from .agent import Agent, AgentLayer
 from .base_model import BaseModel
+from .bert import BERT, BERTLayer, BIOMEDICAL_MODELS
 from .cnn import CNN, CNNLayer
 from .concare import ConCare, ConCareLayer
 from .contrawr import ContraWR, ResBlock2D

--- a/pyhealth/models/bert.py
+++ b/pyhealth/models/bert.py
@@ -1,0 +1,389 @@
+"""BERT and BioBERT models for text classification in healthcare.
+
+This module provides BERT-based models specifically designed for healthcare NLP tasks.
+It supports the following pre-trained models:
+- bert-base-uncased, bert-base-cased
+- dmis-lab/biobert-v1.1 (BioBERT)
+- Any other HuggingFace BERT-compatible model
+"""
+
+from typing import Dict, List, Literal, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+from pyhealth.datasets import SampleDataset
+from pyhealth.models.base_model import BaseModel
+
+
+# Supported BERT models with shorthand aliases
+BIOMEDICAL_MODELS = {
+    "bert-base-uncased": "bert-base-uncased",
+    "bert-base-cased": "bert-base-cased",
+    "biobert": "dmis-lab/biobert-v1.1",
+}
+
+
+class BERTLayer(nn.Module):
+    """BERT layer for encoding text into fixed-size representations.
+    
+    This layer wraps HuggingFace's BERT models and can be used standalone or
+    as part of a larger model. It supports different pooling strategies and
+    can optionally freeze the encoder for feature extraction.
+    
+    Args:
+        model_name: Name of the pre-trained BERT model. Can be a HuggingFace
+            model name or a shorthand from BIOMEDICAL_MODELS.
+        pooling: Pooling strategy for obtaining sentence embeddings.
+            - "cls": Use the [CLS] token embedding (default)
+            - "mean": Mean of all token embeddings (excluding padding)
+            - "max": Max pooling of all token embeddings (excluding padding)
+        max_length: Maximum sequence length for tokenization. Default is 512.
+        dropout: Dropout probability applied after the encoder. Default is 0.1.
+        freeze_encoder: Whether to freeze the BERT encoder weights. Default is False.
+        freeze_layers: Number of encoder layers to freeze from the bottom. 
+            Only used if freeze_encoder is False. Default is 0.
+
+    """
+    
+    def __init__(
+        self,
+        model_name: str = "bert-base-uncased",
+        pooling: Literal["cls", "mean", "max"] = "cls",
+        max_length: int = 512,
+        dropout: float = 0.1,
+        freeze_encoder: bool = False,
+        freeze_layers: int = 0,
+    ):
+        super(BERTLayer, self).__init__()
+        
+        # Resolve model name if using shorthand
+        self.model_name = BIOMEDICAL_MODELS.get(model_name.lower(), model_name)
+        self.pooling = pooling
+        self.max_length = max_length
+        self.freeze_encoder = freeze_encoder
+        self.freeze_layers = freeze_layers
+        
+        # Load tokenizer and model
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self.config = AutoConfig.from_pretrained(self.model_name)
+        self.encoder = AutoModel.from_pretrained(self.model_name)
+        
+        # Get hidden size from config
+        self.hidden_size = self.config.hidden_size
+        
+        # Dropout layer
+        self.dropout = nn.Dropout(dropout)
+        
+        # Apply freezing if requested
+        if freeze_encoder:
+            self._freeze_all_layers()
+        elif freeze_layers > 0:
+            self._freeze_bottom_layers(freeze_layers)
+    
+    def _freeze_all_layers(self):
+        """Freeze all encoder parameters."""
+        for param in self.encoder.parameters():
+            param.requires_grad = False
+    
+    def _freeze_bottom_layers(self, num_layers: int):
+        """Freeze the embeddings and bottom N encoder layers.
+        
+        Args:
+            num_layers: Number of layers to freeze from the bottom.
+        """
+        # Freeze embeddings
+        for param in self.encoder.embeddings.parameters():
+            param.requires_grad = False
+        
+        # Freeze specified number of encoder layers
+        if hasattr(self.encoder, 'encoder'):
+            for i, layer in enumerate(self.encoder.encoder.layer):
+                if i < num_layers:
+                    for param in layer.parameters():
+                        param.requires_grad = False
+    
+    def get_output_size(self) -> int:
+        """Returns the output embedding dimension."""
+        return self.hidden_size
+    
+    def forward(
+        self,
+        texts: Union[str, List[str]],
+        return_attention: bool = False,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """Encode texts into fixed-size embeddings.
+        
+        Args:
+            texts: A single text string or list of text strings.
+            return_attention: Whether to return attention weights. Default is False.
+        
+        Returns:
+            embeddings: Tensor of shape [batch_size, hidden_size].
+            attention_weights: (Optional) Tensor of attention weights if
+                return_attention is True.
+        """
+        # Handle single string input
+        if isinstance(texts, str):
+            texts = [texts]
+        
+        # Tokenize
+        encoding = self.tokenizer(
+            texts,
+            padding=True,
+            truncation=True,
+            max_length=self.max_length,
+            return_tensors="pt",
+        )
+        
+        # Move to same device as model
+        encoding = {k: v.to(self.encoder.device) for k, v in encoding.items()}
+        
+        # Forward pass through encoder
+        outputs = self.encoder(
+            **encoding,
+            output_attentions=return_attention,
+        )
+        
+        # Get hidden states
+        hidden_states = outputs.last_hidden_state  # [batch, seq_len, hidden]
+        attention_mask = encoding["attention_mask"]  # [batch, seq_len]
+        
+        # Apply pooling strategy
+        if self.pooling == "cls":
+            embeddings = hidden_states[:, 0, :]  # [batch, hidden]
+        elif self.pooling == "mean":
+            # Mean pooling with attention mask
+            mask_expanded = attention_mask.unsqueeze(-1).expand(hidden_states.size()).float()
+            sum_embeddings = torch.sum(hidden_states * mask_expanded, dim=1)
+            sum_mask = torch.clamp(mask_expanded.sum(dim=1), min=1e-9)
+            embeddings = sum_embeddings / sum_mask  # [batch, hidden]
+        elif self.pooling == "max":
+            # Max pooling with attention mask
+            mask_expanded = attention_mask.unsqueeze(-1).expand(hidden_states.size())
+            hidden_states[~mask_expanded.bool()] = float('-inf')
+            embeddings = torch.max(hidden_states, dim=1)[0]  # [batch, hidden]
+        else:
+            raise ValueError(f"Unknown pooling strategy: {self.pooling}")
+        
+        # Apply dropout
+        embeddings = self.dropout(embeddings)
+        
+        if return_attention:
+            return embeddings, outputs.attentions
+        return embeddings
+
+
+class BERT(BaseModel):
+    """BERT model for text classification in healthcare applications.
+    
+    This model uses pre-trained BERT models (including BioBERT) for text 
+    classification tasks. It supports fine-tuning the entire model or using 
+    it as a feature extractor with frozen weights.
+    
+    The model expects text input and produces classification outputs for
+    binary, multiclass, or multilabel tasks.
+    
+    Note:
+        This model is designed for single text input features. For multiple
+        text features, each feature should have its own text field in the
+        dataset schema.
+    
+    Args:
+        dataset: SampleDataset containing the training data. Used to infer
+            vocabulary size, label space, and feature keys.
+        model_name: Name of the pre-trained BERT model. Can be a HuggingFace
+            model identifier or a shorthand name (e.g., "biobert").
+            See BIOMEDICAL_MODELS for available shorthands. Default is "bert-base-uncased".
+        pooling: Pooling strategy for sentence embeddings. Options:
+            - "cls": Use [CLS] token embedding (default, recommended for classification)
+            - "mean": Mean of all token embeddings
+            - "max": Max pooling of all token embeddings
+        max_length: Maximum sequence length for tokenization. Default is 512.
+            Longer sequences will be truncated.
+        dropout: Dropout probability applied to encoder output. Default is 0.1.
+        freeze_encoder: If True, freeze all BERT encoder weights and use it
+            as a fixed feature extractor. Default is False.
+        freeze_layers: Number of encoder layers to freeze from the bottom.
+            Only effective if freeze_encoder is False. Useful for gradual
+            unfreezing during fine-tuning. Default is 0.
+        classifier_hidden_dim: Hidden dimension of the classification head.
+            If None, a single linear layer is used. Default is None.
+    
+    Attributes:
+        model_name: Resolved HuggingFace model name.
+        feature_key: Key for the text feature in input data.
+        label_key: Key for the label in input data.
+        encoder: The BERTLayer encoder.
+        classifier: Classification head.
+    """
+    
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        model_name: str = "bert-base-uncased",
+        pooling: Literal["cls", "mean", "max"] = "cls",
+        max_length: int = 512,
+        dropout: float = 0.1,
+        freeze_encoder: bool = False,
+        freeze_layers: int = 0,
+        classifier_hidden_dim: Optional[int] = None,
+    ):
+        super(BERT, self).__init__(dataset=dataset)
+        
+        # Validate feature keys - expect single text feature
+        assert len(self.feature_keys) == 1, (
+            f"BERT model expects a single text feature, got {len(self.feature_keys)} features: "
+            f"{self.feature_keys}. For multiple text features, consider using separate "
+            "BERT encoders or concatenating texts."
+        )
+        self.feature_key = self.feature_keys[0]
+        
+        # Validate label keys
+        assert len(self.label_keys) == 1, (
+            f"BERT model expects a single label key, got {len(self.label_keys)}: {self.label_keys}"
+        )
+        self.label_key = self.label_keys[0]
+        
+        # Store configuration
+        self.model_name = BIOMEDICAL_MODELS.get(model_name.lower(), model_name)
+        self.pooling = pooling
+        self.max_length = max_length
+        self.freeze_encoder = freeze_encoder
+        self.freeze_layers = freeze_layers
+        self.classifier_hidden_dim = classifier_hidden_dim
+        
+        # Initialize encoder
+        self.encoder = BERTLayer(
+            model_name=model_name,
+            pooling=pooling,
+            max_length=max_length,
+            dropout=dropout,
+            freeze_encoder=freeze_encoder,
+            freeze_layers=freeze_layers,
+        )
+        
+        # Get output size from dataset
+        output_size = self.get_output_size()
+        hidden_size = self.encoder.hidden_size
+        
+        # Build classifier head
+        if classifier_hidden_dim is not None:
+            self.classifier = nn.Sequential(
+                nn.Linear(hidden_size, classifier_hidden_dim),
+                nn.ReLU(),
+                nn.Dropout(dropout),
+                nn.Linear(classifier_hidden_dim, output_size),
+            )
+        else:
+            self.classifier = nn.Linear(hidden_size, output_size)
+    
+    def get_encoder_parameters(self):
+        """Returns parameters of the BERT encoder.
+        
+        Useful for applying different learning rates to encoder and classifier.
+        
+        Returns:
+            Iterator of encoder parameters.
+        """
+        return self.encoder.parameters()
+    
+    def get_classifier_parameters(self):
+        """Returns parameters of the classification head.
+        
+        Useful for applying different learning rates to encoder and classifier.
+        
+        Returns:
+            Iterator of classifier parameters.
+        """
+        return self.classifier.parameters()
+    
+    def forward(
+        self,
+        **kwargs,
+    ) -> Dict[str, torch.Tensor]:
+        """Forward propagation.
+        
+        Args:
+            **kwargs: Keyword arguments containing feature and label keys.
+                Must include the text feature key and label key defined in
+                the dataset schema.
+        
+        Returns:
+            Dict[str, torch.Tensor]: Dictionary containing:
+                - loss: Scalar loss tensor
+                - y_prob: Predicted probabilities [batch_size, num_classes]
+                - y_true: Ground truth labels [batch_size, num_classes]
+                - logit: Raw logits before activation [batch_size, num_classes]
+                - embed (optional): Embeddings if embed=True in kwargs
+        """
+        # Get text input
+        texts = kwargs[self.feature_key]
+        
+        # Handle different input types
+        if isinstance(texts, torch.Tensor):
+            # Convert tensor to list of strings if needed
+            texts = [str(t) for t in texts.tolist()]
+        elif not isinstance(texts, list):
+            texts = [texts]
+        
+        # Encode texts
+        embeddings = self.encoder(texts)  # [batch_size, hidden_size]
+        
+        # Classification
+        logits = self.classifier(embeddings)  # [batch_size, output_size]
+        
+        # Get labels and compute loss
+        y_true = kwargs[self.label_key].to(self.device)
+        loss = self.get_loss_function()(logits, y_true)
+        
+        # Compute probabilities
+        y_prob = self.prepare_y_prob(logits)
+        
+        results = {
+            "loss": loss,
+            "y_prob": y_prob,
+            "y_true": y_true,
+            "logit": logits,
+        }
+        
+        # Optionally return embeddings
+        if kwargs.get("embed", False):
+            results["embed"] = embeddings
+        
+        return results
+    
+    def encode(
+        self,
+        texts: Union[str, List[str]],
+    ) -> torch.Tensor:
+        """Encode texts into embeddings without classification.
+        
+        This method is useful for getting text representations for downstream
+        tasks or analysis.
+        
+        Args:
+            texts: Single text string or list of text strings.
+        
+        Returns:
+            torch.Tensor: Embeddings of shape [batch_size, hidden_size].
+        """
+        self.eval()
+        with torch.no_grad():
+            embeddings = self.encoder(texts)
+        return embeddings
+    
+    def __repr__(self) -> str:
+        return (
+            f"BERT(\n"
+            f"  model_name={self.model_name},\n"
+            f"  pooling={self.pooling},\n"
+            f"  max_length={self.max_length},\n"
+            f"  freeze_encoder={self.freeze_encoder},\n"
+            f"  freeze_layers={self.freeze_layers},\n"
+            f"  hidden_size={self.encoder.hidden_size},\n"
+            f"  output_size={self.get_output_size()},\n"
+            f")"
+        )
+

--- a/tests/core/test_bert.py
+++ b/tests/core/test_bert.py
@@ -1,0 +1,485 @@
+"""Unit tests for the BERT model.
+
+This module contains comprehensive tests for the BERT and BERTLayer classes,
+covering initialization, forward pass, backward pass, and various configurations.
+"""
+
+import unittest
+from typing import Dict, Type, Union
+
+import torch
+
+from pyhealth.datasets import SampleDataset, get_dataloader
+from pyhealth.models import BERT, BERTLayer, BIOMEDICAL_MODELS
+from pyhealth.processors.base_processor import FeatureProcessor
+
+
+class TestBERTLayer(unittest.TestCase):
+    """Test cases for the BERTLayer class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Use a smaller model for faster tests
+        self.model_name = "bert-base-uncased"
+        self.sample_texts = [
+            "Patient presents with chest pain.",
+            "Annual wellness checkup completed.",
+        ]
+
+    def test_layer_initialization(self):
+        """Test BERTLayer initialization with default parameters."""
+        layer = BERTLayer(model_name=self.model_name)
+        
+        self.assertEqual(layer.pooling, "cls")
+        self.assertEqual(layer.max_length, 512)
+        self.assertFalse(layer.freeze_encoder)
+        self.assertEqual(layer.freeze_layers, 0)
+        self.assertEqual(layer.hidden_size, 768)
+
+    def test_layer_cls_pooling(self):
+        """Test BERTLayer with CLS pooling strategy."""
+        layer = BERTLayer(model_name=self.model_name, pooling="cls")
+        
+        with torch.no_grad():
+            embeddings = layer(self.sample_texts)
+        
+        self.assertEqual(embeddings.shape, (2, 768))
+
+    def test_layer_mean_pooling(self):
+        """Test BERTLayer with mean pooling strategy."""
+        layer = BERTLayer(model_name=self.model_name, pooling="mean")
+        
+        with torch.no_grad():
+            embeddings = layer(self.sample_texts)
+        
+        self.assertEqual(embeddings.shape, (2, 768))
+
+    def test_layer_max_pooling(self):
+        """Test BERTLayer with max pooling strategy."""
+        layer = BERTLayer(model_name=self.model_name, pooling="max")
+        
+        with torch.no_grad():
+            embeddings = layer(self.sample_texts)
+        
+        self.assertEqual(embeddings.shape, (2, 768))
+
+    def test_layer_single_text_input(self):
+        """Test BERTLayer with single text string input."""
+        layer = BERTLayer(model_name=self.model_name)
+        
+        with torch.no_grad():
+            embeddings = layer("Patient presents with fever.")
+        
+        self.assertEqual(embeddings.shape, (1, 768))
+
+    def test_layer_return_attention(self):
+        """Test BERTLayer returning attention weights."""
+        layer = BERTLayer(model_name=self.model_name)
+        
+        with torch.no_grad():
+            embeddings, attentions = layer(self.sample_texts, return_attention=True)
+        
+        self.assertEqual(embeddings.shape, (2, 768))
+        self.assertIsNotNone(attentions)
+        # BERT-base has 12 layers
+        self.assertEqual(len(attentions), 12)
+
+    def test_layer_max_length_truncation(self):
+        """Test BERTLayer truncates long sequences."""
+        layer = BERTLayer(model_name=self.model_name, max_length=32)
+        
+        # Create a very long text
+        long_text = "word " * 100
+        
+        with torch.no_grad():
+            embeddings = layer(long_text)
+        
+        self.assertEqual(embeddings.shape, (1, 768))
+
+    def test_layer_output_size(self):
+        """Test get_output_size method."""
+        layer = BERTLayer(model_name=self.model_name)
+        
+        self.assertEqual(layer.get_output_size(), 768)
+
+
+class TestBERT(unittest.TestCase):
+    """Test cases for the BERT model."""
+
+    def setUp(self):
+        """Set up test data and model."""
+        self.samples = [
+            {
+                "patient_id": "patient-0",
+                "visit_id": "visit-0",
+                "clinical_note": "Patient presents with acute chest pain.",
+                "label": 1,
+            },
+            {
+                "patient_id": "patient-1",
+                "visit_id": "visit-1",
+                "clinical_note": "Annual wellness visit. No complaints.",
+                "label": 0,
+            },
+            {
+                "patient_id": "patient-2",
+                "visit_id": "visit-2",
+                "clinical_note": "Follow-up for hypertension management.",
+                "label": 0,
+            },
+        ]
+
+        self.input_schema: Dict[str, Union[str, Type[FeatureProcessor]]] = {
+            "clinical_note": "text"
+        }
+        self.output_schema: Dict[str, Union[str, Type[FeatureProcessor]]] = {
+            "label": "binary"
+        }
+
+        self.dataset = SampleDataset(
+            samples=self.samples,
+            input_schema=self.input_schema,
+            output_schema=self.output_schema,
+            dataset_name="test_clinical_notes",
+        )
+
+    def test_model_initialization(self):
+        """Test BERT model initialization with default parameters."""
+        model = BERT(dataset=self.dataset)
+        
+        self.assertIsInstance(model, BERT)
+        self.assertEqual(model.feature_key, "clinical_note")
+        self.assertEqual(model.label_key, "label")
+        self.assertEqual(model.pooling, "cls")
+        self.assertEqual(model.max_length, 512)
+
+    def test_model_initialization_with_biobert_alias(self):
+        """Test BERT model initialization with BioBERT alias."""
+        # Just test that alias resolution works without downloading
+        resolved_name = BIOMEDICAL_MODELS.get("biobert")
+        self.assertEqual(resolved_name, "dmis-lab/biobert-v1.1")
+        
+        resolved_name = BIOMEDICAL_MODELS.get("bert-base-uncased")
+        self.assertEqual(resolved_name, "bert-base-uncased")
+
+    def test_model_forward_pass(self):
+        """Test BERT forward pass produces correct output structure."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        
+        train_loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        data_batch = next(iter(train_loader))
+        
+        with torch.no_grad():
+            output = model(**data_batch)
+        
+        # Check output keys
+        self.assertIn("loss", output)
+        self.assertIn("y_prob", output)
+        self.assertIn("y_true", output)
+        self.assertIn("logit", output)
+        
+        # Check shapes
+        self.assertEqual(output["y_prob"].shape[0], 2)
+        self.assertEqual(output["y_true"].shape[0], 2)
+        self.assertEqual(output["logit"].shape[0], 2)
+        # Binary classification: output size is 1
+        self.assertEqual(output["y_prob"].shape[1], 1)
+        
+        # Check loss is scalar
+        self.assertEqual(output["loss"].dim(), 0)
+
+    def test_model_backward_pass(self):
+        """Test BERT backward pass computes gradients."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        
+        train_loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        data_batch = next(iter(train_loader))
+        
+        output = model(**data_batch)
+        output["loss"].backward()
+        
+        # Check that at least some parameters have gradients
+        has_gradient = any(
+            param.requires_grad and param.grad is not None
+            for param in model.parameters()
+        )
+        self.assertTrue(has_gradient, "No parameters have gradients after backward pass")
+
+    def test_model_with_embeddings(self):
+        """Test BERT returns embeddings when requested."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        
+        train_loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        data_batch = next(iter(train_loader))
+        data_batch["embed"] = True
+        
+        with torch.no_grad():
+            output = model(**data_batch)
+        
+        self.assertIn("embed", output)
+        self.assertEqual(output["embed"].shape[0], 2)
+        self.assertEqual(output["embed"].shape[1], model.encoder.hidden_size)
+
+    def test_model_encode_method(self):
+        """Test BERT encode method for getting embeddings."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        
+        texts = ["Test sentence one.", "Test sentence two."]
+        embeddings = model.encode(texts)
+        
+        self.assertEqual(embeddings.shape, (2, 768))
+
+    def test_model_with_classifier_hidden_dim(self):
+        """Test BERT with hidden layer in classifier head."""
+        model = BERT(
+            dataset=self.dataset,
+            model_name="bert-base-uncased",
+            classifier_hidden_dim=256,
+        )
+        
+        train_loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        data_batch = next(iter(train_loader))
+        
+        with torch.no_grad():
+            output = model(**data_batch)
+        
+        self.assertIn("loss", output)
+        self.assertEqual(output["y_prob"].shape[0], 2)
+
+    def test_model_with_different_pooling(self):
+        """Test BERT with different pooling strategies."""
+        for pooling in ["cls", "mean", "max"]:
+            with self.subTest(pooling=pooling):
+                model = BERT(
+                    dataset=self.dataset,
+                    model_name="bert-base-uncased",
+                    pooling=pooling,
+                )
+                
+                train_loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+                data_batch = next(iter(train_loader))
+                
+                with torch.no_grad():
+                    output = model(**data_batch)
+                
+                self.assertIn("loss", output)
+
+    def test_model_repr(self):
+        """Test BERT __repr__ method."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        repr_str = repr(model)
+        
+        self.assertIn("BERT", repr_str)
+        self.assertIn("bert-base-uncased", repr_str)
+
+
+class TestBERTMulticlass(unittest.TestCase):
+    """Test BERT model with multiclass classification."""
+
+    def setUp(self):
+        """Set up multiclass test data."""
+        self.samples = [
+            {
+                "patient_id": "patient-0",
+                "visit_id": "visit-0",
+                "transcription": "Cardiovascular examination reveals regular rhythm.",
+                "specialty": "Cardiology",
+            },
+            {
+                "patient_id": "patient-1",
+                "visit_id": "visit-1",
+                "transcription": "Patient presents with skin rash.",
+                "specialty": "Dermatology",
+            },
+            {
+                "patient_id": "patient-2",
+                "visit_id": "visit-2",
+                "transcription": "Neurological exam shows normal reflexes.",
+                "specialty": "Neurology",
+            },
+        ]
+
+        self.input_schema = {"transcription": "text"}
+        self.output_schema = {"specialty": "multiclass"}
+
+        self.dataset = SampleDataset(
+            samples=self.samples,
+            input_schema=self.input_schema,
+            output_schema=self.output_schema,
+            dataset_name="test_specialties",
+        )
+
+    def test_multiclass_forward_pass(self):
+        """Test BERT multiclass forward pass."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        
+        train_loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        data_batch = next(iter(train_loader))
+        
+        with torch.no_grad():
+            output = model(**data_batch)
+        
+        # Check output shape matches number of classes
+        num_classes = model.get_output_size()
+        self.assertEqual(output["y_prob"].shape[1], num_classes)
+        
+        # Check probabilities sum to 1 (softmax for multiclass)
+        prob_sums = output["y_prob"].sum(dim=1)
+        torch.testing.assert_close(
+            prob_sums,
+            torch.ones_like(prob_sums),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+
+class TestBERTMultilabel(unittest.TestCase):
+    """Test BERT model with multilabel classification."""
+
+    def setUp(self):
+        """Set up multilabel test data."""
+        # Multilabel expects lists of label names/indices
+        self.samples = [
+            {
+                "patient_id": "patient-0",
+                "visit_id": "visit-0",
+                "note": "Patient has diabetes and hypertension.",
+                "conditions": ["diabetes", "hypertension"],
+            },
+            {
+                "patient_id": "patient-1",
+                "visit_id": "visit-1",
+                "note": "Patient is obese with diabetes.",
+                "conditions": ["diabetes", "obesity"],
+            },
+            {
+                "patient_id": "patient-2",
+                "visit_id": "visit-2",
+                "note": "Patient has all three conditions.",
+                "conditions": ["diabetes", "hypertension", "obesity"],
+            },
+        ]
+
+        self.input_schema = {"note": "text"}
+        self.output_schema = {"conditions": "multilabel"}
+
+        self.dataset = SampleDataset(
+            samples=self.samples,
+            input_schema=self.input_schema,
+            output_schema=self.output_schema,
+            dataset_name="test_conditions",
+        )
+
+    def test_multilabel_forward_pass(self):
+        """Test BERT multilabel forward pass."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        
+        # Get the number of unique labels
+        num_labels = model.get_output_size()
+        
+        train_loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        data_batch = next(iter(train_loader))
+        
+        with torch.no_grad():
+            output = model(**data_batch)
+        
+        # Check output shape matches number of labels
+        self.assertEqual(output["y_prob"].shape[1], num_labels)
+        
+        # Check probabilities are between 0 and 1 (sigmoid for multilabel)
+        self.assertTrue(torch.all(output["y_prob"] >= 0))
+        self.assertTrue(torch.all(output["y_prob"] <= 1))
+
+
+class TestBERTParameterGroups(unittest.TestCase):
+    """Test BERT parameter grouping for different learning rates."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.samples = [
+            {
+                "patient_id": "patient-0",
+                "visit_id": "visit-0",
+                "text": "Test text.",
+                "label": 0,
+            },
+            {
+                "patient_id": "patient-1",
+                "visit_id": "visit-1",
+                "text": "Another test.",
+                "label": 1,
+            },
+        ]
+
+        self.dataset = SampleDataset(
+            samples=self.samples,
+            input_schema={"text": "text"},
+            output_schema={"label": "binary"},
+            dataset_name="test",
+        )
+
+    def test_get_encoder_parameters(self):
+        """Test getting encoder parameters separately."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        
+        encoder_params = list(model.get_encoder_parameters())
+        self.assertGreater(len(encoder_params), 0)
+
+    def test_get_classifier_parameters(self):
+        """Test getting classifier parameters separately."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        
+        classifier_params = list(model.get_classifier_parameters())
+        self.assertGreater(len(classifier_params), 0)
+
+    def test_differential_learning_rates(self):
+        """Test setting different learning rates for encoder and classifier."""
+        model = BERT(dataset=self.dataset, model_name="bert-base-uncased")
+        
+        # Create optimizer with different learning rates
+        optimizer = torch.optim.Adam([
+            {"params": model.get_encoder_parameters(), "lr": 2e-5},
+            {"params": model.get_classifier_parameters(), "lr": 1e-3},
+        ])
+        
+        # Verify optimizer has two parameter groups
+        self.assertEqual(len(optimizer.param_groups), 2)
+        self.assertEqual(optimizer.param_groups[0]["lr"], 2e-5)
+        self.assertEqual(optimizer.param_groups[1]["lr"], 1e-3)
+
+
+class TestBiomedicalModelAliases(unittest.TestCase):
+    """Test biomedical model alias resolution."""
+
+    def test_biobert_alias(self):
+        """Test BioBERT alias resolution."""
+        self.assertEqual(
+            BIOMEDICAL_MODELS["biobert"],
+            "dmis-lab/biobert-v1.1"
+        )
+
+    def test_bert_base_uncased_alias(self):
+        """Test bert-base-uncased alias resolution."""
+        self.assertEqual(
+            BIOMEDICAL_MODELS["bert-base-uncased"],
+            "bert-base-uncased"
+        )
+
+    def test_bert_base_cased_alias(self):
+        """Test bert-base-cased alias resolution."""
+        self.assertEqual(
+            BIOMEDICAL_MODELS["bert-base-cased"],
+            "bert-base-cased"
+        )
+
+    def test_all_aliases_are_strings(self):
+        """Test all aliases map to string model names."""
+        for alias, model_name in BIOMEDICAL_MODELS.items():
+            with self.subTest(alias=alias):
+                self.assertIsInstance(alias, str)
+                self.assertIsInstance(model_name, str)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary

This PR introduces BERT-based models for text classification tasks in healthcare applications, enabling fine-tuning of pre-trained language models on clinical and biomedical text data.

PyHealth currently lacks native support for initializing and fine-tuning BERT models for text classification. This contribution provides a production-ready BERT implementation with fine-tuning controls and BioBERT support.


## Supported Models

| Alias | HuggingFace Model |
|-------|------------------|
| `bert-base-uncased` | `bert-base-uncased` |
| `bert-base-cased` | `bert-base-cased` |
| `biobert` | `dmis-lab/biobert-v1.1` |

Any other HuggingFace BERT-compatible model can also be used by passing the full model name.

## Features

- **Pooling strategies**: `cls`, `mean`, `max`
- **Fine-tuning control**: Freeze entire encoder or N bottom layers
- **Differential learning rates**: Separate LR for encoder vs classifier
- **Task modes**: Binary, multiclass, multilabel classification


This PR is submitted by the following group of UIUC students :

Hung Ngo (hungngo2)
Hao Doan (haodoan2)
