### PR TITLE
Add multi-class support for lime & shap

### DIFF
--- a/pyhealth/interpret/methods/lime.py
+++ b/pyhealth/interpret/methods/lime.py
@@ -1024,7 +1024,7 @@ class LimeExplainer(BaseInterpreter):
         except Exception:
             loss_name = ""
 
-        is_cross_entropy = "cross_entropy" in loss_name
+        is_cross_entropy = loss_name == "cross_entropy"
         if is_cross_entropy:
             dummy = torch.zeros(
                 (batch_size,), device=self.model.device, dtype=torch.long
@@ -1046,7 +1046,7 @@ class LimeExplainer(BaseInterpreter):
         try:
             loss_fn = self.model.get_loss_function()
             loss_name = getattr(loss_fn, "__name__", "").lower()
-            return "cross_entropy" in loss_name
+            return loss_name == "cross_entropy"
         except Exception:
             return False
 

--- a/pyhealth/interpret/methods/shap.py
+++ b/pyhealth/interpret/methods/shap.py
@@ -706,7 +706,7 @@ class ShapExplainer(BaseInterpreter):
         except Exception:
             loss_name = ""
 
-        is_cross_entropy = "cross_entropy" in loss_name
+        is_cross_entropy = loss_name == "cross_entropy"
         if is_cross_entropy:
             dummy = torch.zeros(
                 (batch_size,), device=self.model.device, dtype=torch.long
@@ -728,7 +728,7 @@ class ShapExplainer(BaseInterpreter):
         try:
             loss_fn = self.model.get_loss_function()
             loss_name = getattr(loss_fn, "__name__", "").lower()
-            return "cross_entropy" in loss_name
+            return loss_name == "cross_entropy"
         except Exception:
             return False
 


### PR DESCRIPTION
Contributor: Yongda Fan ([yongdaf2@illinois.edu](mailto:yongdaf2@illinois.edu))

Contribution Type: Interpretability

Description
The old implementation suffers from 
```
RuntimeError: 0D or 1D target tensor expected, multi-target not supported
```

The new code fix this to allow both shap & lime run one the multi-class tasks