### PR TITLE
update benchmark examples and pypi ver.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,29 +1,34 @@
 Installation
 ============
 
-**Python Version Recommendation**
+**Python Version Requirement**
 
-We recommend using **Python 3.12** for optimal parallel processing and memory management performance. While PyHealth supports Python 3.8+, Python 3.12 provides significant improvements in these areas.
-
-**Recommended Installation (Alpha Version)**
-
-We recommend installing the latest alpha version from PyPi, which offers significant improvements in performance:
+PyHealth 2.0 requires **Python 3.12 or higher** (up to Python 3.13). This is a hard requirement due to dependencies on modern Python features for parallel processing and memory management.
 
 .. code-block:: bash
 
-   pip install pyhealth==2.0a13
+   # Verify your Python version
+   python --version  # Should be 3.12.x or 3.13.x
+
+**Recommended Installation (Alpha Version)**
+
+We recommend installing the latest alpha version from PyPI, which offers significant improvements in performance:
+
+.. code-block:: bash
+
+   pip install pyhealth==2.0a14
 
 This version includes optimized implementations and enhanced features compared to the legacy version.
 
 **Legacy Version**
 
-The older stable version is still available for backward compatibility, though it may have performance limitations:
+The older stable version (1.16) is still available for backward compatibility and supports Python 3.9+:
 
 .. code-block:: bash
 
     pip install pyhealth
 
-**Note:** The legacy version (1.x) should still work for most use cases, but we recommend upgrading to 2.0a10 for better performance.
+**Note:** The legacy version (1.16) should still work for most use cases, but we recommend upgrading to 2.0a14 for better performance and new features.
 
 **For Contributors and Developers**
 

--- a/examples/benchmark_perf/benchmark_pandas_drug_rec.py
+++ b/examples/benchmark_perf/benchmark_pandas_drug_rec.py
@@ -1,0 +1,368 @@
+"""
+Benchmark script for MIMIC-IV drug recommendation using pandas
+(analogous to PyHealth DrugRecommendationMIMIC4 task).
+
+This benchmark mimics the DrugRecommendationMIMIC4 task:
+1. Creates visit-level samples with cumulative history
+2. For each visit, extracts conditions, procedures, and drugs
+3. Builds cumulative history of conditions, procedures, and drug history
+4. Target is the drugs for the current visit
+5. Excludes target drugs from history
+
+Drug Recommendation Task:
+- Input: conditions (nested), procedures (nested), drugs_hist (nested)
+- Output: drugs (multilabel) for the current visit
+"""
+
+import argparse
+import time
+import os
+import threading
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+import psutil
+
+
+PEAK_MEM_USAGE = 0
+SELF_PROC = psutil.Process(os.getpid())
+STOP_TRACKING = False
+
+
+def track_mem():
+    """Background thread to track peak memory usage."""
+    global PEAK_MEM_USAGE
+    while not STOP_TRACKING:
+        m = SELF_PROC.memory_info().rss
+        if m > PEAK_MEM_USAGE:
+            PEAK_MEM_USAGE = m
+        time.sleep(0.1)
+
+
+def format_size(size_bytes: int) -> str:
+    """Format bytes to human-readable string."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024.0:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024.0
+    return f"{size_bytes:.2f} PB"
+
+
+def process_patient_drug_recommendation(
+    subject_id: int,
+    admissions_df: pd.DataFrame,
+    diagnoses_df: pd.DataFrame,
+    procedures_df: pd.DataFrame,
+    prescriptions_df: pd.DataFrame,
+) -> List[Dict[str, Any]]:
+    """Process a single patient for drug recommendation task.
+
+    Creates visit-level samples with cumulative history.
+    Each sample includes all previous visits' conditions, procedures, and drugs.
+
+    Args:
+        subject_id: Patient ID
+        admissions_df: Admission records (pre-filtered for this patient)
+        diagnoses_df: Diagnosis ICD codes (pre-filtered for this patient)
+        procedures_df: Procedure ICD codes (pre-filtered for this patient)
+        prescriptions_df: Prescription records (pre-filtered for this patient)
+
+    Returns:
+        List of sample dictionaries, or empty list if patient doesn't qualify
+    """
+    samples = []
+
+    # Get all admissions for this patient, sorted by time
+    patient_admissions = admissions_df[
+        admissions_df["subject_id"] == subject_id
+    ].sort_values("admittime")
+
+    if len(patient_admissions) < 2:
+        # Need at least 2 visits for history-based prediction
+        return []
+
+    # Process each admission to collect visit data
+    visit_data = []
+    for _, admission in patient_admissions.iterrows():
+        hadm_id = admission["hadm_id"]
+
+        # Get diagnosis codes for this admission
+        visit_diagnoses = diagnoses_df[diagnoses_df["hadm_id"] == hadm_id]
+        # Combine ICD version with code (e.g., "10_A123" or "9_456")
+        conditions = []
+        for _, row in visit_diagnoses.iterrows():
+            if pd.notna(row.get("icd_code")) and pd.notna(row.get("icd_version")):
+                conditions.append(f"{int(row['icd_version'])}_{row['icd_code']}")
+
+        # Get procedure codes for this admission
+        visit_procedures = procedures_df[procedures_df["hadm_id"] == hadm_id]
+        procedures = []
+        for _, row in visit_procedures.iterrows():
+            if pd.notna(row.get("icd_code")) and pd.notna(row.get("icd_version")):
+                procedures.append(f"{int(row['icd_version'])}_{row['icd_code']}")
+
+        # Get prescriptions for this admission
+        visit_prescriptions = prescriptions_df[prescriptions_df["hadm_id"] == hadm_id]
+        drugs = []
+        for _, row in visit_prescriptions.iterrows():
+            ndc = row.get("ndc")
+            if pd.notna(ndc) and ndc:
+                ndc_str = str(ndc)
+                if len(ndc_str) >= 4:
+                    # ATC 3 level (first 4 characters)
+                    drugs.append(ndc_str[:4])
+
+        # Exclude visits without condition, procedure, or drug code
+        if len(conditions) == 0 or len(procedures) == 0 or len(drugs) == 0:
+            continue
+
+        visit_data.append({
+            "hadm_id": hadm_id,
+            "conditions": conditions,
+            "procedures": procedures,
+            "drugs": drugs,
+        })
+
+    # Exclude patients with less than 2 valid visits
+    if len(visit_data) < 2:
+        return []
+
+    # Build samples with cumulative history
+    for i, visit in enumerate(visit_data):
+        sample = {
+            "visit_id": visit["hadm_id"],
+            "patient_id": subject_id,
+            "conditions": [],
+            "procedures": [],
+            "drugs_hist": [],
+            "drugs": visit["drugs"],  # Target drugs for this visit
+        }
+
+        # Add cumulative history from all visits up to and including current
+        for j in range(i + 1):
+            sample["conditions"].append(visit_data[j]["conditions"])
+            sample["procedures"].append(visit_data[j]["procedures"])
+            # drugs_hist includes history up to current, but current visit's
+            # drugs will be emptied
+            sample["drugs_hist"].append(visit_data[j]["drugs"])
+
+        # Remove target drug from history (set current visit drugs_hist to empty)
+        sample["drugs_hist"][i] = []
+
+        samples.append(sample)
+
+    return samples
+
+
+def benchmark_drug_recommendation(
+    admissions_df: pd.DataFrame,
+    diagnoses_df: pd.DataFrame,
+    procedures_df: pd.DataFrame,
+    prescriptions_df: pd.DataFrame,
+    n_patients: Optional[int] = None,
+) -> Tuple[List[Dict[str, Any]], float]:
+    """
+    Benchmark MIMIC-IV drug recommendation processing.
+
+    Args:
+        admissions_df: Admissions dataframe
+        diagnoses_df: Diagnoses dataframe
+        procedures_df: Procedures dataframe
+        prescriptions_df: Prescriptions dataframe
+        n_patients: Number of patients to process (None = all patients)
+
+    Returns:
+        Tuple of (list of samples, processing time in seconds)
+    """
+    print("=" * 80)
+    print("BENCHMARK: Pandas Drug Recommendation (MIMIC-IV format)")
+    print("=" * 80)
+
+    # Get unique patients
+    all_patients = admissions_df["subject_id"].unique().tolist()
+
+    if n_patients is None:
+        patients_to_process = all_patients
+        print(f"Processing all {len(patients_to_process)} patients...")
+    else:
+        patients_to_process = all_patients[:n_patients]
+        print(f"Processing first {len(patients_to_process)} patients...")
+
+    # Parse datetime columns
+    admissions_df = admissions_df.copy()
+    admissions_df["admittime"] = pd.to_datetime(admissions_df["admittime"])
+
+    # Start processing timer
+    start_time = time.perf_counter()
+
+    samples = []
+    processed_patients = 0
+    patients_with_samples = 0
+
+    for subject_id in patients_to_process:
+        patient_samples = process_patient_drug_recommendation(
+            subject_id,
+            admissions_df,
+            diagnoses_df,
+            procedures_df,
+            prescriptions_df,
+        )
+
+        if patient_samples:
+            samples.extend(patient_samples)
+            patients_with_samples += 1
+
+        processed_patients += 1
+        if processed_patients % 1000 == 0:
+            print(f"Processed {processed_patients} patients, "
+                  f"{len(samples)} samples so far...")
+
+    # End processing timer
+    processing_time = time.perf_counter() - start_time
+
+    print("\nCompleted processing:")
+    print(f"  - Total patients processed: {processed_patients}")
+    print(f"  - Patients with valid samples: {patients_with_samples}")
+    print(f"  - Total samples created: {len(samples)}")
+    print(f"  - Processing time: {processing_time:.2f}s")
+    print("=" * 80)
+
+    return samples, processing_time
+
+
+def load_mimic_data(
+    data_root: str = "/srv/local/data/physionet.org/files/mimiciv/2.2/hosp",
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Load MIMIC-IV tables needed for drug recommendation.
+
+    Args:
+        data_root: Root directory for MIMIC-IV hosp data
+
+    Returns:
+        Tuple of dataframes: (admissions, diagnoses, procedures, prescriptions)
+    """
+    print("Loading MIMIC-IV data tables...")
+    load_start = time.perf_counter()
+
+    admissions_df = pd.read_csv(f"{data_root}/admissions.csv")
+    diagnoses_df = pd.read_csv(f"{data_root}/diagnoses_icd.csv.gz")
+    procedures_df = pd.read_csv(f"{data_root}/procedures_icd.csv.gz")
+    prescriptions_df = pd.read_csv(f"{data_root}/prescriptions.csv.gz", low_memory=False)
+
+    load_time = time.perf_counter() - load_start
+    print(f"Data loaded in {load_time:.2f}s")
+    print(f"  - Admissions: {len(admissions_df):,}")
+    print(f"  - Diagnoses: {len(diagnoses_df):,}")
+    print(f"  - Procedures: {len(procedures_df):,}")
+    print(f"  - Prescriptions: {len(prescriptions_df):,}")
+    print()
+
+    return (
+        admissions_df,
+        diagnoses_df,
+        procedures_df,
+        prescriptions_df,
+    )
+
+
+def main():
+    """Main function to run the benchmark."""
+    global STOP_TRACKING
+
+    parser = argparse.ArgumentParser(
+        description="Benchmark MIMIC-IV drug recommendation with pandas"
+    )
+    parser.add_argument(
+        "--data-root",
+        type=str,
+        default="/srv/local/data/physionet.org/files/mimiciv/2.2/hosp",
+        help="Path to MIMIC-IV hosp directory",
+    )
+    parser.add_argument(
+        "--n-patients",
+        type=int,
+        default=None,
+        help="Number of patients to process (default: all)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="benchmark_results_pandas_drug_rec.txt",
+        help="Output file for results",
+    )
+    args = parser.parse_args()
+
+    # Start memory tracking thread
+    mem_thread = threading.Thread(target=track_mem, daemon=True)
+    mem_thread.start()
+
+    # Load data
+    total_start = time.perf_counter()
+    (
+        admissions_df,
+        diagnoses_df,
+        procedures_df,
+        prescriptions_df,
+    ) = load_mimic_data(args.data_root)
+    load_time = time.perf_counter() - total_start
+
+    # Run benchmark
+    samples, processing_time = benchmark_drug_recommendation(
+        admissions_df,
+        diagnoses_df,
+        procedures_df,
+        prescriptions_df,
+        n_patients=args.n_patients,
+    )
+
+    total_time = time.perf_counter() - total_start
+
+    # Stop memory tracking
+    STOP_TRACKING = True
+    time.sleep(0.2)  # Allow final memory sample
+
+    # Get peak memory
+    peak_mem = PEAK_MEM_USAGE
+
+    # Print summary
+    print("\n" + "=" * 80)
+    print("FINAL SUMMARY")
+    print("=" * 80)
+    print(f"Data loading time: {load_time:.2f}s")
+    print(f"Processing time: {processing_time:.2f}s")
+    print(f"Total time: {total_time:.2f}s")
+    print(f"Total samples: {len(samples)}")
+    print(f"Peak memory usage: {format_size(peak_mem)}")
+    print("=" * 80)
+
+    # Save results
+    with open(args.output, "w") as f:
+        f.write("BENCHMARK RESULTS: Pandas Drug Recommendation (MIMIC-IV)\n")
+        f.write("=" * 80 + "\n")
+        f.write(f"Data root: {args.data_root}\n")
+        f.write(f"N patients: {args.n_patients or 'all'}\n")
+        f.write("-" * 80 + "\n")
+        f.write(f"Data loading time: {load_time:.2f}s\n")
+        f.write(f"Processing time: {processing_time:.2f}s\n")
+        f.write(f"Total time: {total_time:.2f}s\n")
+        f.write(f"Total samples: {len(samples)}\n")
+        f.write(f"Peak memory usage: {format_size(peak_mem)}\n")
+        f.write("=" * 80 + "\n")
+
+    print(f"\n✓ Results saved to {args.output}")
+
+    # Show example sample
+    if samples:
+        print("\nExample sample (first sample):")
+        first_sample = samples[0]
+        print(f"  Patient ID: {first_sample['patient_id']}")
+        print(f"  Visit ID: {first_sample['visit_id']}")
+        print(f"  Num visits in history: {len(first_sample['conditions'])}")
+        print(f"  Conditions (last visit): {first_sample['conditions'][-1][:5]}...")
+        print(f"  Procedures (last visit): {first_sample['procedures'][-1][:3]}...")
+        print(f"  Target drugs: {first_sample['drugs'][:5]}...")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/benchmark_perf/benchmark_workers_n_drug_recommendation.py
+++ b/examples/benchmark_perf/benchmark_workers_n_drug_recommendation.py
@@ -1,0 +1,400 @@
+"""Benchmark script for MIMIC-IV drug recommendation across multiple num_workers.
+
+This benchmark measures:
+1. Time to load the base dataset (once)
+2. Time to process the task for each num_workers value (optionally repeated)
+3. Cache sizes for base dataset and each task run
+4. Peak memory usage (RSS, includes child processes)
+
+Typical usage:
+  python benchmark_workers_n_drug_recommendation.py
+  python benchmark_workers_n_drug_recommendation.py --workers 1,4,8,12,16 --repeats 3
+  python benchmark_workers_n_drug_recommendation.py --dev --workers 1,2,4
+
+Notes:
+- The task cache directory is recreated for each run and deleted after measuring size.
+- The base dataset cache is also deleted before and after each run, so every run
+    measures full dataset + task processing time from scratch.
+- Peak memory is sampled in a background thread; it reports total RSS of the current
+  process plus all child processes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import shutil
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+import psutil
+
+from pyhealth.datasets import MIMIC4Dataset
+from pyhealth.tasks import DrugRecommendationMIMIC4
+
+try:
+    import resource
+
+    HAS_RESOURCE = True
+except ImportError:
+    HAS_RESOURCE = False
+
+
+@dataclass
+class RunResult:
+    num_workers: int
+    repeat_index: int
+    dataset_load_s: float
+    task_process_s: float
+    total_s: float
+    base_cache_bytes: int
+    task_cache_bytes: int
+    peak_rss_bytes: int
+
+
+def format_size(size_bytes: int) -> str:
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024.0:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024.0
+    return f"{size_bytes:.2f} PB"
+
+
+def get_directory_size(path: str | Path) -> int:
+    total = 0
+    p = Path(path)
+    if not p.exists():
+        return 0
+    try:
+        for entry in p.rglob("*"):
+            if entry.is_file():
+                try:
+                    total += entry.stat().st_size
+                except FileNotFoundError:
+                    # File might disappear if something is concurrently modifying cache.
+                    pass
+    except Exception as e:
+        print(f"Error calculating size for {p}: {e}")
+    return total
+
+
+def set_memory_limit(max_memory_gb: float) -> None:
+    """Set a hard virtual memory limit for the process."""
+    if not HAS_RESOURCE:
+        print(
+            "Warning: resource module not available (Windows?). "
+            "Memory limit not enforced."
+        )
+        return
+
+    max_memory_bytes = int(max_memory_gb * 1024**3)
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (max_memory_bytes, max_memory_bytes))
+        print(f"✓ Memory limit set to {max_memory_gb} GB")
+    except Exception as e:
+        print(f"Warning: Failed to set memory limit: {e}")
+
+
+class PeakMemoryTracker:
+    """Tracks peak RSS for current process + children."""
+
+    def __init__(self, poll_interval_s: float = 0.1) -> None:
+        self._proc = psutil.Process(os.getpid())
+        self._poll_interval_s = poll_interval_s
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._peak = 0
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def reset(self) -> None:
+        with self._lock:
+            self._peak = 0
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def peak_bytes(self) -> int:
+        with self._lock:
+            return self._peak
+
+    def _total_rss_bytes(self) -> int:
+        total = 0
+        try:
+            total += self._proc.memory_info().rss
+            for child in self._proc.children(recursive=True):
+                try:
+                    total += child.memory_info().rss
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+        return total
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            rss = self._total_rss_bytes()
+            with self._lock:
+                if rss > self._peak:
+                    self._peak = rss
+            time.sleep(self._poll_interval_s)
+
+
+def parse_workers(value: str) -> list[int]:
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    workers: list[int] = []
+    for p in parts:
+        w = int(p)
+        if w <= 0:
+            raise argparse.ArgumentTypeError("All worker counts must be > 0")
+        workers.append(w)
+    if not workers:
+        raise argparse.ArgumentTypeError("No workers provided")
+    return workers
+
+
+def ensure_empty_dir(path: str | Path) -> None:
+    p = Path(path)
+    if p.exists():
+        shutil.rmtree(p)
+    p.mkdir(parents=True, exist_ok=True)
+
+
+def remove_dir(path: str | Path, retries: int = 3, delay: float = 1.0) -> None:
+    """Remove a directory with retry logic for busy file handles."""
+    p = Path(path)
+    if not p.exists():
+        return
+    for attempt in range(retries):
+        try:
+            shutil.rmtree(p)
+            return
+        except OSError as e:
+            if attempt < retries - 1:
+                time.sleep(delay)
+            else:
+                print(f"Warning: Failed to delete {p} after {retries} attempts: {e}")
+
+
+def median(values: Iterable[float]) -> float:
+    xs = sorted(values)
+    if not xs:
+        return 0.0
+    mid = len(xs) // 2
+    if len(xs) % 2 == 1:
+        return xs[mid]
+    return (xs[mid - 1] + xs[mid]) / 2.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark MIMIC-IV drug recommendation over multiple num_workers"
+    )
+    parser.add_argument(
+        "--workers",
+        type=parse_workers,
+        default=[1, 4, 8, 12, 16],
+        help="Comma-separated list of num_workers values (default: 1,4,8,12,16)",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=1,
+        help="Number of repeats per worker setting (default: 1)",
+    )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Use dev mode dataset loading (smaller subset)",
+    )
+    parser.add_argument(
+        "--ehr-root",
+        type=str,
+        default="/srv/local/data/physionet.org/files/mimiciv/2.2/",
+        help="Path to MIMIC-IV root directory",
+    )
+    parser.add_argument(
+        "--cache-root",
+        type=str,
+        default="/shared/eng/pyhealth/",
+        help="Root directory for benchmark caches (default: /shared/eng/pyhealth/)",
+    )
+    parser.add_argument(
+        "--enable-memory-limit",
+        action="store_true",
+        help="Enforce a hard memory limit via resource.setrlimit (Unix only)",
+    )
+    parser.add_argument(
+        "--max-memory-gb",
+        type=float,
+        default=None,
+        help=(
+            "Hard memory limit in GB (only used if --enable-memory-limit is set). "
+            "If omitted, no memory limit is applied by default."
+        ),
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=str,
+        default="../benchmark_results_drug_rec_workers_sweep.csv",
+        help="Where to write per-run results as CSV",
+    )
+    args = parser.parse_args()
+
+    if args.repeats <= 0:
+        raise SystemExit("--repeats must be > 0")
+
+    if args.enable_memory_limit:
+        if args.max_memory_gb is None:
+            raise SystemExit(
+                "When using --enable-memory-limit, you must also pass "
+                "--max-memory-gb (e.g., --max-memory-gb 32)."
+            )
+        set_memory_limit(args.max_memory_gb)
+
+    tracker = PeakMemoryTracker(poll_interval_s=0.1)
+    tracker.start()
+
+    print("=" * 80)
+    print("BENCHMARK: Drug Recommendation num_workers sweep")
+    print(f"workers={args.workers} repeats={args.repeats} dev={args.dev}")
+    if args.enable_memory_limit:
+        print(f"Memory Limit: {args.max_memory_gb} GB (ENFORCED)")
+    else:
+        print("Memory Limit: None (unrestricted)")
+    print(f"ehr_root: {args.ehr_root}")
+    print(f"cache_root: {args.cache_root}")
+    print("=" * 80)
+
+    cache_root = Path(args.cache_root)
+    base_cache_dir = cache_root / (
+        "base_dataset_drug_rec_dev" if args.dev else "base_dataset_drug_rec"
+    )
+
+    total_start = time.time()
+
+    results: list[RunResult] = []
+
+    print("\n[1/1] Sweeping num_workers (each run reloads dataset + task)...")
+    for w in args.workers:
+        for r in range(args.repeats):
+            task_cache_dir = cache_root / f"task_samples_drug_rec_w{w}"
+
+            # Ensure no cache artifacts before this run.
+            remove_dir(base_cache_dir)
+            ensure_empty_dir(task_cache_dir)
+
+            tracker.reset()
+            run_start = time.time()
+
+            dataset_start = time.time()
+            base_dataset = MIMIC4Dataset(
+                ehr_root=args.ehr_root,
+                ehr_tables=[
+                    "patients",
+                    "admissions",
+                    "diagnoses_icd",
+                    "procedures_icd",
+                    "prescriptions",
+                ],
+                dev=args.dev,
+                cache_dir=str(base_cache_dir),
+            )
+            dataset_load_s = time.time() - dataset_start
+            base_cache_bytes = get_directory_size(base_cache_dir)
+
+            task_start = time.time()
+            sample_dataset = base_dataset.set_task(
+                DrugRecommendationMIMIC4(),
+                num_workers=w,
+                cache_dir=str(task_cache_dir),
+            )
+
+            task_process_s = time.time() - task_start
+            total_s = time.time() - run_start
+            peak_rss_bytes = tracker.peak_bytes()
+            task_cache_bytes = get_directory_size(task_cache_dir)
+
+            # Capture sample count BEFORE cleaning up the cache (litdata needs it).
+            num_samples = len(sample_dataset)
+
+            # Release the dataset reference to free file handles before cleanup.
+            del sample_dataset
+            del base_dataset
+
+            # Clean up to avoid disk growth across an overnight sweep.
+            remove_dir(task_cache_dir)
+            remove_dir(base_cache_dir)
+
+            results.append(
+                RunResult(
+                    num_workers=w,
+                    repeat_index=r,
+                    dataset_load_s=dataset_load_s,
+                    task_process_s=task_process_s,
+                    total_s=total_s,
+                    base_cache_bytes=base_cache_bytes,
+                    task_cache_bytes=task_cache_bytes,
+                    peak_rss_bytes=peak_rss_bytes,
+                )
+            )
+
+            print(
+                "✓ "
+                f"workers={w:>2} repeat={r+1:>2}/{args.repeats} "
+                f"samples={num_samples} "
+                f"dataset={dataset_load_s:.2f}s "
+                f"task={task_process_s:.2f}s "
+                f"total={total_s:.2f}s "
+                f"peak_rss={format_size(peak_rss_bytes)} "
+                f"base_cache={format_size(base_cache_bytes)} "
+                f"task_cache={format_size(task_cache_bytes)}"
+            )
+
+    total_sweep_s = time.time() - total_start
+
+    # Write CSV
+    out_csv = Path(args.output_csv)
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    with out_csv.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(asdict(results[0]).keys()))
+        writer.writeheader()
+        for rr in results:
+            writer.writerow(asdict(rr))
+
+    # Print a compact summary per worker (median across repeats)
+    print("\n" + "=" * 80)
+    print("SUMMARY (median across repeats)")
+    print("=" * 80)
+
+    for w in args.workers:
+        wrs = [rr for rr in results if rr.num_workers == w]
+        med_task = median([rr.task_process_s for rr in wrs])
+        med_total = median([rr.total_s for rr in wrs])
+        med_peak = median([float(rr.peak_rss_bytes) for rr in wrs])
+        med_cache = median([float(rr.task_cache_bytes) for rr in wrs])
+        print(
+            f"workers={w:>2}  "
+            f"task_med={med_task:>8.2f}s  "
+            f"total_med={med_total:>8.2f}s  "
+            f"peak_rss_med={format_size(int(med_peak)):>10}  "
+            f"task_cache_med={format_size(int(med_cache)):>10}"
+        )
+
+    print("\nArtifacts:")
+    print(f"  - CSV: {out_csv}")
+    print(f"  - Cache root: {cache_root}")
+    print("\nTotals:")
+    print(f"  - Sweep wall time: {total_sweep_s:.2f}s")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/benchmark_perf/legacy_ver/benchmark_legacy_drug_rec.py
+++ b/examples/benchmark_perf/legacy_ver/benchmark_legacy_drug_rec.py
@@ -1,0 +1,471 @@
+"""Legacy PyHealth 1.1.6 Benchmark script for MIMIC-IV drug recommendation.
+
+This benchmark measures performance across multiple worker counts (via pandarallel):
+1. Time to load the base dataset
+2. Time to process the task for each num_workers value
+3. Cache sizes for base dataset
+4. Peak memory usage (RSS, includes child processes)
+
+Typical usage:
+  # First, install the legacy version:
+  pip install pyhealth==1.1.6
+
+  # Then run the benchmark:
+  python benchmark_legacy_drug_rec.py
+  python benchmark_legacy_drug_rec.py --workers 1,4,8,12,16 --repeats 3
+  python benchmark_legacy_drug_rec.py --dev --workers 1,2,4
+
+API differences from PyHealth 2.0:
+- Uses `root` instead of `ehr_root`
+- Uses `tables` instead of `ehr_tables`
+- Uses `refresh_cache` instead of `cache_dir`
+- set_task() takes a `task_fn` function instead of a task class
+- Parallelization via pandarallel (not num_workers in set_task)
+
+Notes:
+- This uses the PyHealth 1.1.6 legacy API
+- Uses the built-in drug_recommendation_mimic4_fn task function
+- Pandarallel is re-initialized for each worker count
+- Cache is cleared before each run to ensure fresh timing data
+- Peak memory is sampled in a background thread; it reports total RSS of the current
+  process plus all child processes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import shutil
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+import psutil
+
+# Import pandarallel - will be initialized before each run
+from pandarallel import pandarallel
+
+# Global variable to store desired worker count for monkey-patching
+_DESIRED_NB_WORKERS: int = 16
+
+# Store the original pandarallel.initialize function
+_original_pandarallel_initialize = pandarallel.initialize
+
+
+def _patched_pandarallel_initialize(*args, **kwargs):
+    """Patched pandarallel.initialize that enforces our worker count.
+    
+    The legacy PyHealth code calls pandarallel.initialize() without nb_workers,
+    which defaults to all CPUs. This patch ensures our desired worker count is used.
+    """
+    # Override nb_workers with our desired value
+    kwargs['nb_workers'] = _DESIRED_NB_WORKERS
+    return _original_pandarallel_initialize(*args, **kwargs)
+
+
+# Apply the monkey-patch
+pandarallel.initialize = _patched_pandarallel_initialize
+
+# Legacy PyHealth 1.1.6 imports (AFTER monkey-patching)
+from pyhealth.datasets import MIMIC4Dataset
+from pyhealth.datasets.utils import MODULE_CACHE_PATH
+from pyhealth.tasks import drug_recommendation_mimic4_fn
+
+try:
+    import resource
+
+    HAS_RESOURCE = True
+except ImportError:
+    HAS_RESOURCE = False
+
+
+# =============================================================================
+# Benchmark Infrastructure
+# =============================================================================
+
+
+@dataclass
+class RunResult:
+    num_workers: int
+    repeat_index: int
+    dataset_load_s: float
+    task_process_s: float
+    total_s: float
+    base_cache_bytes: int
+    peak_rss_bytes: int
+    num_samples: int
+
+
+def format_size(size_bytes: int) -> str:
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024.0:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024.0
+    return f"{size_bytes:.2f} PB"
+
+
+def get_directory_size(path: str | Path) -> int:
+    total = 0
+    p = Path(path)
+    if not p.exists():
+        return 0
+    try:
+        for entry in p.rglob("*"):
+            if entry.is_file():
+                try:
+                    total += entry.stat().st_size
+                except FileNotFoundError:
+                    pass
+    except Exception as e:
+        print(f"Error calculating size for {p}: {e}")
+    return total
+
+
+def clear_pyhealth_cache(verbose: bool = True) -> int:
+    """Clear all PyHealth cache files.
+    
+    PyHealth 1.1.6 stores cache as .pkl files in MODULE_CACHE_PATH.
+    This function deletes all .pkl files in that directory.
+    
+    Args:
+        verbose: Whether to print information about deleted files.
+        
+    Returns:
+        Number of cache files deleted.
+    """
+    cache_path = Path(MODULE_CACHE_PATH)
+    if not cache_path.exists():
+        return 0
+    
+    deleted_count = 0
+    total_size = 0
+    
+    # Find all .pkl cache files
+    for cache_file in cache_path.glob("*.pkl"):
+        try:
+            file_size = cache_file.stat().st_size
+            cache_file.unlink()
+            deleted_count += 1
+            total_size += file_size
+        except OSError as e:
+            if verbose:
+                print(f"    Warning: Could not delete {cache_file}: {e}")
+    
+    if verbose and deleted_count > 0:
+        print(f"    Cleared {deleted_count} cache files ({format_size(total_size)})")
+    
+    return deleted_count
+
+
+def set_memory_limit(max_memory_gb: float) -> None:
+    """Set a hard virtual memory limit for the process."""
+    if not HAS_RESOURCE:
+        print(
+            "Warning: resource module not available (Windows?). "
+            "Memory limit not enforced."
+        )
+        return
+
+    max_memory_bytes = int(max_memory_gb * 1024**3)
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (max_memory_bytes, max_memory_bytes))
+        print(f"✓ Memory limit set to {max_memory_gb} GB")
+    except Exception as e:
+        print(f"Warning: Failed to set memory limit: {e}")
+
+
+class PeakMemoryTracker:
+    """Tracks peak RSS for current process + children."""
+
+    def __init__(self, poll_interval_s: float = 0.1) -> None:
+        self._proc = psutil.Process(os.getpid())
+        self._poll_interval_s = poll_interval_s
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._peak = 0
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def reset(self) -> None:
+        with self._lock:
+            self._peak = 0
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def peak_bytes(self) -> int:
+        with self._lock:
+            return self._peak
+
+    def _total_rss_bytes(self) -> int:
+        total = 0
+        try:
+            total += self._proc.memory_info().rss
+            for child in self._proc.children(recursive=True):
+                try:
+                    total += child.memory_info().rss
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+        return total
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            rss = self._total_rss_bytes()
+            with self._lock:
+                if rss > self._peak:
+                    self._peak = rss
+            time.sleep(self._poll_interval_s)
+
+
+def remove_dir(path: str | Path, retries: int = 3, delay: float = 1.0) -> None:
+    """Remove a directory with retry logic for busy file handles."""
+    p = Path(path)
+    if not p.exists():
+        return
+    for attempt in range(retries):
+        try:
+            shutil.rmtree(p)
+            return
+        except OSError as e:
+            if attempt < retries - 1:
+                time.sleep(delay)
+            else:
+                print(f"Warning: Failed to delete {p} after {retries} attempts: {e}")
+
+
+def parse_workers(value: str) -> list[int]:
+    """Parse comma-separated list of worker counts."""
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    workers: list[int] = []
+    for p in parts:
+        w = int(p)
+        if w <= 0:
+            raise argparse.ArgumentTypeError("All worker counts must be > 0")
+        workers.append(w)
+    if not workers:
+        raise argparse.ArgumentTypeError("No workers provided")
+    return workers
+
+
+def median(values: Iterable[float]) -> float:
+    xs = sorted(values)
+    if not xs:
+        return 0.0
+    mid = len(xs) // 2
+    if len(xs) % 2 == 1:
+        return xs[mid]
+    return (xs[mid - 1] + xs[mid]) / 2.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Legacy PyHealth 1.1.6 Benchmark for MIMIC-IV drug recommendation"
+    )
+    parser.add_argument(
+        "--workers",
+        type=parse_workers,
+        default=[1, 4, 8, 12, 16],
+        help="Comma-separated list of num_workers values (default: 1,4,8,12,16)",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=1,
+        help="Number of repeats per worker setting (default: 1)",
+    )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Use dev mode dataset loading (smaller subset)",
+    )
+    parser.add_argument(
+        "--root",
+        type=str,
+        default="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
+        help="Path to MIMIC-IV hosp directory (legacy uses single root)",
+    )
+    parser.add_argument(
+        "--enable-memory-limit",
+        action="store_true",
+        help="Enforce a hard memory limit via resource.setrlimit (Unix only)",
+    )
+    parser.add_argument(
+        "--max-memory-gb",
+        type=float,
+        default=None,
+        help=(
+            "Hard memory limit in GB (only used if --enable-memory-limit is set). "
+            "If omitted, no memory limit is applied by default."
+        ),
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=str,
+        default="benchmark_legacy_drug_rec_workers_sweep.csv",
+        help="Where to write per-run results as CSV",
+    )
+    parser.add_argument(
+        "--no-clear-cache",
+        action="store_true",
+        help="Do not clear PyHealth cache before each run (default: clear cache)",
+    )
+    args = parser.parse_args()
+
+    if args.repeats <= 0:
+        raise SystemExit("--repeats must be > 0")
+
+    if args.enable_memory_limit:
+        if args.max_memory_gb is None:
+            raise SystemExit(
+                "When using --enable-memory-limit, you must also pass "
+                "--max-memory-gb (e.g., --max-memory-gb 32)."
+            )
+        set_memory_limit(args.max_memory_gb)
+
+    tracker = PeakMemoryTracker(poll_interval_s=0.1)
+    tracker.start()
+
+    print("=" * 80)
+    print("LEGACY BENCHMARK: PyHealth 1.1.6 API - Drug Recommendation (Worker Sweep)")
+    print(f"workers={args.workers} repeats={args.repeats} dev={args.dev}")
+    print(f"clear_cache={not args.no_clear_cache}")
+    if args.enable_memory_limit:
+        print(f"Memory Limit: {args.max_memory_gb} GB (ENFORCED)")
+    else:
+        print("Memory Limit: None (unrestricted)")
+    print(f"root: {args.root}")
+    print(f"cache_path: {MODULE_CACHE_PATH}")
+    print("=" * 80)
+
+    # Determine cache directory based on PyHealth's default location
+    cache_dir = Path(MODULE_CACHE_PATH)
+
+    total_start = time.time()
+    results: list[RunResult] = []
+
+    print("\n[1/1] Sweeping num_workers (pandarallel)...")
+
+    for w in args.workers:
+        for r in range(args.repeats):
+            # Clear cache before each run to ensure fresh timing data
+            if not args.no_clear_cache:
+                print(f"\n  Clearing PyHealth cache...")
+                clear_pyhealth_cache(verbose=True)
+
+            # Set the desired worker count for pandarallel
+            # The monkey-patched initialize() will enforce this when PyHealth calls it
+            global _DESIRED_NB_WORKERS
+            _DESIRED_NB_WORKERS = w
+            print(f"  Set pandarallel worker count to {w} (will be enforced via monkey-patch)")
+
+            tracker.reset()
+            run_start = time.time()
+
+            # Step 1: Load base dataset using legacy API
+            print(f"  workers={w} repeat={r + 1}/{args.repeats}: Loading dataset...")
+            dataset_start = time.time()
+
+            # Legacy PyHealth 1.1.6 API:
+            # - Uses `root` instead of `ehr_root`
+            # - Uses `tables` instead of `ehr_tables`
+            # - Always use refresh_cache=True to force reprocessing (for accurate timing)
+            # Drug recommendation uses: diagnoses_icd, procedures_icd, prescriptions
+            base_dataset = MIMIC4Dataset(
+                root=args.root,
+                tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
+                dev=args.dev,
+                code_mapping={"NDC": "ATC"},
+                refresh_cache=True,  # Always refresh to measure processing time
+            )
+            dataset_load_s = time.time() - dataset_start
+            base_cache_bytes = get_directory_size(cache_dir)
+
+            # Step 2: Set task using legacy API (built-in drug_recommendation_mimic4_fn)
+            print("    Processing task...")
+            task_start = time.time()
+
+            sample_dataset = base_dataset.set_task(
+                task_fn=drug_recommendation_mimic4_fn
+            )
+
+            task_process_s = time.time() - task_start
+            total_s = time.time() - run_start
+            peak_rss_bytes = tracker.peak_bytes()
+
+            # Get sample count
+            num_samples = len(sample_dataset.samples)
+
+            results.append(
+                RunResult(
+                    num_workers=w,
+                    repeat_index=r,
+                    dataset_load_s=dataset_load_s,
+                    task_process_s=task_process_s,
+                    total_s=total_s,
+                    base_cache_bytes=base_cache_bytes,
+                    peak_rss_bytes=peak_rss_bytes,
+                    num_samples=num_samples,
+                )
+            )
+
+            print(
+                f"  ✓ workers={w:>2} repeat={r + 1:>2}/{args.repeats} "
+                f"samples={num_samples} "
+                f"dataset={dataset_load_s:.2f}s "
+                f"task={task_process_s:.2f}s "
+                f"total={total_s:.2f}s "
+                f"peak_rss={format_size(peak_rss_bytes)} "
+                f"cache={format_size(base_cache_bytes)}"
+            )
+
+            # Clean up references
+            del sample_dataset
+            del base_dataset
+
+    total_sweep_s = time.time() - total_start
+
+    # Write CSV
+    out_csv = Path(args.output_csv)
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    with out_csv.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(asdict(results[0]).keys()))
+        writer.writeheader()
+        for rr in results:
+            writer.writerow(asdict(rr))
+
+    # Print a compact summary per worker (median across repeats)
+    print("\n" + "=" * 80)
+    print("SUMMARY (median across repeats)")
+    print("=" * 80)
+
+    for w in args.workers:
+        wrs = [rr for rr in results if rr.num_workers == w]
+        med_dataset = median([rr.dataset_load_s for rr in wrs])
+        med_task = median([rr.task_process_s for rr in wrs])
+        med_total = median([rr.total_s for rr in wrs])
+        med_peak = median([float(rr.peak_rss_bytes) for rr in wrs])
+        print(
+            f"workers={w:>2}  "
+            f"dataset_med={med_dataset:>8.2f}s  "
+            f"task_med={med_task:>8.2f}s  "
+            f"total_med={med_total:>8.2f}s  "
+            f"peak_rss_med={format_size(int(med_peak)):>10}"
+        )
+
+    print("\nArtifacts:")
+    print(f"  - CSV: {out_csv}")
+    print(f"  - Cache dir: {cache_dir}")
+    print("\nTotals:")
+    print(f"  - Sweep wall time: {total_sweep_s:.2f}s")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmark_perf/legacy_ver/benchmark_legacy_mortality.py
+++ b/examples/benchmark_perf/legacy_ver/benchmark_legacy_mortality.py
@@ -1,0 +1,649 @@
+"""Legacy PyHealth 1.1.6 Benchmark script for MIMIC-IV mortality prediction.
+
+This benchmark measures performance across multiple worker counts (via pandarallel):
+1. Time to load the base dataset
+2. Time to process the task for each num_workers value
+3. Cache sizes for base dataset
+4. Peak memory usage (RSS, includes child processes)
+
+Typical usage:
+  # First, install the legacy version:
+  pip install pyhealth==1.1.6
+
+  # Then run the benchmark:
+  python benchmark_legacy_mortality.py
+  python benchmark_legacy_mortality.py --workers 1,4,8,12,16 --repeats 3
+  python benchmark_legacy_mortality.py --dev --workers 1,2,4
+
+API differences from PyHealth 2.0:
+- Uses `root` instead of `ehr_root`
+- Uses `tables` instead of `ehr_tables`
+- Uses `refresh_cache` instead of `cache_dir`
+- set_task() takes a `task_fn` function instead of a task class
+- Parallelization via pandarallel (not num_workers in set_task)
+
+Notes:
+- This uses the PyHealth 1.1.6 legacy API
+- Pandarallel is re-initialized for each worker count
+- Cache is cleared before each run to ensure fresh timing data
+- Peak memory is sampled in a background thread; it reports total RSS of the current
+  process plus all child processes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import os
+import shutil
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import psutil
+
+# Import pandarallel - will be initialized before each run
+from pandarallel import pandarallel
+
+# Global variable to store desired worker count for monkey-patching
+_DESIRED_NB_WORKERS: int = 16
+
+# Store the original pandarallel.initialize function
+_original_pandarallel_initialize = pandarallel.initialize
+
+
+def _patched_pandarallel_initialize(*args, **kwargs):
+    """Patched pandarallel.initialize that enforces our worker count.
+    
+    The legacy PyHealth code calls pandarallel.initialize() without nb_workers,
+    which defaults to all CPUs. This patch ensures our desired worker count is used.
+    """
+    # Override nb_workers with our desired value
+    kwargs['nb_workers'] = _DESIRED_NB_WORKERS
+    return _original_pandarallel_initialize(*args, **kwargs)
+
+
+# Apply the monkey-patch
+pandarallel.initialize = _patched_pandarallel_initialize
+
+# Legacy PyHealth 1.1.6 imports (AFTER monkey-patching)
+from pyhealth.datasets import MIMIC4Dataset
+from pyhealth.datasets.utils import MODULE_CACHE_PATH
+from pyhealth.data import Patient, Visit
+
+try:
+    import resource
+
+    HAS_RESOURCE = True
+except ImportError:
+    HAS_RESOURCE = False
+
+
+# =============================================================================
+# Lab Categories (matching StageNet implementation from PyHealth 2.0)
+# =============================================================================
+
+# Each category maps to ONE dimension in the output vector
+LAB_CATEGORIES: Dict[str, List[str]] = {
+    "Sodium": ["50824", "52455", "50983", "52623"],
+    "Potassium": ["50822", "52452", "50971", "52610"],
+    "Chloride": ["50806", "52434", "50902", "52535"],
+    "Bicarbonate": ["50803", "50804"],
+    "Glucose": ["50809", "52027", "50931", "52569"],
+    "Calcium": ["50808", "51624"],
+    "Magnesium": ["50960"],
+    "Anion Gap": ["50868", "52500"],
+    "Osmolality": ["52031", "50964", "51701"],
+    "Phosphate": ["50970"],
+}
+
+# Ordered list of category names (defines vector dimension order)
+LAB_CATEGORY_NAMES: List[str] = [
+    "Sodium",
+    "Potassium",
+    "Chloride",
+    "Bicarbonate",
+    "Glucose",
+    "Calcium",
+    "Magnesium",
+    "Anion Gap",
+    "Osmolality",
+    "Phosphate",
+]
+
+# Flat set of all lab item IDs for filtering
+LAB_ITEM_IDS: set = {
+    item for itemids in LAB_CATEGORIES.values() for item in itemids
+}
+
+
+# =============================================================================
+# Custom Task Function for Mortality Prediction with Lab Events (StageNet-like)
+# =============================================================================
+
+# Debug counter to limit print output
+_DEBUG_PRINT_COUNT = 0
+_DEBUG_PRINT_MAX = 3  # Print details for first N patients with lab events
+
+
+def mortality_prediction_labevents_mimic4_fn(patient: Patient) -> List[dict]:
+    """Processes a single patient for mortality prediction task with lab events.
+
+    This task is designed for StageNet-like models that use:
+    - diagnoses_icd: ICD diagnosis codes
+    - procedures_icd: ICD procedure codes
+    - labevents: Laboratory test results (filtered to specific item IDs)
+
+    Mortality prediction aims at predicting whether the patient will decease in the
+    next hospital visit based on the clinical information from current visit.
+
+    Args:
+        patient: a Patient object
+
+    Returns:
+        samples: a list of samples, each sample is a dict with patient_id,
+            visit_id, and other task-specific attributes as key
+
+    Note that we define the task as a binary classification task.
+    """
+    global _DEBUG_PRINT_COUNT
+    
+    samples = []
+
+    # We will drop the last visit (need next visit for mortality label)
+    for i in range(len(patient) - 1):
+        visit: Visit = patient[i]
+        next_visit: Visit = patient[i + 1]
+
+        # Determine mortality label from next visit's discharge status
+        if next_visit.discharge_status not in [0, 1]:
+            mortality_label = 0
+        else:
+            mortality_label = int(next_visit.discharge_status)
+
+        # Extract clinical codes from current visit
+        conditions = visit.get_code_list(table="diagnoses_icd")
+        procedures = visit.get_code_list(table="procedures_icd")
+
+        # Extract lab events - filter to specific StageNet item IDs
+        # Access the event list to get both codes and potentially values
+        lab_events = visit.get_event_list(table="labevents")
+        
+        # DEBUG: Print sample data for first few patients with lab events
+        if _DEBUG_PRINT_COUNT < _DEBUG_PRINT_MAX and len(lab_events) > 0:
+            print("\n" + "=" * 60)
+            print(f"DEBUG: Patient {patient.patient_id}, Visit {visit.visit_id}")
+            print(f"  Available tables in visit: {visit.available_tables}")
+            print(f"  Number of lab events: {len(lab_events)}")
+            
+            # Print first 5 lab events for inspection
+            print(f"  First 5 lab events (raw):")
+            for j, event in enumerate(lab_events[:5]):
+                print(f"    [{j}] code={event.code!r} (type={type(event.code).__name__})")
+                print(f"        vocabulary={event.vocabulary}, table={event.table}")
+                if hasattr(event, 'attr_dict') and event.attr_dict:
+                    print(f"        attr_dict={event.attr_dict}")
+            
+            # Check what codes are matching our filter
+            all_codes = [e.code for e in lab_events]
+            unique_codes = list(dict.fromkeys(all_codes))
+            matching = [c for c in unique_codes if c in LAB_ITEM_IDS]
+            print(f"  Unique lab codes (first 10): {unique_codes[:10]}")
+            print(f"  Expected LAB_ITEM_IDS (sample): {list(LAB_ITEM_IDS)[:5]}")
+            print(f"  Matching codes: {matching[:10] if matching else 'NONE!'}")
+            
+            # Check type mismatch
+            if unique_codes and not matching:
+                sample_code = unique_codes[0]
+                sample_expected = list(LAB_ITEM_IDS)[0]
+                print(f"  TYPE CHECK: code type={type(sample_code)}, expected type={type(sample_expected)}")
+                print(f"  String comparison: '{sample_code}' == '{sample_expected}' -> {sample_code == sample_expected}")
+            
+            _DEBUG_PRINT_COUNT += 1
+            print("=" * 60 + "\n")
+        
+        # Filter to only the lab item IDs we care about (StageNet categories)
+        filtered_lab_codes = []
+        for event in lab_events:
+            if event.code in LAB_ITEM_IDS:
+                filtered_lab_codes.append(event.code)
+        
+        # Remove duplicates while preserving order
+        labs = list(dict.fromkeys(filtered_lab_codes))
+
+        # Exclude visits without sufficient clinical information
+        # For lab-based mortality prediction, we require at least conditions and labs
+        if len(conditions) == 0 or len(labs) == 0:
+            continue
+
+        samples.append(
+            {
+                "visit_id": visit.visit_id,
+                "patient_id": patient.patient_id,
+                "conditions": [conditions],
+                "procedures": [procedures] if procedures else [[]],
+                "labs": [labs],
+                "label": mortality_label,
+            }
+        )
+
+    return samples
+
+
+# =============================================================================
+# Benchmark Infrastructure
+# =============================================================================
+
+
+@dataclass
+class RunResult:
+    num_workers: int
+    repeat_index: int
+    dataset_load_s: float
+    task_process_s: float
+    total_s: float
+    base_cache_bytes: int
+    peak_rss_bytes: int
+    num_samples: int
+
+
+def format_size(size_bytes: int) -> str:
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024.0:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024.0
+    return f"{size_bytes:.2f} PB"
+
+
+def get_directory_size(path: str | Path) -> int:
+    total = 0
+    p = Path(path)
+    if not p.exists():
+        return 0
+    try:
+        for entry in p.rglob("*"):
+            if entry.is_file():
+                try:
+                    total += entry.stat().st_size
+                except FileNotFoundError:
+                    pass
+    except Exception as e:
+        print(f"Error calculating size for {p}: {e}")
+    return total
+
+
+def clear_pyhealth_cache(verbose: bool = True) -> int:
+    """Clear all PyHealth cache files.
+    
+    PyHealth 1.1.6 stores cache as .pkl files in MODULE_CACHE_PATH.
+    This function deletes all .pkl files in that directory.
+    
+    Args:
+        verbose: Whether to print information about deleted files.
+        
+    Returns:
+        Number of cache files deleted.
+    """
+    cache_path = Path(MODULE_CACHE_PATH)
+    if not cache_path.exists():
+        return 0
+    
+    deleted_count = 0
+    total_size = 0
+    
+    # Find all .pkl cache files
+    for cache_file in cache_path.glob("*.pkl"):
+        try:
+            file_size = cache_file.stat().st_size
+            cache_file.unlink()
+            deleted_count += 1
+            total_size += file_size
+        except OSError as e:
+            if verbose:
+                print(f"    Warning: Could not delete {cache_file}: {e}")
+    
+    if verbose and deleted_count > 0:
+        print(f"    Cleared {deleted_count} cache files ({format_size(total_size)})")
+    
+    return deleted_count
+
+
+def set_memory_limit(max_memory_gb: float) -> None:
+    """Set a hard virtual memory limit for the process."""
+    if not HAS_RESOURCE:
+        print(
+            "Warning: resource module not available (Windows?). "
+            "Memory limit not enforced."
+        )
+        return
+
+    max_memory_bytes = int(max_memory_gb * 1024**3)
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (max_memory_bytes, max_memory_bytes))
+        print(f"✓ Memory limit set to {max_memory_gb} GB")
+    except Exception as e:
+        print(f"Warning: Failed to set memory limit: {e}")
+
+
+class PeakMemoryTracker:
+    """Tracks peak RSS for current process + children."""
+
+    def __init__(self, poll_interval_s: float = 0.1) -> None:
+        self._proc = psutil.Process(os.getpid())
+        self._poll_interval_s = poll_interval_s
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._peak = 0
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def reset(self) -> None:
+        with self._lock:
+            self._peak = 0
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def peak_bytes(self) -> int:
+        with self._lock:
+            return self._peak
+
+    def _total_rss_bytes(self) -> int:
+        total = 0
+        try:
+            total += self._proc.memory_info().rss
+            for child in self._proc.children(recursive=True):
+                try:
+                    total += child.memory_info().rss
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+        return total
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            rss = self._total_rss_bytes()
+            with self._lock:
+                if rss > self._peak:
+                    self._peak = rss
+            time.sleep(self._poll_interval_s)
+
+
+def remove_dir(path: str | Path, retries: int = 3, delay: float = 1.0) -> None:
+    """Remove a directory with retry logic for busy file handles."""
+    p = Path(path)
+    if not p.exists():
+        return
+    for attempt in range(retries):
+        try:
+            shutil.rmtree(p)
+            return
+        except OSError as e:
+            if attempt < retries - 1:
+                time.sleep(delay)
+            else:
+                print(f"Warning: Failed to delete {p} after {retries} attempts: {e}")
+
+
+def parse_workers(value: str) -> list[int]:
+    """Parse comma-separated list of worker counts."""
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    workers: list[int] = []
+    for p in parts:
+        w = int(p)
+        if w <= 0:
+            raise argparse.ArgumentTypeError("All worker counts must be > 0")
+        workers.append(w)
+    if not workers:
+        raise argparse.ArgumentTypeError("No workers provided")
+    return workers
+
+
+def median(values: Iterable[float]) -> float:
+    xs = sorted(values)
+    if not xs:
+        return 0.0
+    mid = len(xs) // 2
+    if len(xs) % 2 == 1:
+        return xs[mid]
+    return (xs[mid - 1] + xs[mid]) / 2.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Legacy PyHealth 1.1.6 Benchmark for MIMIC-IV mortality prediction"
+    )
+    parser.add_argument(
+        "--workers",
+        type=parse_workers,
+        default=[1, 4, 8, 12, 16],
+        help="Comma-separated list of num_workers values (default: 1,4,8,12,16)",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=1,
+        help="Number of repeats per worker setting (default: 1)",
+    )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Use dev mode dataset loading (smaller subset)",
+    )
+    parser.add_argument(
+        "--root",
+        type=str,
+        default="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
+        help="Path to MIMIC-IV hosp directory (legacy uses single root)",
+    )
+    parser.add_argument(
+        "--enable-memory-limit",
+        action="store_true",
+        help="Enforce a hard memory limit via resource.setrlimit (Unix only)",
+    )
+    parser.add_argument(
+        "--max-memory-gb",
+        type=float,
+        default=None,
+        help=(
+            "Hard memory limit in GB (only used if --enable-memory-limit is set). "
+            "If omitted, no memory limit is applied by default."
+        ),
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=str,
+        default="benchmark_legacy_mortality_workers_sweep.csv",
+        help="Where to write per-run results as CSV",
+    )
+    parser.add_argument(
+        "--no-clear-cache",
+        action="store_true",
+        help="Do not clear PyHealth cache before each run (default: clear cache)",
+    )
+    args = parser.parse_args()
+
+    if args.repeats <= 0:
+        raise SystemExit("--repeats must be > 0")
+
+    if args.enable_memory_limit:
+        if args.max_memory_gb is None:
+            raise SystemExit(
+                "When using --enable-memory-limit, you must also pass "
+                "--max-memory-gb (e.g., --max-memory-gb 32)."
+            )
+        set_memory_limit(args.max_memory_gb)
+
+    tracker = PeakMemoryTracker(poll_interval_s=0.1)
+    tracker.start()
+
+    print("=" * 80)
+    print("LEGACY BENCHMARK: PyHealth 1.1.6 API - Mortality Prediction (Worker Sweep)")
+    print(f"workers={args.workers} repeats={args.repeats} dev={args.dev}")
+    print(f"clear_cache={not args.no_clear_cache}")
+    if args.enable_memory_limit:
+        print(f"Memory Limit: {args.max_memory_gb} GB (ENFORCED)")
+    else:
+        print("Memory Limit: None (unrestricted)")
+    print(f"root: {args.root}")
+    print(f"cache_path: {MODULE_CACHE_PATH}")
+    print("=" * 80)
+
+    # Determine cache directory based on PyHealth's default location
+    cache_dir = Path(MODULE_CACHE_PATH)
+
+    total_start = time.time()
+    results: list[RunResult] = []
+
+    print("\n[1/1] Sweeping num_workers (pandarallel)...")
+
+    for w in args.workers:
+        for r in range(args.repeats):
+            # Clear cache before each run to ensure fresh timing data
+            if not args.no_clear_cache:
+                print(f"\n  Clearing PyHealth cache...")
+                clear_pyhealth_cache(verbose=True)
+
+            # Set the desired worker count for pandarallel
+            # The monkey-patched initialize() will enforce this when PyHealth calls it
+            global _DESIRED_NB_WORKERS
+            _DESIRED_NB_WORKERS = w
+            print(f"  Set pandarallel worker count to {w} (will be enforced via monkey-patch)")
+
+            tracker.reset()
+            run_start = time.time()
+
+            # Step 1: Load base dataset using legacy API
+            print(f"  workers={w} repeat={r + 1}/{args.repeats}: Loading dataset...")
+            dataset_start = time.time()
+
+            # Legacy PyHealth 1.1.6 API:
+            # - Uses `root` instead of `ehr_root`
+            # - Uses `tables` instead of `ehr_tables`
+            # - Always use refresh_cache=True to force reprocessing (for accurate timing)
+            base_dataset = MIMIC4Dataset(
+                root=args.root,
+                tables=["diagnoses_icd", "procedures_icd", "labevents"],
+                dev=args.dev,
+                refresh_cache=True,  # Always refresh to measure processing time
+            )
+            dataset_load_s = time.time() - dataset_start
+            base_cache_bytes = get_directory_size(cache_dir)
+
+            # Step 2: Set task using legacy API (task_fn function, no num_workers)
+            print("    Processing task...")
+            task_start = time.time()
+
+            sample_dataset = base_dataset.set_task(
+                task_fn=mortality_prediction_labevents_mimic4_fn
+            )
+
+            task_process_s = time.time() - task_start
+            total_s = time.time() - run_start
+            peak_rss_bytes = tracker.peak_bytes()
+
+            # Get sample count
+            num_samples = len(sample_dataset.samples)
+            
+            # Print sample information for debugging (only on first run)
+            if r == 0 and w == args.workers[0]:
+                print("\n" + "-" * 60)
+                print("SAMPLE DATASET INFO:")
+                print(f"  Total samples: {num_samples}")
+                if num_samples > 0:
+                    print(f"  Sample keys: {list(sample_dataset.samples[0].keys())}")
+                    # Show first sample structure
+                    first_sample = sample_dataset.samples[0]
+                    print(f"\n  Example sample (first):")
+                    print(f"    patient_id: {first_sample.get('patient_id')}")
+                    print(f"    visit_id: {first_sample.get('visit_id')}")
+                    print(f"    conditions: {first_sample.get('conditions', [])[:1]}...")  # Nested
+                    print(f"    procedures: {first_sample.get('procedures', [])[:1]}...")  # Nested
+                    print(f"    labs: {first_sample.get('labs', [])}")  # Should be nested [[lab1, lab2, ...]]
+                    print(f"    label: {first_sample.get('label')}")
+                    
+                    # Verify labs structure
+                    labs = first_sample.get('labs', [])
+                    if labs and isinstance(labs, list) and len(labs) > 0:
+                        inner_labs = labs[0] if isinstance(labs[0], list) else labs
+                        print(f"\n  Labs verification:")
+                        print(f"    Outer list length: {len(labs)}")
+                        print(f"    Inner list length: {len(inner_labs) if isinstance(labs[0], list) else 'N/A (not nested)'}")
+                        print(f"    Sample lab codes: {inner_labs[:5] if inner_labs else 'EMPTY'}")
+                else:
+                    print("  WARNING: No samples created! Check if lab codes are matching.")
+                print("-" * 60 + "\n")
+
+            results.append(
+                RunResult(
+                    num_workers=w,
+                    repeat_index=r,
+                    dataset_load_s=dataset_load_s,
+                    task_process_s=task_process_s,
+                    total_s=total_s,
+                    base_cache_bytes=base_cache_bytes,
+                    peak_rss_bytes=peak_rss_bytes,
+                    num_samples=num_samples,
+                )
+            )
+
+            print(
+                f"  ✓ workers={w:>2} repeat={r + 1:>2}/{args.repeats} "
+                f"samples={num_samples} "
+                f"dataset={dataset_load_s:.2f}s "
+                f"task={task_process_s:.2f}s "
+                f"total={total_s:.2f}s "
+                f"peak_rss={format_size(peak_rss_bytes)} "
+                f"cache={format_size(base_cache_bytes)}"
+            )
+
+            # Clean up references
+            del sample_dataset
+            del base_dataset
+
+    total_sweep_s = time.time() - total_start
+
+    # Write CSV
+    out_csv = Path(args.output_csv)
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    with out_csv.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(asdict(results[0]).keys()))
+        writer.writeheader()
+        for rr in results:
+            writer.writerow(asdict(rr))
+
+    # Print a compact summary per worker (median across repeats)
+    print("\n" + "=" * 80)
+    print("SUMMARY (median across repeats)")
+    print("=" * 80)
+
+    for w in args.workers:
+        wrs = [rr for rr in results if rr.num_workers == w]
+        med_dataset = median([rr.dataset_load_s for rr in wrs])
+        med_task = median([rr.task_process_s for rr in wrs])
+        med_total = median([rr.total_s for rr in wrs])
+        med_peak = median([float(rr.peak_rss_bytes) for rr in wrs])
+        print(
+            f"workers={w:>2}  "
+            f"dataset_med={med_dataset:>8.2f}s  "
+            f"task_med={med_task:>8.2f}s  "
+            f"total_med={med_total:>8.2f}s  "
+            f"peak_rss_med={format_size(int(med_peak)):>10}"
+        )
+
+    print("\nArtifacts:")
+    print(f"  - CSV: {out_csv}")
+    print(f"  - Cache dir: {cache_dir}")
+    print("\nTotals:")
+    print(f"  - Sweep wall time: {total_sweep_s:.2f}s")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/pixi.lock
+++ b/pixi.lock
@@ -66,6 +66,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/64/41c4367bcaecbc03ef0d2a3ecee58a7065d0a36ae1aa817fe573a2da66d4/matplotlib-3.10.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -194,6 +195,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/ab/8db1a5ac9b3a7352fb914133001dae889f9fcecb3146541be46bed41339c/matplotlib-3.10.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -298,6 +300,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6c/0c/02f1c3b66b30da9ee343c343acbb6251bef5b01d34fad732446eaadcd108/matplotlib-3.10.3-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -403,6 +406,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/0f/eed564407bd4d935ffabf561ed31099ed609e19287409a27b6d336848653/matplotlib-3.10.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -490,6 +494,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
@@ -627,6 +632,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.1.0-hf1166c9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.5.1-hd08dc88_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
@@ -741,6 +747,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.2-hf8de324_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.1-h81ee809_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
@@ -854,6 +861,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.2-hf5d6505_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.1-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh145f28c_0.conda
@@ -1615,6 +1623,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
@@ -1751,6 +1760,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.1.0-hf1166c9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.5.1-hd08dc88_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
@@ -1864,6 +1874,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.2-hf8de324_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.1-h81ee809_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
@@ -1976,6 +1987,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.2-hf5d6505_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.1-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -2140,6 +2152,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/64/41c4367bcaecbc03ef0d2a3ecee58a7065d0a36ae1aa817fe573a2da66d4/matplotlib-3.10.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -2269,6 +2282,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/ab/8db1a5ac9b3a7352fb914133001dae889f9fcecb3146541be46bed41339c/matplotlib-3.10.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -2374,6 +2388,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6c/0c/02f1c3b66b30da9ee343c343acbb6251bef5b01d34fad732446eaadcd108/matplotlib-3.10.3-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -2480,6 +2495,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/0f/eed564407bd4d935ffabf561ed31099ed609e19287409a27b6d336848653/matplotlib-3.10.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -2600,6 +2616,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/64/41c4367bcaecbc03ef0d2a3ecee58a7065d0a36ae1aa817fe573a2da66d4/matplotlib-3.10.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -2728,6 +2745,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/ab/8db1a5ac9b3a7352fb914133001dae889f9fcecb3146541be46bed41339c/matplotlib-3.10.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -2832,6 +2850,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6c/0c/02f1c3b66b30da9ee343c343acbb6251bef5b01d34fad732446eaadcd108/matplotlib-3.10.3-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -2937,6 +2956,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/0f/eed564407bd4d935ffabf561ed31099ed609e19287409a27b6d336848653/matplotlib-3.10.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ba/2e714947ff8786f370d71940f83cd928fa807c83ef660709824cb770d804/mne-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/87/0d/1861d1599571974b15b025e12b142d8e6b42ad66c8a07a89cb0fc21f1e03/narwhals-2.13.0-py3-none-any.whl
@@ -5488,6 +5508,11 @@ packages:
   - vulture ; extra == 'test-extra'
   - wheel ; extra == 'test-extra'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
+  name: more-itertools
+  version: 10.8.0
+  sha256: 52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhd8ed1ab_0.conda
   sha256: fabe81c8f8f3e1d0ef227fc1306526c76189b3f1175f12302c707e0972dd707c
   md5: d7620a15dc400b448e1c88a981b23ddd
@@ -6790,8 +6815,8 @@ packages:
   timestamp: 1750615908735
 - pypi: ./
   name: pyhealth
-  version: 2.0a13
-  sha256: e18e9cd98265905468a20a551e092a9f695f2fd9ac2fb5c000acf46be115a019
+  version: 2.0a14
+  sha256: 1e57bb9914feb2f50571ac2e0ee646294dfb2c01eed1c5dcd5b19f08f87f1da1
   requires_dist:
   - torch~=2.7.1
   - torchvision
@@ -6811,10 +6836,11 @@ packages:
   - pandarallel~=1.6.5
   - pydantic~=2.11.7
   - dask[complete]~=2025.11.0
-  - litdata~=0.2.58
+  - litdata~=0.2.59
   - pyarrow~=22.0.0
   - narwhals~=2.13.0
-  requires_python: '>=3.10,<3.14'
+  - more-itertools~=10.8.0
+  requires_python: '>=3.12,<3.14'
   editable: true
 - pypi: https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl
   name: pyparsing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [project]
 name = "pyhealth"
 # must be kept in sync with git tags; is not updated by any automation tools
-version = "2.0a13"
+version = "2.0a14"
 authors = [
   {name = "John Wu", email = "johnwu3@illinois.edu"},
   {name = "Chaoqi Yang"},
@@ -20,7 +20,7 @@ authors = [
 ]
 description = "A Python library for healthcare AI"
 readme = "README.rst"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.12,<3.14"
 dependencies = [
   "torch~=2.7.1",
   "torchvision",


### PR DESCRIPTION
This pull request adds two new benchmarking scripts for drug recommendation tasks using the MIMIC-IV dataset and updates the installation documentation to clarify Python version requirements and recommended package versions. The new scripts provide reproducible performance measurements for both single-threaded pandas processing and parallelized PyHealth task processing with configurable worker counts, including detailed tracking of memory usage and cache sizes.

**Benchmarking scripts for drug recommendation:**

* Added `examples/benchmark_perf/benchmark_pandas_drug_rec.py`, a standalone pandas-based benchmark for the MIMIC-IV drug recommendation task, including cumulative visit history construction, memory tracking, and result reporting.
* Added `examples/benchmark_perf/benchmark_workers_n_drug_recommendation.py`, a benchmarking script that measures PyHealth's drug recommendation task performance across multiple `num_workers` values. It tracks dataset/task cache sizes, peak memory usage (including child processes), and supports repeated runs for robust statistics. Results are written to CSV for analysis.

**Documentation updates:**

* Updated `docs/install.rst` to clarify that PyHealth 2.0 requires Python 3.12 or higher (up to 3.13), reflecting a hard dependency on modern Python features. Also updated recommended and legacy version installation instructions and notes.