### PR TITLE
init commit to clarify install docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,25 +1,37 @@
 Installation
 ============
 
-You could install from PyPi for the older stable version of PyHealth:
+**Recommended Installation (Alpha Version)**
+
+We recommend installing the latest alpha version from PyPi, which offers significant improvements in performance:
+
+.. code-block:: bash
+
+   pip install pyhealth==2.0a10
+
+This version includes optimized implementations and enhanced features compared to the legacy version.
+
+**Legacy Version**
+
+The older stable version is still available for backward compatibility, though it may have performance limitations:
 
 .. code-block:: bash
 
     pip install pyhealth
 
-or our most-updated alpha version from PyPi:
+**Note:** The legacy version (1.x) should still work for most use cases, but we recommend upgrading to 2.0a10 for better performance.
 
-.. code-block:: bash
+**For Contributors and Developers**
 
-   pip install pyhealth==2.0a4
-
-or from github source for the latest version of PyHealth:
+If you are contributing to PyHealth or need the latest development features, install from GitHub source:
 
 .. code-block:: bash
 
    git clone https://github.com/sunlabuiuc/PyHealth.git
-   cd pyhealth
+   cd PyHealth
    pip install -e .
+
+This approach is recommended for developers as it allows you to modify the code and immediately see changes without reinstalling.
 
 
 .. **Required Dependencies**\ :


### PR DESCRIPTION
This pull request updates the installation instructions in the `docs/install.rst` file to clarify the recommended installation method and improve guidance for users and contributors. The changes emphasize installing the latest alpha version for better performance, clarify the availability of the legacy version, and provide clearer instructions for contributors.

**Installation instructions update:**

* Updated the documentation to recommend installing the latest alpha version (`pyhealth==2.0a10`) from PyPi for improved performance and features, while still providing information about the legacy version for backward compatibility.
* Added a dedicated section for contributors and developers, explaining how to install the package from the GitHub source for development purposes.
* Improved clarity and organization of installation steps, including notes on performance and use cases for each version.