### PR TITLE
Submitting the ability to use SleepQA datasets as PyHealth datasets.

### DIFF
--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -62,6 +62,8 @@ from .mimic4 import MIMIC4CXRDataset, MIMIC4Dataset, MIMIC4EHRDataset, MIMIC4Not
 from .mimicextract import MIMICExtractDataset
 from .omop import OMOPDataset
 from .sample_dataset import SampleDataset
+from .sleepqa_dpr_dataset import SleepQADPRDataset
+from .sleepqa_reader_dataset import SleepQAReaderDataset
 from .shhs import SHHSDataset
 from .sleepedf import SleepEDFDataset
 from .bmd_hs import BMDHSDataset

--- a/pyhealth/datasets/sleepqa_dpr_dataset.py
+++ b/pyhealth/datasets/sleepqa_dpr_dataset.py
@@ -1,0 +1,186 @@
+"""
+Author(s): Ezra Hieh, Jeffrey Lee, Venkatesh Venkataramanan
+NetID(s): iezralh2, jl187, vv33
+Paper: SleepQA: Question Answering for Sleep and Health Knowledge
+Paper Link: https://github.com/IvaBojic/SleepQA
+Description: SleepQA Reader dataset compatible with PyHealth v1.1.6
+"""
+
+# pyhealth/datasets/sleepqa_dpr_dataset.py
+"""SleepQA DPR dataset.
+This module provides a PyHealth dataset wrapper for DPR-style SleepQA data.
+The goal of this dataset is to make it easy to use SleepQA for training
+bi-encoder retrievers such as Dense Passage Retrieval (DPR). Each sample
+in the dataset corresponds to a single question and its associated
+positive and negative contexts.
+The expected JSON format follows the standard DPR style:
+    [
+      {
+        "id": "0",  # optional; if missing, a sequential id will be used
+        "question": "what can lack of sleep in children impact?",
+        "answers": [
+          "academic performance, behavior, and mood."
+        ],
+        "positive_ctxs": [
+          {
+            "title": "is your smartphone affecting your sleep",
+            "text": "..."
+          }
+        ],
+        "negative_ctxs": [
+          {
+            "title": "how does lack of sleep effect cognitive impairment",
+            "text": "..."
+          }
+        ]
+      },
+      ...
+    ]
+This module exposes :class:`SleepQADPRDataset`, a subclass of
+:class:`pyhealth.datasets.SampleDataset`, which:
+Loads the JSON file.
+Builds one sample per question.
+Preserves all DPR fields (question, answers, positive_ctxs, negative_ctxs).
+Uses the ``text`` processor for the question text and the ``raw`` processor
+  for everything else, so downstream DPR models can implement their own
+  tokenization and loss.
+Example:
+    >>> from pyhealth.datasets import SleepQADPRDataset
+    >>> dataset = SleepQADPRDataset(
+    ...     root="path/to/data",
+    ...     split="train",
+    ... )
+    >>> sample = dataset[0]
+    >>> sample["question"]
+    'what can lack of sleep in children impact?'
+    >>> len(sample["positive_ctxs"]) > 0
+    True
+Typical DPR usage:
+Question encoder consumes ``sample["question"]``.
+Context encoder consumes the ``"text"`` field inside each context in
+      ``sample["positive_ctxs"]`` and ``sample["negative_ctxs"]``.
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from pyhealth.datasets.sample_dataset import SampleDataset
+class SleepQADPRDataset(SampleDataset):
+    """DPR-style SleepQA dataset.
+    This dataset is designed specifically for training DPR-style bi-encoder
+    retrievers on the SleepQA data. Each sample corresponds to one question
+    together with its positive and negative contexts.
+    The class builds on :class:`pyhealth.datasets.SampleDataset` to produce
+    processed samples with appropriate feature processors:
+``question``: processed with the ``text`` processor.
+``answers``: passed through as-is using the ``raw`` processor.
+``positive_ctxs``: passed through as-is using the ``raw`` processor.
+``negative_ctxs``: passed through as-is using the ``raw`` processor.
+    A "patient" in this dataset corresponds to a question, and the
+    ``patient_id`` as well as the ``record_id`` are set to the question id.
+    This keeps compatibility with utilities that expect patient/record maps
+    without forcing an EHR structure.
+    Args:
+        root: Root directory where the SleepQA JSON file is stored.
+        split: String identifying the split, such as "train", "dev", or
+            "test". The default is "train".
+        json_filename: Optional explicit filename. If not provided, it will
+            default to ``f"sleepqa_retriever_{split}.json"``.
+        dataset_name: Name of the dataset. Defaults to "SleepQADPR".
+        task_name: Name of the task. Defaults to "dpr_retrieval".
+    Raises:
+        FileNotFoundError: If the JSON file cannot be found at the resolved
+            path.
+        ValueError: If the JSON file does not contain a list of entries.
+    """
+    def __init__(
+        self,
+        root: Union[str, Path],
+        split: str = "train",
+        json_filename: Optional[str] = None,
+        dataset_name: str = "SleepQADPR",
+        task_name: str = "dpr_retrieval",
+    ) -> None:
+        self.root = Path(root)
+        self.split = split
+        if json_filename is None:
+            json_filename = f"sleepqa_retriever_{split}.json"
+        self.json_path = self.root / json_filename
+        samples = self._load_samples(self.json_path)
+        input_schema = {
+            "question": "text",
+            "answers": "raw",
+            "positive_ctxs": "raw",
+            "negative_ctxs": "raw",
+            "question_id": "raw",
+            "patient_id": "raw",
+            "record_id": "raw",
+        }
+        # DPR does not have scalar labels in the classic formulation.
+        output_schema: Dict[str, Any] = {}
+        super().__init__(
+            samples=samples,
+            input_schema=input_schema,
+            output_schema=output_schema,
+            dataset_name=dataset_name,
+            task_name=task_name,
+        )
+    @staticmethod
+    def _load_samples(json_path: Path) -> List[Dict[str, Any]]:
+        """Load DPR-style SleepQA JSON into a list of sample dicts.
+        This helper reads the JSON file and converts each entry into a
+        standardized dictionary that can be consumed by
+        :class:`pyhealth.datasets.SampleDataset`.
+        Each output sample has the following keys:
+``patient_id``: string identifier for the "patient" (question).
+``record_id``: string identifier for the record (equal to
+          ``patient_id``).
+``question_id``: string identifier mirroring the original entry id.
+``question``: question text.
+``answers``: list of answer strings.
+``positive_ctxs``: list of context dictionaries.
+``negative_ctxs``: list of context dictionaries.
+        Args:
+            json_path: Path to the JSON file with DPR-style SleepQA data.
+        Returns:
+            A list of sample dictionaries ready to be passed into
+            :class:`pyhealth.datasets.SampleDataset`.
+        Raises:
+            FileNotFoundError: If the JSON file does not exist.
+            ValueError: If the top-level JSON object is not a list.
+        """
+        if not json_path.exists():
+            raise FileNotFoundError(
+                f"SleepQA JSON file not found at: {json_path}"
+            )
+        with json_path.open("r", encoding="utf-8") as json_file:
+            raw_data = json.load(json_file)
+        if not isinstance(raw_data, list):
+            raise ValueError(
+                "SleepQA JSON must contain a list of entries, "
+                f"got type {type(raw_data)!r}"
+            )
+        samples: List[Dict[str, Any]] = []
+        for index, entry in enumerate(raw_data):
+            # Determine question id: use explicit "id" if present, otherwise
+            # fall back to a zero-based index.
+            entry_id = entry.get("id")
+            if entry_id is None:
+                entry_id = str(index)
+            else:
+                entry_id = str(entry_id)
+            question = entry.get("question", "")
+            answers = entry.get("answers", [])
+            positive_ctxs = entry.get("positive_ctxs", [])
+            negative_ctxs = entry.get("negative_ctxs", [])
+            sample: Dict[str, Any] = {
+                "patient_id": f"q_{entry_id}",
+                "record_id": f"q_{entry_id}",
+                "question_id": entry_id,
+                "question": question,
+                "answers": answers,
+                "positive_ctxs": positive_ctxs,
+                "negative_ctxs": negative_ctxs,
+            }
+            samples.append(sample)
+        return samples

--- a/pyhealth/datasets/sleepqa_reader_dataset.py
+++ b/pyhealth/datasets/sleepqa_reader_dataset.py
@@ -1,0 +1,157 @@
+"""
+Author(s): Ezra Hieh, Jeffrey Lee, Venkatesh Venkataramanan
+NetID(s): iezralh2, jl187, vv33
+Paper: SleepQA: Question Answering for Sleep and Health Knowledge
+Paper Link: https://github.com/IvaBojic/SleepQA
+Description: SleepQA Reader dataset compatible with PyHealth v1.1.6
+"""
+
+"""This module exposes :class:`SleepQAReaderDataset`, a subclass of
+:class:`pyhealth.datasets.SampleDataset`, which:
+Loads the JSON file.
+Builds one sample per QA instance.
+Preserves the DPR-style reader fields:
+  ``question``, ``answers``, ``ctxs``.
+Example:
+    >>> from pyhealth.datasets import SleepQAReaderDataset
+    >>> dataset = SleepQAReaderDataset(
+    ...     root="path/to/data",
+    ...     split="train",
+    ... )
+    >>> sample = dataset[0]
+    >>> sample["question"]
+    'what can lack of sleep in children impact?'
+    >>> len(sample["ctxs"]) > 0
+    True
+Typical reader usage:
+Model consumes ``sample["question"]`` and the ``"text"`` inside each
+      context in ``sample["ctxs"]``.
+Evaluation compares predictions against ``sample["answers"]`` and
+      optionally uses ``ctx["has_answer"]`` for supervision.
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from pyhealth.datasets.sample_dataset import SampleDataset
+class SleepQAReaderDataset(SampleDataset):
+    """Reader-style SleepQA dataset using the official SleepQA schema.
+    This dataset is designed for training DPR-style readers using the SleepQA
+    data. Each sample corresponds to one question with:
+``question``: the question text.
+``answers``: a list of reference answer strings.
+``ctxs``: a list of context dictionaries, each containing keys such as
+      ``id``, ``title``, ``text``, ``score``, and ``has_answer``.
+    The class builds on :class:`pyhealth.datasets.SampleDataset` to produce
+    processed samples with appropriate feature processors:
+``question``: processed with the ``text`` processor.
+``answers``: passed through as-is using the ``raw`` processor.
+``ctxs``: passed through as-is using the ``raw`` processor.
+``question_id``: passed through as-is using the ``raw`` processor.
+``patient_id`` and ``record_id``: passed through as-is using the
+      ``raw`` processor.
+    A "patient" in this dataset corresponds to a question, and the
+    ``patient_id`` as well as the ``record_id`` are set to a stable question
+    identifier. This keeps compatibility with utilities that expect
+    patient/record maps without forcing an EHR structure.
+    Args:
+        root: Root directory where the SleepQA JSON file is stored.
+        split: String identifying the split, such as "train", "dev", or
+            "test". The default is "train".
+        json_filename: Optional explicit filename. If not provided, it will
+            default to ``f"sleepqa_reader_{split}.json"``.
+        dataset_name: Name of the dataset. Defaults to "SleepQAReader".
+        task_name: Name of the task. Defaults to "reader_qa".
+    Raises:
+        FileNotFoundError: If the JSON file cannot be found at the resolved
+            path.
+        ValueError: If the JSON file does not contain a list of entries.
+    """
+    def __init__(
+        self,
+        root: Union[str, Path],
+        split: str = "train",
+        json_filename: Optional[str] = None,
+        dataset_name: str = "SleepQAReader",
+        task_name: str = "reader_qa",
+    ) -> None:
+        self.root = Path(root)
+        self.split = split
+        if json_filename is None:
+            json_filename = f"sleepqa_reader_{split}.json"
+        self.json_path = self.root / json_filename
+        samples = self._load_samples(self.json_path)
+        input_schema = {
+            "question": "text",
+            "answers": "raw",
+            "ctxs": "raw",
+            "question_id": "raw",
+            "patient_id": "raw",
+            "record_id": "raw",
+        }
+        # Reader evaluation is usually based on string metrics (EM/F1) rather
+        # than scalar labels, so we keep output_schema empty here.
+        output_schema: Dict[str, Any] = {}
+        super().__init__(
+            samples=samples,
+            input_schema=input_schema,
+            output_schema=output_schema,
+            dataset_name=dataset_name,
+            task_name=task_name,
+        )
+    @staticmethod
+    def _load_samples(json_path: Path) -> List[Dict[str, Any]]:
+        """Load SleepQA reader JSON into a list of sample dicts.
+        This helper reads the JSON file and converts each entry into a
+        standardized dictionary that can be consumed by
+        :class:`pyhealth.datasets.SampleDataset`.
+        Each output sample has the following keys:
+``patient_id``: string identifier for the "patient" (question).
+``record_id``: string identifier for the record (equal to
+          ``patient_id``).
+``question_id``: string identifier derived from an explicit
+          ``id`` field when present or from the zero-based index.
+``question``: question text.
+``answers``: list of answer strings.
+``ctxs``: list of context dictionaries, each including keys such as
+          ``id``, ``title``, ``text``, ``score``, and ``has_answer``.
+        Args:
+            json_path: Path to the JSON file with SleepQA reader data.
+        Returns:
+            A list of sample dictionaries ready to be passed into
+            :class:`pyhealth.datasets.SampleDataset`.
+        Raises:
+            FileNotFoundError: If the JSON file does not exist.
+            ValueError: If the top-level JSON object is not a list.
+        """
+        if not json_path.exists():
+            raise FileNotFoundError(
+                f"SleepQA reader JSON file not found at: {json_path}"
+            )
+        with json_path.open("r", encoding="utf-8") as json_file:
+            raw_data = json.load(json_file)
+        if not isinstance(raw_data, list):
+            raise ValueError(
+                "SleepQA reader JSON must contain a list of entries, "
+                f"got type {type(raw_data)!r}"
+            )
+        samples: List[Dict[str, Any]] = []
+        for index, entry in enumerate(raw_data):
+            entry_id = entry.get("id")
+            if entry_id is None:
+                entry_id = str(index)
+            else:
+                entry_id = str(entry_id)
+            question = entry.get("question", "")
+            answers = entry.get("answers", [])
+            ctxs = entry.get("ctxs", [])
+            sample: Dict[str, Any] = {
+                "patient_id": f"q_{entry_id}",
+                "record_id": f"q_{entry_id}",
+                "question_id": entry_id,
+                "question": question,
+                "answers": answers,
+                "ctxs": ctxs,
+            }
+            samples.append(sample)
+        return samples

--- a/tests/datasets/test_sleepqa_dpr_dataset.py
+++ b/tests/datasets/test_sleepqa_dpr_dataset.py
@@ -1,0 +1,103 @@
+# tests/datasets/test_sleepqa_dpr_dataset.py
+# -*- coding: utf-8 -*-
+"""Tests for the SleepQADPRDataset."""
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+import pytest
+from pyhealth.datasets import SleepQADPRDataset
+from pyhealth.processors import RawProcessor, TextProcessor
+def _write_sleepqa_json(tmp_path: Path) -> Path:
+    """Write a small DPR-style SleepQA JSON file for testing.
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    Returns:
+        Path to the created JSON file.
+    """
+    data: List[Dict[str, Any]] = [
+        {
+            "id": "42",
+            "question": "what can lack of sleep in children impact?",
+            "answers": ["academic performance, behavior, and mood."],
+            "positive_ctxs": [
+                {
+                    "title": "is your smartphone affecting your sleep",
+                    "text": "lack of sleep in children can impact academic "
+                    "performance, behavior, and mood.",
+                }
+            ],
+            "negative_ctxs": [
+                {
+                    "title": "how does lack of sleep effect "
+                    "cognitive impairment",
+                    "text": "teens are considered to be especially high-risk "
+                    "for detrimental effects of poor sleep.",
+                }
+            ],
+        }
+    ]
+    json_path = tmp_path / "sleepqa_retriever_train.json"
+    json_path.write_text(
+        json.dumps(data),
+        encoding="utf-8",
+    )
+    return json_path
+def test_sleepqa_dpr_dataset_loads_and_preserves_fields(tmp_path: Path) -> None:
+    """Test that SleepQADPRDataset loads data and preserves DPR structure."""
+    _write_sleepqa_json(tmp_path)
+    dataset = SleepQADPRDataset(root=tmp_path, split="train")
+    assert len(dataset) == 1
+    sample = dataset[0]
+    # Basic keys should be present.
+    for key in (
+        "patient_id",
+        "record_id",
+        "question_id",
+        "question",
+        "answers",
+        "positive_ctxs",
+        "negative_ctxs",
+    ):
+        assert key in sample, f"Missing expected key {key!r} in sample"
+    # IDs should be consistent.
+    assert sample["patient_id"] == "q_42"
+    assert sample["record_id"] == "q_42"
+    assert sample["question_id"] == "42"
+    # Question and answers should match the JSON.
+    assert (
+        sample["question"]
+        == "what can lack of sleep in children impact?"
+    )
+    assert sample["answers"] == ["academic performance, behavior, and mood."]
+    # Positive and negative contexts should be lists with one element each.
+    assert isinstance(sample["positive_ctxs"], list)
+    assert isinstance(sample["negative_ctxs"], list)
+    assert len(sample["positive_ctxs"]) == 1
+    assert len(sample["negative_ctxs"]) == 1
+    pos_ctx = sample["positive_ctxs"][0]
+    neg_ctx = sample["negative_ctxs"][0]
+    assert "title" in pos_ctx and "text" in pos_ctx
+    assert "title" in neg_ctx and "text" in neg_ctx
+    assert "lack of sleep in children can impact" in pos_ctx["text"]
+def test_sleepqa_dpr_dataset_processors(tmp_path: Path) -> None:
+    """Test that SleepQADPRDataset configures processors correctly."""
+    _write_sleepqa_json(tmp_path)
+    dataset = SleepQADPRDataset(root=tmp_path, split="train")
+    # Question should use TextProcessor.
+    question_processor = dataset.input_processors["question"]
+    assert isinstance(question_processor, TextProcessor)
+    # All other DPR fields should use RawProcessor.
+    for key in ("answers", "positive_ctxs", "negative_ctxs"):
+        processor = dataset.input_processors[key]
+        assert isinstance(
+            processor,
+            RawProcessor,
+        ), f"Expected RawProcessor for key {key!r}"
+    # ID-related fields should also be raw.
+    for key in ("patient_id", "record_id", "question_id"):
+        processor = dataset.input_processors[key]
+        assert isinstance(
+            processor,
+            RawProcessor,
+        ), f"Expected RawProcessor for key {key!r}"

--- a/tests/datasets/test_sleepqa_reader_dataset.py
+++ b/tests/datasets/test_sleepqa_reader_dataset.py
@@ -1,0 +1,139 @@
+# tests/datasets/test_sleepqa_reader_dataset.py
+# -*- coding: utf-8 -*-
+"""Tests for the SleepQAReaderDataset."""
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+from pyhealth.datasets import SleepQAReaderDataset
+from pyhealth.processors import RawProcessor, TextProcessor
+def _write_sleepqa_reader_json(tmp_path: Path) -> Path:
+    """Write a small SleepQA reader JSON file for testing.
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    Returns:
+        Path to the created JSON file.
+    """
+    data: List[Dict[str, Any]] = [
+        {
+            "question": "what can lack of sleep in children impact?",
+            "answers": [
+                "academic performance, behavior, and mood."
+            ],
+            "ctxs": [
+                {
+                    "id": "sleep:126",
+                    "title": "is your smartphone affecting your sleep",
+                    "text": (
+                        "children's eyes are even more sensitive to light, "
+                        "and the blue light from screens can delay "
+                        "melatonin production by up to two times as much for "
+                        "children compared with adults. this can lead to "
+                        "insomnia and poor quality of sleep, which can be "
+                        "particularly harmful for children. quality rest is "
+                        "crucial for children as they grow and develop. lack "
+                        "of sleep in children can impact academic "
+                        "performance, behavior, and mood. poor sleep in "
+                        "children has also been associated with health "
+                        "issues, such as obesity and depression."
+                    ),
+                    "score": "103.232",
+                    "has_answer": True,
+                }
+            ],
+        },
+        {
+            "question": (
+                "what is the purpose of the light sensor in the watch?"
+            ),
+            "answers": [
+                "can reveal whether someone's sleep problems might be due "
+                "to an overly bright bedroom or insufficient light during "
+                "the day"
+            ],
+            "ctxs": [
+                {
+                    "id": "sleep:909",
+                    "title": "how is actigraphy used to evaluate sleep",
+                    "text": (
+                        "the watch may also have a light sensor, which can "
+                        "reveal whether someone's sleep problems might be "
+                        "due to an overly bright bedroom or insufficient "
+                        "light during the day."
+                    ),
+                    "score": "103.232",
+                    "has_answer": True,
+                }
+            ],
+        },
+    ]
+    json_path = tmp_path / "sleepqa_reader_train.json"
+    json_path.write_text(
+        json.dumps(data),
+        encoding="utf-8",
+    )
+    return json_path
+def test_sleepqa_reader_dataset_loads_and_preserves_fields(
+    tmp_path: Path,
+) -> None:
+    """Test that SleepQAReaderDataset loads data and preserves structure."""
+    _write_sleepqa_reader_json(tmp_path)
+    dataset = SleepQAReaderDataset(root=tmp_path, split="train")
+    assert len(dataset) == 2
+    first = dataset[0]
+    second = dataset[1]
+    # Basic keys should be present.
+    for sample in (first, second):
+        for key in (
+            "patient_id",
+            "record_id",
+            "question_id",
+            "question",
+            "answers",
+            "ctxs",
+        ):
+            assert key in sample, f"Missing expected key {key!r} in sample"
+    # IDs should be consistent.
+    assert first["patient_id"] == "q_0"
+    assert first["record_id"] == "q_0"
+    assert first["question_id"] == "0"
+    assert second["patient_id"] == "q_1"
+    assert second["record_id"] == "q_1"
+    assert second["question_id"] == "1"
+    # Questions and answers should match.
+    assert (
+        first["question"]
+        == "what can lack of sleep in children impact?"
+    )
+    assert (
+        second["question"]
+        == "what is the purpose of the light sensor in the watch?"
+    )
+    assert first["answers"] == [
+        "academic performance, behavior, and mood."
+    ]
+    assert (
+        "overly bright bedroom" in second["answers"][0]
+    )
+    # Ctxs should be lists with expected fields.
+    for sample in (first, second):
+        assert isinstance(sample["ctxs"], list)
+        assert len(sample["ctxs"]) == 1
+        ctx = sample["ctxs"][0]
+        for key in ("id", "title", "text", "score", "has_answer"):
+            assert key in ctx, f"Missing key {key!r} in ctx"
+        assert isinstance(ctx["has_answer"], bool)
+def test_sleepqa_reader_dataset_processors(tmp_path: Path) -> None:
+    """Test that SleepQAReaderDataset configures processors correctly."""
+    _write_sleepqa_reader_json(tmp_path)
+    dataset = SleepQAReaderDataset(root=tmp_path, split="train")
+    # Question should use TextProcessor.
+    question_processor = dataset.input_processors["question"]
+    assert isinstance(question_processor, TextProcessor)
+    # Other fields should use RawProcessor.
+    for key in ("answers", "ctxs", "patient_id", "record_id", "question_id"):
+        processor = dataset.input_processors[key]
+        assert isinstance(
+            processor,
+            RawProcessor,
+        ), f"Expected RawProcessor for key {key!r}"


### PR DESCRIPTION
Contributor netids are: vv33, ezralh2 and jl187. The SleepQA paper trains the Facebook DPR framework to train an bi-encoder and a reader model. Our submission includes two classes: one for use to load training data for use by bi-encoder and the second one for use by the reader. We have also included test cases for validating the classes. The code and associated test cases were generated using LLM's. While the assignment talked about extending from BaseDataset object, we chose the SampleDataset object as the sleepqa dataset is more amenable to this object. The BaseDataset object has deep notions of patients, events which doesn't blend well with the training data for SleepQA.