### PR TITLE
init commit with additional visit ids for tables as attributes, altho…

### DIFF
--- a/pyhealth/datasets/configs/mimic4_ehr.yaml
+++ b/pyhealth/datasets/configs/mimic4_ehr.yaml
@@ -32,6 +32,7 @@ tables:
     patient_id: "subject_id"
     timestamp: "intime"
     attributes:
+      - "hadm_id"
       - "stay_id"
       - "first_careunit"
       - "last_careunit"
@@ -96,6 +97,7 @@ tables:
           - "category"
     timestamp: "charttime"
     attributes:
+      - "hadm_id"
       - "itemid"
       - "label"
       - "fluid"


### PR DESCRIPTION
…ugh can be missing values in many 
This pull request makes minor updates to the `mimic4_ehr.yaml` configuration file by adding the `hadm_id` attribute to two tables. These changes ensure that the hospital admission ID is included in the relevant tables for better data linkage and analysis.

- Configuration enhancements:
  * Added `hadm_id` to the `attributes` list in the relevant table to capture hospital admission IDs. [[1]](diffhunk://#diff-07b0508f5d4e3ba33bbb7dace77e8fc95458547c27e4dc13d35555b6b361c3fdR35) [[2]](diffhunk://#diff-07b0508f5d4e3ba33bbb7dace77e8fc95458547c27e4dc13d35555b6b361c3fdR100)