### PR TITLE
Add option to cache transformed data from processors and skip pipeline entirely

### DIFF
--- a/pyhealth/datasets/base_dataset.py
+++ b/pyhealth/datasets/base_dataset.py
@@ -842,7 +842,7 @@ class BaseDataset(ABC):
         )
 
         if cache_dir is None:
-            cache_dir = self.cache_dir / "tasks" / f"{task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params).hex}"
+            cache_dir = self.cache_dir / "tasks" / f"{task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params)}"
             cache_dir.mkdir(parents=True, exist_ok=True)
         else:
             # Ensure the explicitly provided cache_dir exists
@@ -875,7 +875,7 @@ class BaseDataset(ABC):
         )
 
         task_df_path = Path(cache_dir) / "task_df.ld"
-        samples_path = Path(cache_dir) / f"samples_{uuid.uuid5(uuid.NAMESPACE_DNS, proc_params).hex}.ld"
+        samples_path = Path(cache_dir) / f"samples_{uuid.uuid5(uuid.NAMESPACE_DNS, proc_params)}.ld"
 
         task_df_path.mkdir(parents=True, exist_ok=True)
         samples_path.mkdir(parents=True, exist_ok=True)

--- a/tests/core/test_caching.py
+++ b/tests/core/test_caching.py
@@ -167,7 +167,7 @@ class TestCachingFunctionality(BaseTestCase):
             default=str
         )
 
-        task_cache = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params).hex}"
+        task_cache = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params)}"
         sample_dataset = self.dataset.set_task(self.task)
 
         self.assertTrue(task_cache.exists())
@@ -211,8 +211,8 @@ class TestCachingFunctionality(BaseTestCase):
             default=str
         )
 
-        task_cache1 = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params1).hex}"
-        task_cache2 = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params2).hex}"
+        task_cache1 = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params1)}"
+        task_cache2 = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params2)}"
 
         self.assertTrue(task_cache1.exists())
         self.assertTrue(task_cache2.exists())


### PR DESCRIPTION
**Contributor**: Yongda Fan (yongdaf2@illinois.edu)

**Contribution Type**: Dataset

**Description**
Based on input/output_scheam/processors, if it detects the same one used, it will reuse the cache.

Fix #774 