### PR TITLE
add pyhealth example

### DIFF
--- a/examples/pyhealth_clinical_summarization_demo.ipynb
+++ b/examples/pyhealth_clinical_summarization_demo.ipynb
@@ -1,0 +1,553 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c1403ace",
+   "metadata": {},
+   "source": [
+    "# Clinical Text Summarization and Hallucination-Aware Evaluation\n",
+    "\n",
+    "This notebook provides a demonstration of clinical text summarization and\n",
+    "hallucination-aware evaluation inspired by:\n",
+    "\n",
+    "> *A Data-Centric Approach to Generate Faithful and High Quality Clinical Summaries with Large Language Models* (Hegselmann et al., 2024).\n",
+    "\n",
+    "\n",
+    "It shows\n",
+    "- Synthetic clinical encounters (no real patient data)\n",
+    "- Summaries produced by a simple baseline\n",
+    "- Hallucination-style checks using keyword heuristics\n",
+    "- Text-based metrics (ROUGE, BLEU) computed without `evaluate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46b4b8fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If running in Colab or a clean environment, uncomment this cell to install dependencies.\n",
+    "# This uses a *minimal* set of packages (no transformers, no evaluate).\n",
+    "#\n",
+    "# !pip install pyhealth sacrebleu rouge-score\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f30ff7eb",
+   "metadata": {},
+   "source": [
+    "## Imports and basic setup\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "41acaacc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PyHealth version: 1.1.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "import random\n",
+    "from pprint import pprint\n",
+    "\n",
+    "import pyhealth\n",
+    "print(\"PyHealth version:\", pyhealth.__version__)\n",
+    "\n",
+    "# Metrics libraries (do not depend on transformers)\n",
+    "import sacrebleu\n",
+    "from rouge_score import rouge_scorer\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "934aacd5",
+   "metadata": {},
+   "source": [
+    "## Create synthetic clinical encounters\n",
+    "\n",
+    "We define a small list of synthetic encounters. Each encounter has:\n",
+    "\n",
+    "- an `encounter_id`\n",
+    "- a free-text `history` describing the clinical scenario\n",
+    "- a short `reference_summary` which we treat as the gold standard summary\n",
+    "- a list of `key_conditions` we expect to appear in a faithful summary\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fa4ac1d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toy_encounters = [\n",
+    "    {\n",
+    "        \"encounter_id\": \"E001\",\n",
+    "        \"history\": (\n",
+    "            \"65-year-old male with history of hypertension and diabetes admitted \"\n",
+    "            \"for shortness of breath. Chest X-ray shows bilateral infiltrates. \"\n",
+    "            \"Started on IV antibiotics and oxygen therapy.\"\n",
+    "        ),\n",
+    "        \"reference_summary\": (\n",
+    "            \"Elderly male with hypertension and diabetes admitted for dyspnea \"\n",
+    "            \"and bilateral infiltrates, treated with IV antibiotics and oxygen.\"\n",
+    "        ),\n",
+    "        \"key_conditions\": [\"hypertension\", \"diabetes\", \"dyspnea\", \"bilateral infiltrates\"],\n",
+    "    },\n",
+    "    {\n",
+    "        \"encounter_id\": \"E002\",\n",
+    "        \"history\": (\n",
+    "            \"54-year-old female with breast cancer in remission presents with new-onset \"\n",
+    "            \"headache and visual changes. MRI of the brain is pending. Given analgesics \"\n",
+    "            \"and neurology consulted.\"\n",
+    "        ),\n",
+    "        \"reference_summary\": (\n",
+    "            \"Middle-aged female with history of breast cancer in remission presents with \"\n",
+    "            \"new headache and visual symptoms; brain MRI pending and neurology consulted.\"\n",
+    "        ),\n",
+    "        \"key_conditions\": [\"breast cancer\", \"headache\", \"visual changes\", \"MRI\"],\n",
+    "    },\n",
+    "    {\n",
+    "        \"encounter_id\": \"E003\",\n",
+    "        \"history\": (\n",
+    "            \"72-year-old with chronic kidney disease and heart failure presents with \"\n",
+    "            \"leg swelling and fatigue. Labs show elevated creatinine and BNP. \"\n",
+    "            \"Diuretics initiated and nephrology consulted.\"\n",
+    "        ),\n",
+    "        \"reference_summary\": (\n",
+    "            \"Older adult with CKD and heart failure presents with edema and fatigue; \"\n",
+    "            \"found to have elevated creatinine and BNP, started on diuretics and \"\n",
+    "            \"seen by nephrology.\"\n",
+    "        ),\n",
+    "        \"key_conditions\": [\"chronic kidney disease\", \"heart failure\", \"edema\", \"fatigue\", \"creatinine\", \"BNP\"],\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "len(toy_encounters)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5254083",
+   "metadata": {},
+   "source": [
+    "## Define a simple rule-based summarizer\n",
+    "\n",
+    "We use a simple lead-based extractive baseline:\n",
+    "\n",
+    "- Take the first few sentences from the history.\n",
+    "- Optionally truncate to a maximum token length.\n",
+    "- Return this as the \"model\" summary.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5861b534",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "def simple_summarize(text: str, max_sentences: int = 2, max_tokens: int = 64) -> str:\n",
+    "    if not isinstance(text, str) or not text.strip():\n",
+    "        return \"\"\n",
+    "\n",
+    "    sentences = re.split(r\"(?<=[.!?])\\s+\", text.strip())\n",
+    "    sentences = [s for s in sentences if s.strip()]\n",
+    "    if not sentences:\n",
+    "        return \"\"\n",
+    "    selected = sentences[:max_sentences]\n",
+    "    summary = \" \".join(selected).strip()\n",
+    "\n",
+    "    # Truncate by token count\n",
+    "    tokens = summary.split()\n",
+    "    if len(tokens) > max_tokens:\n",
+    "        summary = \" \".join(tokens[:max_tokens])\n",
+    "\n",
+    "    return summary\n",
+    "\n",
+    "def batch_summarize(texts, max_sentences: int = 2, max_tokens: int = 64):\n",
+    "    return [\n",
+    "        simple_summarize(t, max_sentences=max_sentences, max_tokens=max_tokens)\n",
+    "        for t in texts\n",
+    "    ]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2255c262",
+   "metadata": {},
+   "source": [
+    "## Generate summaries from the clean histories\n",
+    "\n",
+    "Apply the baseline summarizer to each encounter's clean history and store\n",
+    "the result in `model_summary`. This is analogous to running a real neural\n",
+    "sequence-to-sequence model, but much cheaper and entirely deterministic.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3da16f65",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'history': '65-year-old male with history of hypertension and diabetes '\n",
+      "             'admitted for shortness of breath. Chest X-ray shows bilateral '\n",
+      "             'infiltrates. Started on IV antibiotics and oxygen therapy.',\n",
+      "  'id': 'E001',\n",
+      "  'model_summary': '65-year-old male with history of hypertension and diabetes '\n",
+      "                   'admitted for shortness of breath. Chest X-ray shows '\n",
+      "                   'bilateral infiltrates.',\n",
+      "  'reference_summary': 'Elderly male with hypertension and diabetes admitted '\n",
+      "                       'for dyspnea and bilateral infiltrates, treated with IV '\n",
+      "                       'antibiotics and oxygen.'},\n",
+      " {'history': '54-year-old female with breast cancer in remission presents with '\n",
+      "             'new-onset headache and visual changes. MRI of the brain is '\n",
+      "             'pending. Given analgesics and neurology consulted.',\n",
+      "  'id': 'E002',\n",
+      "  'model_summary': '54-year-old female with breast cancer in remission '\n",
+      "                   'presents with new-onset headache and visual changes. MRI '\n",
+      "                   'of the brain is pending.',\n",
+      "  'reference_summary': 'Middle-aged female with history of breast cancer in '\n",
+      "                       'remission presents with new headache and visual '\n",
+      "                       'symptoms; brain MRI pending and neurology consulted.'},\n",
+      " {'history': '72-year-old with chronic kidney disease and heart failure '\n",
+      "             'presents with leg swelling and fatigue. Labs show elevated '\n",
+      "             'creatinine and BNP. Diuretics initiated and nephrology '\n",
+      "             'consulted.',\n",
+      "  'id': 'E003',\n",
+      "  'model_summary': '72-year-old with chronic kidney disease and heart failure '\n",
+      "                   'presents with leg swelling and fatigue. Labs show elevated '\n",
+      "                   'creatinine and BNP.',\n",
+      "  'reference_summary': 'Older adult with CKD and heart failure presents with '\n",
+      "                       'edema and fatigue; found to have elevated creatinine '\n",
+      "                       'and BNP, started on diuretics and seen by nephrology.'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for enc in toy_encounters:\n",
+    "    enc[\"model_summary\"] = simple_summarize(enc[\"history\"])\n",
+    "\n",
+    "pprint([\n",
+    "    {\n",
+    "        \"id\": e[\"encounter_id\"],\n",
+    "        \"history\": e[\"history\"],\n",
+    "        \"reference_summary\": e[\"reference_summary\"],\n",
+    "        \"model_summary\": e[\"model_summary\"],\n",
+    "    }\n",
+    "    for e in toy_encounters\n",
+    "])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5011318",
+   "metadata": {},
+   "source": [
+    "## Add noisy / templated content to simulate more complex inputs\n",
+    "\n",
+    "To mimic more realistic clinical notes, we create a noisy version of the history\n",
+    "by appending extra social history and templated text. We then summarize this noisy\n",
+    "history with the same baseline model to see how robust it is.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ee47bcd3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'clean_history_summary': '65-year-old male with history of hypertension and '\n",
+      "                           'diabetes admitted for shortness of breath. Chest '\n",
+      "                           'X-ray shows bilateral infiltrates.',\n",
+      "  'id': 'E001',\n",
+      "  'noisy_history_summary': '65-year-old male with history of hypertension and '\n",
+      "                           'diabetes admitted for shortness of breath. Chest '\n",
+      "                           'X-ray shows bilateral infiltrates.'},\n",
+      " {'clean_history_summary': '54-year-old female with breast cancer in remission '\n",
+      "                           'presents with new-onset headache and visual '\n",
+      "                           'changes. MRI of the brain is pending.',\n",
+      "  'id': 'E002',\n",
+      "  'noisy_history_summary': '54-year-old female with breast cancer in remission '\n",
+      "                           'presents with new-onset headache and visual '\n",
+      "                           'changes. MRI of the brain is pending.'},\n",
+      " {'clean_history_summary': '72-year-old with chronic kidney disease and heart '\n",
+      "                           'failure presents with leg swelling and fatigue. '\n",
+      "                           'Labs show elevated creatinine and BNP.',\n",
+      "  'id': 'E003',\n",
+      "  'noisy_history_summary': '72-year-old with chronic kidney disease and heart '\n",
+      "                           'failure presents with leg swelling and fatigue. '\n",
+      "                           'Labs show elevated creatinine and BNP.'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for enc in toy_encounters:\n",
+    "    enc[\"noisy_history\"] = (\n",
+    "        enc[\"history\"]\n",
+    "        + \" Social: lives with family, enjoys gardening, no recent travel. \"\n",
+    "          \"Multiple duplicated notes and templated phrases are present in the record.\"\n",
+    "    )\n",
+    "\n",
+    "for enc in toy_encounters:\n",
+    "    enc[\"summary_noisy_input\"] = simple_summarize(enc[\"noisy_history\"])\n",
+    "\n",
+    "pprint([\n",
+    "    {\n",
+    "        \"id\": e[\"encounter_id\"],\n",
+    "        \"clean_history_summary\": e[\"model_summary\"],\n",
+    "        \"noisy_history_summary\": e[\"summary_noisy_input\"],\n",
+    "    }\n",
+    "    for e in toy_encounters\n",
+    "])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac746e2c",
+   "metadata": {},
+   "source": [
+    "## Simple hallucination-style checks\n",
+    "\n",
+    "Here we implement heuristics to flag potential hallucinations. First, we maintain a list of condition\n",
+    "keywrods that we care about (e.g., cancer, stroke).\n",
+    "\n",
+    "A summary is flagged as hallucinated if it mentions a condition that does **not**\n",
+    "appear in the original history. We also check for **missing key facts**, which are\n",
+    "expected conditions in `key_conditions` that do not appear in the model summary.\n",
+    "\n",
+    "These heuristics are simple but illustrate the idea of hallucination-aware\n",
+    "evaluation from the paper.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8273432c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'hallucinated_conditions': [],\n",
+      "  'id': 'E001',\n",
+      "  'missing_key_conditions': ['dyspnea'],\n",
+      "  'model_summary': '65-year-old male with history of hypertension and diabetes '\n",
+      "                   'admitted for shortness of breath. Chest X-ray shows '\n",
+      "                   'bilateral infiltrates.'},\n",
+      " {'hallucinated_conditions': [],\n",
+      "  'id': 'E002',\n",
+      "  'missing_key_conditions': [],\n",
+      "  'model_summary': '54-year-old female with breast cancer in remission '\n",
+      "                   'presents with new-onset headache and visual changes. MRI '\n",
+      "                   'of the brain is pending.'},\n",
+      " {'hallucinated_conditions': [],\n",
+      "  'id': 'E003',\n",
+      "  'missing_key_conditions': ['edema'],\n",
+      "  'model_summary': '72-year-old with chronic kidney disease and heart failure '\n",
+      "                   'presents with leg swelling and fatigue. Labs show elevated '\n",
+      "                   'creatinine and BNP.'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "condition_keywords = [\n",
+    "    \"cancer\", \"stroke\", \"myocardial infarction\", \"sepsis\",\n",
+    "    \"pneumonia\", \"hypertension\", \"diabetes\", \"heart failure\",\n",
+    "    \"kidney disease\", \"dialysis\",\n",
+    "]\n",
+    "\n",
+    "def detect_hallucinations(history: str, summary: str):\n",
+    "    \"\"\"Return a set of condition keywords that appear in the summary but not in the history.\"\"\"\n",
+    "    history_lower = history.lower()\n",
+    "    summary_lower = summary.lower()\n",
+    "    hallucinated = set()\n",
+    "\n",
+    "    for cond in condition_keywords:\n",
+    "        if cond in summary_lower and cond not in history_lower:\n",
+    "            hallucinated.add(cond)\n",
+    "\n",
+    "    return hallucinated\n",
+    "\n",
+    "def missing_key_facts(key_conditions, summary: str):\n",
+    "    \"\"\"Return a set of key conditions that are missing from the summary.\"\"\"\n",
+    "\n",
+    "    summary_lower = summary.lower()\n",
+    "    missing = set()\n",
+    "\n",
+    "    for cond in key_conditions:\n",
+    "        if cond.lower() not in summary_lower:\n",
+    "            missing.add(cond)\n",
+    "\n",
+    "    return missing\n",
+    "\n",
+    "for enc in toy_encounters:\n",
+    "    h = enc[\"history\"]\n",
+    "    s = enc[\"model_summary\"]\n",
+    "\n",
+    "    enc[\"hallucinated_conditions\"] = detect_hallucinations(h, s)\n",
+    "    enc[\"missing_key_conditions\"] = missing_key_facts(enc[\"key_conditions\"], s)\n",
+    "pprint([\n",
+    "    {\n",
+    "        \"id\": e[\"encounter_id\"],\n",
+    "        \"model_summary\": e[\"model_summary\"],\n",
+    "        \"hallucinated_conditions\": sorted(e[\"hallucinated_conditions\"]),\n",
+    "        \"missing_key_conditions\": sorted(e[\"missing_key_conditions\"]),\n",
+    "    }\n",
+    "    for e in toy_encounters\n",
+    "])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0553d30",
+   "metadata": {},
+   "source": [
+    "## Compute ROUGE and BLEU metrics\n",
+    "\n",
+    "We now compute standard text-based metrics directly, using their respective packages:\n",
+    "\n",
+    "- **ROUGE-1 / ROUGE-2 / ROUGE-L** with `rouge-score`\n",
+    "- **BLEU** with `sacrebleu`\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2ae7dd16",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average ROUGE scores (F1):\n",
+      "  rouge1: 0.5524\n",
+      "  rouge2: 0.3604\n",
+      "  rougeL: 0.5234\n",
+      "Corpus BLEU: 25.31\n"
+     ]
+    }
+   ],
+   "source": [
+    "refs = [e[\"reference_summary\"] for e in toy_encounters]\n",
+    "preds = [e[\"model_summary\"] for e in toy_encounters]\n",
+    "\n",
+    "# ROUGE\n",
+    "rouge_types = [\"rouge1\", \"rouge2\", \"rougeL\"]\n",
+    "scorer = rouge_scorer.RougeScorer(rouge_types, use_stemmer=True)\n",
+    "\n",
+    "rouge_scores = {r: [] for r in rouge_types}\n",
+    "for ref, pred in zip(refs, preds):\n",
+    "    scores = scorer.score(ref, pred)  # (target, prediction)\n",
+    "    for r in rouge_types:\n",
+    "        rouge_scores[r].append(scores[r].fmeasure)\n",
+    "\n",
+    "avg_rouge = {r: sum(vals) / len(vals) for r, vals in rouge_scores.items()}\n",
+    "\n",
+    "# BLEU\n",
+    "bleu = sacrebleu.corpus_bleu(preds, [refs])\n",
+    "\n",
+    "print(\"Average ROUGE scores (F1):\")\n",
+    "for r, v in avg_rouge.items():\n",
+    "    print(f\"  {r}: {v:.4f}\")\n",
+    "\n",
+    "print(f\"Corpus BLEU: {bleu.score:.2f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a24a26d4",
+   "metadata": {},
+   "source": [
+    "## Aggregate hallucination-style statistics\n",
+    "\n",
+    "Summarize the hallucination-style checks into the \n",
+    "- proportion of summaries with any hallucinated condition keyword\n",
+    "- Average number of missing key conditions per summary\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f6ccc46d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of encounters: 3\n",
+      "Summaries with any hallucinated condition: 0 (0.00)\n",
+      "Average number of missing key conditions per summary: 0.67\n"
+     ]
+    }
+   ],
+   "source": [
+    "num_encounters = len(toy_encounters)\n",
+    "num_with_hallucinations = sum(1 for e in toy_encounters if e[\"hallucinated_conditions\"])\n",
+    "avg_missing_key_conditions = sum(len(e[\"missing_key_conditions\"]) for e in toy_encounters) / num_encounters\n",
+    "\n",
+    "print(f\"Number of encounters: {num_encounters}\")\n",
+    "print(f\"Summaries with any hallucinated condition: {num_with_hallucinations} \"\n",
+    "      f\"({num_with_hallucinations / num_encounters:.2f})\")\n",
+    "print(f\"Average number of missing key conditions per summary: {avg_missing_key_conditions:.2f}\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a reproducible example notebook that performs clinical note summarization with PyHealth. Covers dataset loading, preprocessing, model construction, training, evaluation with a small model.