### PR TITLE
ViewXGen Reproduction: New PyHealth ExampleDevelop

### DIFF
--- a/pyhealth/examples/viewxgen/README.md
+++ b/pyhealth/examples/viewxgen/README.md
@@ -1,1 +1,37 @@
-temp
+# ViewXGen Reproduction Example
+
+This example demonstrates a lightweight reproduction of the ViewXGen
+multimodal chest X ray generation workflow using PyHealth.
+
+Because the full ViewXGen model is too large for a course environment,
+this example uses:
+- a tiny dummy dataset loaded with `SampleDataset`
+- a reduced transformer with 2 layers
+- short token sequences to simulate VQ GAN image tokens
+- a simple training loop
+- a minimal evaluation script
+
+This example is fully self-contained and does not require access to the
+restricted MIMIC CXR dataset.
+
+## File Structure
+
+viewxgen_reproduction/
+    dataset_demo.py
+    model_demo.py
+    train_demo.py
+    evaluate_demo.py
+
+## Running the Example
+
+1. Install Dependencies:
+pip install torch torchvision einops transformers pillow scikit-learn
+
+2. Run the dataset demo:
+python dataset_demo.py
+
+3. Train the model:
+python train_demo.py
+
+4. Evaluate:
+python evaluate_demo.py

--- a/pyhealth/examples/viewxgen/dataset_demo.py
+++ b/pyhealth/examples/viewxgen/dataset_demo.py
@@ -1,0 +1,21 @@
+from pyhealth.datasets import SampleDataset
+
+samples = [
+    {
+        "id": "sample1",
+        "text": "Lungs are clear.",
+        "view": "PA",
+        "image_tokens": [12, 57, 91, 33, 44]
+    },
+    {
+        "id": "sample2",
+        "text": "Mild cardiomegaly.",
+        "view": "AP",
+        "image_tokens": [11, 52, 19, 6, 71]
+    }
+]
+
+dataset = SampleDataset(samples=samples)
+
+print("Loaded dataset length:", len(dataset))
+print("Example sample:", dataset[0])

--- a/pyhealth/examples/viewxgen/evaluate_demo.py
+++ b/pyhealth/examples/viewxgen/evaluate_demo.py
@@ -1,0 +1,11 @@
+import torch
+from model_demo import MiniViewXGen
+
+model = MiniViewXGen()
+
+tokens = torch.tensor([[12, 57, 91, 33]])
+
+output = model(tokens)
+
+print("Output shape:", output.shape)
+print("Evaluation script executed successfully.")

--- a/pyhealth/examples/viewxgen/model_demo.py
+++ b/pyhealth/examples/viewxgen/model_demo.py
@@ -1,0 +1,19 @@
+import torch
+from torch import nn
+
+class MiniViewXGen(nn.Module):
+    def __init__(self, vocab_size=256, hidden=128, layers=2):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, hidden)
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=hidden,
+            nhead=4,
+            batch_first=True
+        )
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=layers)
+        self.out = nn.Linear(hidden, vocab_size)
+
+    def forward(self, tokens):
+        x = self.embed(tokens)
+        x = self.transformer(x)
+        return self.out(x)

--- a/pyhealth/examples/viewxgen/train_demo.py
+++ b/pyhealth/examples/viewxgen/train_demo.py
@@ -1,0 +1,25 @@
+import torch
+from torch.utils.data import DataLoader
+from model_demo import MiniViewXGen
+from dataset_demo import dataset
+
+model = MiniViewXGen()
+optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+loss_fn = torch.nn.CrossEntropyLoss()
+
+loader = DataLoader(dataset, batch_size=1, shuffle=True)
+
+for epoch in range(2):
+    for batch in loader:
+        tokens = torch.tensor(batch["image_tokens"])
+        inp = tokens[:, :-1]
+        tgt = tokens[:, 1:]
+
+        out = model(inp)
+        loss = loss_fn(out.reshape(-1, 256), tgt.reshape(-1))
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+    print("Epoch", epoch, "Loss", float(loss))


### PR DESCRIPTION
This PR contributes a new PyHealth example for reproducing the ViewXGen chest X-ray generative model.

Added:
• New example directory: pyhealth/examples/viewxgen/
• dataset_demo.py – minimal dataset wrapper
• model_demo.py – small generator model
• train_demo.py – simple training using
• evaluate_demo.py – evaluation script
• README.md – instructions for running the example
