### PR TITLE
Add a few more methods to indicate the output data of a processor

### DIFF
--- a/pyhealth/processors/audio_processor.py
+++ b/pyhealth/processors/audio_processor.py
@@ -163,26 +163,16 @@ class AudioProcessor(FeatureProcessor):
             return (3,)
         return (2,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
+    def spatial(self) -> tuple[bool, ...]:
         """Whether each dimension of the output tensor is spatial.
 
         For waveform (channels, samples): channels is not spatial, samples is.
         For mel spectrogram (channels, n_mels, time): channels is not spatial,
         n_mels and time are.
 
-        Args:
-            i: Index of the output tensor (must be 0).
-
         Returns:
             Tuple of booleans for each axis.
-
-        Raises:
-            IndexError: If i != 0 (only one output tensor).
         """
-        if i != 0:
-            raise IndexError(
-                f"AudioProcessor has 1 output tensor, but index {i} was requested."
-            )
         if self.n_mels is not None:
             # (channels, n_mels, time)
             return (False, True, True)

--- a/pyhealth/processors/base_processor.py
+++ b/pyhealth/processors/base_processor.py
@@ -89,19 +89,16 @@ class FeatureProcessor(Processor):
         """
         raise NotImplementedError("dim method is not implemented for this processor.")
     
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        """Whether each dimension (axis) of the i-th output tensor is spatial (i.e. corresponds to a spatial 
+    def spatial(self) -> tuple[bool, ...]:
+        """Whether each dimension (axis) of the value tensor is spatial (i.e. corresponds to a spatial 
         axis like time, height, width, etc.) or not. This is used to determine how to apply 
         augmentations and other transformations that should only be applied to spatial dimensions.
         
         E.g. for CNN or RNN features, this would help determine which dimensions to apply spatial augmentations to, 
         and which dimensions to treat as channels or features.
         
-        Args:
-            i: Index of the output tensor to check.
-        
         Returns:
-            Tuple of booleans corresponding to whether each axis of the i-th output tensor is spatial or not.
+            Tuple of booleans corresponding to whether each axis of the value tensor is spatial or not.
         """
         raise NotImplementedError("spatial method is not implemented for this processor.")
     

--- a/pyhealth/processors/deep_nested_sequence_processor.py
+++ b/pyhealth/processors/deep_nested_sequence_processor.py
@@ -196,11 +196,7 @@ class DeepNestedSequenceProcessor(FeatureProcessor, TokenProcessorInterface):
         """Output is a 3D tensor (groups, visits, codes)."""
         return (3,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"DeepNestedSequenceProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         # Groups are not sequential; visits are temporal/spatial; codes-per-visit is an unordered set
         return (False, True, False)
 
@@ -411,10 +407,6 @@ class DeepNestedFloatsProcessor(FeatureProcessor):
         """Output is a 3D tensor (groups, visits, features)."""
         return (3,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"DeepNestedFloatsProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         # Groups are not sequential; visits are temporal/spatial; features dimension is not
         return (False, True, False)

--- a/pyhealth/processors/image_processor.py
+++ b/pyhealth/processors/image_processor.py
@@ -119,21 +119,14 @@ class ImageProcessor(FeatureProcessor):
         """
         return (3,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
+    def spatial(self) -> tuple[bool, ...]:
         """Spatial axes for the output tensor (C, H, W).
 
         Channels are not spatial; height and width are.
 
-        Args:
-            i: Index of the output tensor (must be 0).
-
         Returns:
             (False, True, True)
         """
-        if i != 0:
-            raise IndexError(
-                f"ImageProcessor has 1 output tensor, but index {i} was requested."
-            )
         return (False, True, True)
 
     def __repr__(self) -> str:

--- a/pyhealth/processors/label_processor.py
+++ b/pyhealth/processors/label_processor.py
@@ -51,11 +51,7 @@ class BinaryLabelProcessor(FeatureProcessor):
         """Output shape is (1,), so 1 dimension."""
         return (1,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"BinaryLabelProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         return (False,)
 
     def __repr__(self):
@@ -101,11 +97,7 @@ class MultiClassLabelProcessor(FeatureProcessor):
         """Output is a scalar tensor (dim 0)."""
         return (0,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"MultiClassLabelProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         return ()
 
     def __repr__(self):
@@ -162,11 +154,7 @@ class MultiLabelProcessor(FeatureProcessor):
         """Output shape is (num_classes,), so 1 dimension."""
         return (1,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"MultiLabelProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         return (False,)
 
     def __repr__(self):
@@ -196,11 +184,7 @@ class RegressionLabelProcessor(FeatureProcessor):
         """Output shape is (1,), so 1 dimension."""
         return (1,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"RegressionLabelProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         return (False,)
 
     def __repr__(self):

--- a/pyhealth/processors/nested_sequence_processor.py
+++ b/pyhealth/processors/nested_sequence_processor.py
@@ -173,11 +173,7 @@ class NestedSequenceProcessor(FeatureProcessor, TokenProcessorInterface):
         """Output is a 2D tensor (visits, codes_per_visit)."""
         return (2,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"NestedSequenceProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         # Visits (time) is spatial; codes-per-visit is an unordered set, not spatial
         return (True, False)
 
@@ -372,10 +368,6 @@ class NestedFloatsProcessor(FeatureProcessor):
         """Output is a 2D tensor (visits, features)."""
         return (2,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"NestedFloatsProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         # Visits (time) is spatial; features dimension is not
         return (True, False)

--- a/pyhealth/processors/sequence_processor.py
+++ b/pyhealth/processors/sequence_processor.py
@@ -82,11 +82,7 @@ class SequenceProcessor(FeatureProcessor, TokenProcessorInterface):
         """Output is a 1D tensor of code indices."""
         return (1,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"SequenceProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         return (True,)
 
     def __repr__(self):

--- a/pyhealth/processors/stagenet_processor.py
+++ b/pyhealth/processors/stagenet_processor.py
@@ -247,29 +247,18 @@ class StageNetProcessor(FeatureProcessor, TokenProcessorInterface):
             return (1, 2)
         return (1, 1)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        """Whether each dimension of the i-th output tensor is spatial.
-
-        Args:
-            i: 0 for time tensor, 1 for value tensor.
-        """
-        if i == 0:
-            # Time tensor: 1D, the time dimension is spatial
-            return (True,)
-        elif i == 1:
-            if self._is_nested is None:
-                raise NotImplementedError(
-                    "StageNetProcessor.spatial() requires fit() to be called first."
-                )
-            if self._is_nested:
-                # (visits, codes_per_visit) - visits are sequential/spatial,
-                # codes_per_visit is an unordered set and not spatial
-                return (True, False)
-            # Flat codes: single sequence dimension is spatial
-            return (True,)
-        raise IndexError(
-            f"StageNetProcessor has 2 output tensors, but index {i} was requested."
-        )
+    def spatial(self) -> tuple[bool, ...]:
+        """Whether each dimension of the value tensor is spatial."""
+        if self._is_nested is None:
+            raise NotImplementedError(
+                "StageNetProcessor.spatial() requires fit() to be called first."
+            )
+        if self._is_nested:
+            # (visits, codes_per_visit) - visits are sequential/spatial,
+            # codes_per_visit is an unordered set and not spatial
+            return (True, False)
+        # Flat codes: single sequence dimension is spatial
+        return (True,)
 
     def __repr__(self):
         if self._is_nested:
@@ -447,28 +436,17 @@ class StageNetTensorProcessor(FeatureProcessor):
             return (1, 2)
         return (1, 1)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        """Whether each dimension of the i-th output tensor is spatial.
-
-        Args:
-            i: 0 for time tensor, 1 for value tensor.
-        """
-        if i == 0:
-            # Time tensor: 1D, the time dimension is spatial
-            return (True,)
-        elif i == 1:
-            if self._is_nested is None:
-                raise NotImplementedError(
-                    "StageNetTensorProcessor.spatial() requires fit() to be called first."
-                )
-            if self._is_nested:
-                # (time_steps, features) - time is spatial, features are not
-                return (True, False)
-            # Flat: single sequence dimension is spatial
-            return (True,)
-        raise IndexError(
-            f"StageNetTensorProcessor has 2 output tensors, but index {i} was requested."
-        )
+    def spatial(self) -> tuple[bool, ...]:
+        """Whether each dimension of the value tensor is spatial."""
+        if self._is_nested is None:
+            raise NotImplementedError(
+                "StageNetTensorProcessor.spatial() requires fit() to be called first."
+            )
+        if self._is_nested:
+            # (time_steps, features) - time is spatial, features are not
+            return (True, False)
+        # Flat: single sequence dimension is spatial
+        return (True,)
 
     def __repr__(self):
         return (

--- a/pyhealth/processors/tensor_processor.py
+++ b/pyhealth/processors/tensor_processor.py
@@ -110,19 +110,12 @@ class TensorProcessor(FeatureProcessor):
             )
         return (self._n_dim,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
+    def spatial(self) -> tuple[bool, ...]:
         """Whether each dimension of the output tensor is spatial.
 
         If spatial_dims was provided at init, returns that. Otherwise defaults
         to all False based on n_dim.
-
-        Args:
-            i: Index of the output tensor (must be 0).
         """
-        if i != 0:
-            raise IndexError(
-                f"TensorProcessor has 1 output tensor, but index {i} was requested."
-            )
         if self._spatial_dims is not None:
             return self._spatial_dims
         if self._n_dim is None:

--- a/pyhealth/processors/timeseries_processor.py
+++ b/pyhealth/processors/timeseries_processor.py
@@ -113,11 +113,7 @@ class TimeseriesProcessor(FeatureProcessor):
         """Output is a 2D tensor (time_steps, features)."""
         return (2,)
 
-    def spatial(self, i: int) -> tuple[bool, ...]:
-        if i != 0:
-            raise IndexError(
-                f"TimeseriesProcessor has 1 output tensor, but index {i} was requested."
-            )
+    def spatial(self) -> tuple[bool, ...]:
         # Time dimension is spatial; feature dimension is not
         return (True, False)
 


### PR DESCRIPTION
This propose a new set of methods need to be implemented for processor.

This should greatly reduce the complexity for both models & interpretability methods to generalize across multiple inputs, as they now have a standard way to understand the data they are receiving. 

new APIs are
```python
    def is_token(self) -> bool:
        """Returns whether the output (in particular, the value tensor) of the processor 
        represents discrete token indices (True) or continuous values (False). This is used to 
        determine whether to apply token-based transformations (e.g. `nn.Embedding`) or 
        value-based augmentations (e.g. `nn.Linear`). 

        Returns:
            True if the output of the processor represents discrete token indices, False otherwise.
        """
        raise NotImplementedError("is_token method is not implemented for this processor.")
    
    def schema(self) -> tuple[str, ...]:
        """Returns the schema of the processed feature. For a processor that emits a single tensor,
        this should just return `["value"]`. For a processor that emits a tuple of tensors, 
        this should return a tuple of the same length as the tuple, with the semantic name of each tensor,
        such as `["time", "value"]`, `["value", "mask"]`, etc.
        
        Typical semantic names include:
            - "value": the main processed tensor output of the processor
            - "time": the time tensor output of the processor (mostly for StageNet)
            - "mask": the mask tensor output of the processor (if applicable)
        
        Returns:
            Tuple of semantic names corresponding to the output of the processor.
        """
        raise NotImplementedError("Schema method is not implemented for this processor.")
    
    def dim(self) -> tuple[int, ...]:
        """Number of dimensions (`Tensor.dim()`) for each output
        tensor, in the same order as the output tuple.

        Returns:
            Tuple of integers corresponding to the number of dimensions of each output tensor.
        """
        raise NotImplementedError("dim method is not implemented for this processor.")
    
    def spatial(self, i: int) -> tuple[bool, ...]:
        """Whether each dimension (axis) of the i-th output tensor is spatial (i.e. corresponds to a spatial 
        axis like time, height, width, etc.) or not. This is used to determine how to apply 
        augmentations and other transformations that should only be applied to spatial dimensions.
        
        E.g. for CNN or RNN features, this would help determine which dimensions to apply spatial augmentations to, 
        and which dimensions to treat as channels or features.
        
        Args:
            i: Index of the output tensor to check.
        
        Returns:
            Tuple of booleans corresponding to whether each axis of the i-th output tensor is spatial or not.
        """
        raise NotImplementedError("spatial method is not implemented for this processor.")
    
```