### PR TITLE
Add SOZStimulationDataset for Seizure Onset Zone Localization from SPES EEG

### DIFF
--- a/examples/soz_stimulation_example.py
+++ b/examples/soz_stimulation_example.py
@@ -1,0 +1,63 @@
+# examples/soz_stimulation_example.py
+
+from torch.utils.data import DataLoader
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from pyhealth.datasets import SOZStimulationDataset
+
+
+class SimpleSOZCNN(nn.Module):
+    """Simple 1D CNN for SOZ classification from stimulation-locked EEG."""
+    def __init__(self, in_channels: int, n_classes: int = 2):
+        super().__init__()
+        self.conv1 = nn.Conv1d(in_channels, 32, kernel_size=7, padding=3)
+        self.bn1 = nn.BatchNorm1d(32)
+        self.relu = nn.ReLU()
+        self.pool = nn.AdaptiveAvgPool1d(1)
+        self.fc = nn.Linear(32, n_classes)
+
+    def forward(self, x_stim):
+        # x_stim: [B, C, T]
+        x = self.conv1(x_stim)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.pool(x)  # [B, 32, 1]
+        x = x.squeeze(-1) # [B, 32]
+        return self.fc(x)
+
+
+def main():
+    root = "data/soz_spes_processed"
+    train_ds = SOZStimulationDataset(root=root, split="train")
+    train_loader = DataLoader(train_ds, batch_size=16, shuffle=True)
+
+    first_sample, _ = train_ds[0]
+    in_channels = first_sample["X_stim"].shape[0]
+
+    model = SimpleSOZCNN(in_channels=in_channels, n_classes=2)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=1e-3)
+
+    for epoch in range(2):  # toy run
+        model.train()
+        total_loss = 0.0
+        for features, labels in train_loader:
+            x_stim = features["X_stim"]         # [B, C, T]
+            labels = torch.as_tensor(labels, dtype=torch.long)
+
+            optimizer.zero_grad()
+            logits = model(x_stim)
+            loss = criterion(logits, labels)
+            loss.backward()
+            optimizer.step()
+
+            total_loss += loss.item() * x_stim.size(0)
+
+        avg_loss = total_loss / len(train_ds)
+        print(f"Epoch {epoch+1}: loss = {avg_loss:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -84,3 +84,4 @@ from .utils import (
     load_processors,
     save_processors,
 )
+from .soz_stimulation import SOZStimulationDataset

--- a/pyhealth/datasets/soz_stimulation.py
+++ b/pyhealth/datasets/soz_stimulation.py
@@ -1,0 +1,102 @@
+# pyhealth/datasets/soz_stimulation.py
+
+from typing import Dict, Tuple, Optional
+import os
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+class SOZStimulationDataset(Dataset):
+    r"""
+    SOZStimulationDataset
+
+    Dataset for seizure onset zone (SOZ) localization using single-pulse
+    electrical stimulation (SPES) EEG responses, based on the paper:
+
+    Norris, J., Chari, A., van Blooijs, D., Cooray, G., Friston, K.,
+    Tisdall, M., & Rosch, R. (2024). Localising the Seizure Onset Zone
+    from Single-Pulse Electrical Stimulation Responses with a CNN
+    Transformer. arXiv preprint arXiv:2403.20324.
+    https://doi.org/10.48550/arXiv.2403.20324
+
+
+    This class is designed to work with preprocessed numpy arrays generated
+    from the original BIDS EEG dataset. We do NOT ship the raw or preprocessed
+    data with PyHealth. Instead, users are expected to:
+
+    1. Obtain access to the original SPES/BIDS dataset.
+    2. Run a preprocessing script (e.g., from the reproduction repo) that
+       saves numpy files in a format like:
+
+        root/
+          train_X_stim.npy        # shape: [N_train, C_stim, T]
+          train_y.npy             # shape: [N_train]
+
+          val_X_stim.npy
+          val_y.npy
+
+          test_X_stim.npy
+          test_y.npy
+
+    Each sample consists of:
+        - "X_stim": stimulation-locked EEG response segment, shape [C_stim, T]
+        - label: int in {0, 1}, indicating SOZ vs non-SOZ.
+
+    Args:
+        root: Root directory containing preprocessed numpy arrays.
+        split: One of {"train", "val", "test"}.
+        device: Optional torch.device to move tensors to on __getitem__.
+    """
+
+    def __init__(
+        self,
+        root: str,
+        split: str = "train",
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__()
+        assert split in {"train", "val", "test"}, f"Invalid split: {split}"
+
+        self.root = root
+        self.split = split
+        self.device = device
+
+        stim_path = os.path.join(root, f"{split}_X_stim.npy")
+        y_path = os.path.join(root, f"{split}_y.npy")
+
+        if not os.path.exists(stim_path):
+            raise FileNotFoundError(f"Cannot find {stim_path}")
+        if not os.path.exists(y_path):
+            raise FileNotFoundError(f"Cannot find {y_path}")
+
+        self.X_stim = np.load(stim_path)  # [N, C_stim, T]
+        self.y = np.load(y_path)         # [N]
+
+        if len(self.X_stim) != len(self.y):
+            raise ValueError("X_stim and y must have the same number of samples")
+
+    def __len__(self) -> int:
+        return len(self.y)
+
+    def __getitem__(self, idx: int) -> Tuple[Dict[str, torch.Tensor], int]:
+        x_stim = torch.as_tensor(self.X_stim[idx], dtype=torch.float32)
+        label = int(self.y[idx])
+
+        sample: Dict[str, torch.Tensor] = {"X_stim": x_stim}
+
+        if self.device is not None:
+            sample = {k: v.to(self.device) for k, v in sample.items()}
+
+        return sample, label
+
+
+if __name__ == "__main__":
+    # Simple smoke test (requires real preprocessed data under this folder)
+    ds = SOZStimulationDataset(root="data/soz_spes_processed", split="train")
+    print(f"Num samples: {len(ds)}")
+    x, y = ds[0]
+    print("Keys:", x.keys())
+    print("X_stim shape:", x["X_stim"].shape)
+    print("Label:", y)

--- a/tests/core/test_soz_stimulation_dataset.py
+++ b/tests/core/test_soz_stimulation_dataset.py
@@ -1,0 +1,30 @@
+# tests/core/test_soz_stimulation_dataset.py
+
+import os
+import numpy as np
+import torch
+
+from pyhealth.datasets import SOZStimulationDataset
+
+
+def test_soz_stimulation_dataset_loading(tmp_path):
+    # Create temp directory with fake data
+    root = tmp_path / "soz_spes_processed"
+    os.makedirs(root, exist_ok=True)
+
+    # Fake data
+    N, C, T = 10, 4, 100
+    X_stim = np.random.randn(N, C, T).astype("float32")
+    y = np.random.randint(0, 2, size=(N,)).astype("int64")
+
+    np.save(root / "train_X_stim.npy", X_stim)
+    np.save(root / "train_y.npy", y)
+
+    # Load dataset
+    ds = SOZStimulationDataset(root=str(root), split="train")
+    assert len(ds) == N
+
+    sample, label = ds[0]
+    assert "X_stim" in sample
+    assert isinstance(sample["X_stim"], torch.Tensor)
+    assert isinstance(label, int)


### PR DESCRIPTION
**Contributors**:
Vineetha Gurrala, vgurr4
Clay Douglas, ckd6

**Type**: Dataset Contribution

**Description**:
This PR introduces SOZStimulationDataset, a PyTorch-compatible dataset class for single-pulse electrical stimulation (SPES) EEG recordings used for seizure onset zone (SOZ) localization, replicating the dataset structure used in our reproducibility project:

**Reproducing:**
SAMIL: Spatial Attention-based Multi-modal Integration for Localizing Seizure Onset Zones from Single-pulse Electrical Stimulation
This dataset class does not include raw EEG data due to size/IRB constraints, but instead provides a standardized loading interface compatible with the preprocessed numpy outputs typically generated in SPES-based epilepsy research pipelines.


**The expected input format is:**
root/
 ├── train_X_stim.npy      # [N_train, C, T]
 ├── train_y.npy           # [N_train]
 ├── val_X_stim.npy
 ├── val_y.npy
 ├── test_X_stim.npy
 └── test_y.npy


**Each sample returns:**
{"X_stim": Tensor[C, T]}, label

Where label ∈ {0,1} corresponds to SOZ vs non-SOZ stimulation sites.

**The PR also includes:**
Example usage script in examples/soz_stimulation_example.py
Minimal test case validating dataset load behavior
Documentation describing expected data format and reference to the original study

**Usage**:
from pyhealth.datasets import SOZStimulationDataset
ds = SOZStimulationDataset(root="data/soz_spes_processed", split="train")
x, y = ds[0]
print(x["X_stim"].shape, y)