### PR TITLE
add ann pt dataset to pyhealth

### DIFF
--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -58,7 +58,13 @@ from .eicu import eICUDataset
 from .isruc import ISRUCDataset
 from .medical_transcriptions import MedicalTranscriptionsDataset
 from .mimic3 import MIMIC3Dataset
-from .mimic4 import MIMIC4CXRDataset, MIMIC4Dataset, MIMIC4EHRDataset, MIMIC4NoteDataset
+from .mimic4 import (
+    MIMIC4CXRDataset,
+    MIMIC4Dataset,
+    MIMIC4EHRDataset,
+    MIMIC4NoteDataset,
+    MIMIC4EDDataset,
+)
 from .mimicextract import MIMICExtractDataset
 from .omop import OMOPDataset
 from .sample_dataset import SampleDataset
@@ -67,6 +73,7 @@ from .sleepedf import SleepEDFDataset
 from .bmd_hs import BMDHSDataset
 from .support2 import Support2Dataset
 from .tcga_prad import TCGAPRADDataset
+from .ann_pt_summ import ANNPTSummDataset
 from .splitter import (
     split_by_patient,
     split_by_patient_conformal,

--- a/pyhealth/datasets/ann_pt_summ.py
+++ b/pyhealth/datasets/ann_pt_summ.py
@@ -1,0 +1,60 @@
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from .base_dataset import BaseDataset
+
+logger = logging.getLogger(__name__)
+
+
+class ANNPTSummDataset(BaseDataset):
+    """Annotated patient summary dataset from PhysioNet's ann-pt-summ release.
+
+    Each table corresponds to a newline-delimited JSON file containing at least
+    the discharge ``text`` (context) and ``summary`` fields, plus optional
+    ``labels`` for hallucination spans or other metadata.
+
+    Args:
+        root: Root directory containing the ann-pt-summ release.
+        tables: List of table names defined in ``ann_pt_summ.yaml``.
+            Defaults to ``["mimic_di_bhc_all"]`` (all Brief Hospital Course
+            summaries).
+        dataset_name: Optional dataset name override.
+        config_path: Optional path to the dataset config yaml.
+        **kwargs: Passed to :class:`BaseDataset`.
+
+    Examples:
+        >>> from pyhealth.datasets import ANNPTSummDataset
+        >>> dataset = ANNPTSummDataset(
+        ...     root="/tmp/ann-pt-summ/1.0.1",
+        ...     tables=["hallucinations_mimic_di"],
+        ... )
+        >>> dataset.stats()
+    """
+
+    def __init__(
+        self,
+        root: str,
+        tables: Optional[List[str]] = None,
+        dataset_name: Optional[str] = None,
+        config_path: Optional[str] = None,
+        **kwargs,
+    ):
+        if config_path is None:
+            config_path = Path(__file__).parent / "configs" / "ann_pt_summ.yaml"
+            logger.info("Using default ann-pt-summ config: %s", config_path)
+
+        default_tables = tables or ["mimic_di_bhc_all"]
+
+        super().__init__(
+            root=root,
+            tables=default_tables,
+            dataset_name=dataset_name or "ann_pt_summ",
+            config_path=str(config_path),
+            **kwargs,
+        )
+
+    @property
+    def default_task(self):
+        """Dataset currently ships without a default downstream task."""
+        return None

--- a/pyhealth/datasets/configs/ann_pt_summ.yaml
+++ b/pyhealth/datasets/configs/ann_pt_summ.yaml
@@ -1,0 +1,162 @@
+version: "1.0"
+tables:
+  mimic_di_all:
+    file_path: "mimic-iv-note-ext-di/dataset/all.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_train:
+    file_path: "mimic-iv-note-ext-di/dataset/train.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_valid:
+    file_path: "mimic-iv-note-ext-di/dataset/valid.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_test:
+    file_path: "mimic-iv-note-ext-di/dataset/test.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_train_4000_600:
+    file_path: "mimic-iv-note-ext-di/dataset/train_4000_600_chars.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_valid_4000_600:
+    file_path: "mimic-iv-note-ext-di/dataset/valid_4000_600_chars.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_test_4000_600:
+    file_path: "mimic-iv-note-ext-di/dataset/test_4000_600_chars.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_bhc_all:
+    file_path: "mimic-iv-note-ext-di-bhc/dataset/all.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_bhc_train:
+    file_path: "mimic-iv-note-ext-di-bhc/dataset/train.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_bhc_valid:
+    file_path: "mimic-iv-note-ext-di-bhc/dataset/valid.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_bhc_test:
+    file_path: "mimic-iv-note-ext-di-bhc/dataset/test.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_bhc_train_4000_600:
+    file_path: "mimic-iv-note-ext-di-bhc/dataset/train_4000_600_chars.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_bhc_valid_4000_600:
+    file_path: "mimic-iv-note-ext-di-bhc/dataset/valid_4000_600_chars.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  mimic_di_bhc_test_4000_600:
+    file_path: "mimic-iv-note-ext-di-bhc/dataset/test_4000_600_chars.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  hallucinations_mimic_di:
+    file_path: "hallucination_datasets/hallucinations_mimic_di.jsonl"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  hallucinations_mimic_di_validation:
+    file_path: "hallucination_datasets/hallucinations_mimic_di_validation.jsonl"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  hallucinations_generated_di:
+    file_path: "hallucination_datasets/hallucinations_generated_di.jsonl"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  derived_mimic_di_original:
+    file_path: "derived_datasets/hallucinations_mimic_di_original.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  derived_mimic_di_cleaned:
+    file_path: "derived_datasets/hallucinations_mimic_di_cleaned.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  derived_mimic_di_cleaned_improved:
+    file_path: "derived_datasets/hallucinations_mimic_di_cleaned_improved.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  derived_mimic_di_validation_original:
+    file_path: "derived_datasets/hallucinations_mimic_di_validation_original.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  derived_mimic_di_validation_cleaned:
+    file_path: "derived_datasets/hallucinations_mimic_di_validation_cleaned.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"
+
+  derived_mimic_di_validation_cleaned_improved:
+    file_path: "derived_datasets/hallucinations_mimic_di_validation_cleaned_improved.json"
+    patient_id: null
+    timestamp: null
+    attributes:
+      - "*"

--- a/tests/core/test_dataset_config.py
+++ b/tests/core/test_dataset_config.py
@@ -1,0 +1,86 @@
+import json
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from pyhealth.datasets.base_dataset import BaseDataset
+
+
+class DemoDataset(BaseDataset):
+    def __init__(self, root: str, config_path: str):
+        super().__init__(root=root, tables=["demo"], config_path=config_path)
+
+
+class DatasetConfigTest(unittest.TestCase):
+    def test_wildcard_attributes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            csv_path = root / "demo.csv"
+            csv_path.write_text(
+                "subject_id,value,charttime\n1,foo,2020-01-01 00:00:00\n",
+                encoding="utf-8",
+            )
+
+            config_path = root / "demo.yaml"
+            config_path.write_text(
+                textwrap.dedent(
+                    """
+                    version: "1.0"
+                    tables:
+                      demo:
+                        file_path: "demo.csv"
+                        patient_id: "subject_id"
+                        timestamp: "charttime"
+                        attributes:
+                          - "*"
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            dataset = DemoDataset(str(root), str(config_path))
+            df = dataset.collected_global_event_df
+
+            self.assertIn("demo/value", df.columns)
+            self.assertNotIn("demo/subject_id", df.columns)
+
+    def test_json_loader_support(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            json_path = root / "demo.json"
+            records = [
+                {"text": "ctx", "summary": "sum"},
+                {"text": "ctx2", "summary": "sum2", "labels": [{"label": "foo"}]},
+            ]
+            json_path.write_text(
+                "\n".join(json.dumps(record) for record in records),
+                encoding="utf-8",
+            )
+            config_path = root / "demo_json.yaml"
+            config_path.write_text(
+                textwrap.dedent(
+                    """
+                    version: "1.0"
+                    tables:
+                      demo:
+                        file_path: "demo.json"
+                        patient_id: null
+                        timestamp: null
+                        attributes:
+                          - "*"
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            dataset = DemoDataset(str(root), str(config_path))
+            df = dataset.collected_global_event_df
+
+            self.assertIn("demo/text", df.columns)
+            self.assertIn("demo/summary", df.columns)
+            self.assertIn("demo/labels", df.columns)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Background

ANNPTSummDataset packages [PhysioNet’s Medical Expert Annotations of Unsupported Facts in Doctor-Written and LLM-Generated Patient Summaries](https://physionet.org/content/ann-pt-summ/1.0.1/)  (MIMIC-IV discharge contexts, summaries, and hallucination annotations) so PyHealth users can study unsupported facts in doctor- or LLM-written summaries across all provided splits (full, BHC, filtered 4k/600, hallucination subsets, and cleaned/improved derivatives).

### Approach

- Extend the file scanner to ingest NDJSON/JSONL so those tables load natively.
- Add the ann-pt-summ YAML + dataset class and expose it via pyhealth.datasets.
- Add a regression test covering wildcard attributes and JSON ingestion.
