### PR TITLE
Typo in "How to Get Started" Documentation

### DIFF
--- a/docs/how_to_get_started.rst
+++ b/docs/how_to_get_started.rst
@@ -120,7 +120,7 @@ Example:
        train_dataloader=train_loader,
        val_dataloader=val_loader,
        epochs=50,
-       monitor="pr_auc_samples",
+       monitor="pr_auc",
    )
 
 Stage 5: Evaluating Model Performance


### PR DESCRIPTION
Fixing a small typo in the "how_to_get_started" documentation.

I believe for this eval/monitoring method:

```
trainer.train(
    train_dataloader=train_loader,
    val_dataloader=val_loader,
    epochs=50,
    monitor="pr_auc_samples",
)
```

We want `monitor=pr_auc` as `prc_auc_samples` is for multi label classification, whereas `pr_auc` is for binary classification (yes/no decease).

Running the current documentation leads the pipeline to error out/fail.