### PR TITLE
Fix ChestX-ray14 Example Notebooks

### DIFF
--- a/examples/cxr/chestxray14_binary_classification.ipynb
+++ b/examples/cxr/chestxray14_binary_classification.ipynb
@@ -1,0 +1,423 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5b1f2fc",
+   "metadata": {},
+   "source": [
+    "# Binary Classification Using the ChestX-ray14 Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef73c37a",
+   "metadata": {},
+   "source": [
+    "## Step 0: Install PyHealth"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89df5010",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install pyhealth ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ad732a0",
+   "metadata": {},
+   "source": [
+    "## Step 1: Load Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1f8f4f2a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading ./images_01.tar.gz...\n",
+      "Checking MD5 checksum for ./images_01.tar.gz...\n",
+      "Extracting ./images_01.tar.gz...\n",
+      "Deleting ./images_01.tar.gz...\n",
+      "Download complete\n",
+      "Initializing ChestX-ray14 dataset from . (dev mode: False)\n",
+      "No cache_dir provided. Using default cache dir: /root/.cache/pyhealth/fb6e8a46-32a1-580b-bb6c-4015d54b1bc1\n",
+      "Scanning table: chestxray14 from /root/chestxray14-metadata-pyhealth.csv\n",
+      "Caching event dataframe to /root/.cache/pyhealth/fb6e8a46-32a1-580b-bb6c-4015d54b1bc1/global_event_df.parquet...\n",
+      "Dataset: ChestX-ray14\n",
+      "Dev mode: False\n",
+      "Number of patients: 1335\n",
+      "Number of events: 4999\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyhealth.datasets import ChestXray14Dataset\n",
+    "\n",
+    "dataset = ChestXray14Dataset(download=True, partial=True)\n",
+    "dataset.stats()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "501af8c4",
+   "metadata": {},
+   "source": [
+    "## Step 2: Define Task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6cf188af",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting task ChestXray14BinaryClassification for ChestX-ray14 base dataset...\n",
+      "Applying task transformations on data with 1 workers...\n",
+      "Detected Jupyter notebook environment, setting num_workers to 1\n",
+      "Single worker mode, processing sequentially\n",
+      "Worker 0 started processing 1335 patients. (Polars threads: 22)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/1335 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rank 0 inferred the following `['bytes']` data format.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1335/1335 [00:04<00:00, 311.17it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Worker 0 finished processing patients.\n",
+      "Fitting processors on the dataset...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Label label vocab: {0: 0, 1: 1}\n",
+      "Processing samples and saving to /root/.cache/pyhealth/fb6e8a46-32a1-580b-bb6c-4015d54b1bc1/tasks/ChestXray14BinaryClassification_acac6c08-a7e0-5016-99fb-ace461d83f56/samples_0a9d8d5e-42c4-534f-9f35-24cffedeb0db.ld...\n",
+      "Applying processors on data with 1 workers...\n",
+      "Detected Jupyter notebook environment, setting num_workers to 1\n",
+      "Single worker mode, processing sequentially\n",
+      "Worker 0 started processing 4999 samples. (0 to 4999)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/4999 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rank 0 inferred the following `['tensor', 'no_header_tensor:1']` data format.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 4999/4999 [01:21<00:00, 61.52it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Worker 0 finished processing samples.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cached processed samples to /root/.cache/pyhealth/fb6e8a46-32a1-580b-bb6c-4015d54b1bc1/tasks/ChestXray14BinaryClassification_acac6c08-a7e0-5016-99fb-ace461d83f56/samples_0a9d8d5e-42c4-534f-9f35-24cffedeb0db.ld\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyhealth.tasks import ChestXray14BinaryClassification\n",
+    "\n",
+    "task = ChestXray14BinaryClassification(disease=\"infiltration\")\n",
+    "samples = dataset.set_task(task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eeb5d0fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyhealth.datasets import get_dataloader, split_by_sample\n",
+    "\n",
+    "train_dataset, val_dataset, test_dataset = split_by_sample(samples, [0.7, 0.1, 0.2])\n",
+    "\n",
+    "train_loader = get_dataloader(train_dataset, batch_size=16, shuffle=True)\n",
+    "val_loader = get_dataloader(val_dataset, batch_size=16, shuffle=False)\n",
+    "test_loader = get_dataloader(test_dataset, batch_size=16, shuffle=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "863fcec2",
+   "metadata": {},
+   "source": [
+    "## Step 3: Define Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1f0d27cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.13/site-packages/pyhealth/sampler/sage_sampler.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n",
+      "  import pkg_resources\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: No embedding created for field due to lack of compatible processor: image\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyhealth.models import CNN\n",
+    "\n",
+    "model = CNN(dataset=samples)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e1d3adc",
+   "metadata": {},
+   "source": [
+    "## Step 4: Train Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d932a8f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CNN(\n",
+      "  (embedding_model): EmbeddingModel(embedding_layers=ModuleDict())\n",
+      "  (cnn): ModuleDict(\n",
+      "    (image): CNNLayer(\n",
+      "      (cnn): ModuleList(\n",
+      "        (0): CNNBlock(\n",
+      "          (conv1): Sequential(\n",
+      "            (0): Conv2d(1, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "            (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+      "            (2): ReLU()\n",
+      "          )\n",
+      "          (conv2): Sequential(\n",
+      "            (0): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "            (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+      "          )\n",
+      "          (downsample): Sequential(\n",
+      "            (0): Conv2d(1, 128, kernel_size=(1, 1), stride=(1, 1))\n",
+      "            (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+      "          )\n",
+      "          (relu): ReLU()\n",
+      "        )\n",
+      "      )\n",
+      "      (pooling): AdaptiveAvgPool2d(output_size=1)\n",
+      "    )\n",
+      "  )\n",
+      "  (fc): Linear(in_features=128, out_features=1, bias=True)\n",
+      ")\n",
+      "Metrics: None\n",
+      "Device: cpu\n",
+      "\n",
+      "Training:\n",
+      "Batch size: 16\n",
+      "Optimizer: <class 'torch.optim.adam.Adam'>\n",
+      "Optimizer params: {'lr': 0.001}\n",
+      "Weight decay: 0.0\n",
+      "Max grad norm: None\n",
+      "Val dataloader: <torch.utils.data.dataloader.DataLoader object at 0x7f2f9e3b6350>\n",
+      "Monitor: None\n",
+      "Monitor criterion: max\n",
+      "Epochs: 1\n",
+      "Patience: None\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e539aa75e4045fdbcc80b6ea50be128",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Epoch 0 / 1:   0%|          | 0/219 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Train epoch-0, step-219 ---\n",
+      "loss: 0.4468\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluation: 100%|██████████| 32/32 [00:24<00:00,  1.32it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Eval epoch-0, step-219 ---\n",
+      "pr_auc: 0.2070\n",
+      "roc_auc: 0.6026\n",
+      "f1: 0.0000\n",
+      "loss: 0.4438\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyhealth.trainer import Trainer\n",
+    "\n",
+    "trainer = Trainer(model=model)\n",
+    "trainer.train(train_dataloader=train_loader, val_dataloader=val_loader, epochs=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41eb3279",
+   "metadata": {},
+   "source": [
+    "## Step 5: Evaluate Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "fd83ff61",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluation: 100%|██████████| 63/63 [00:47<00:00,  1.31it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'pr_auc': 0.2557703830457655,\n",
+       " 'roc_auc': 0.6404010464501405,\n",
+       " 'f1': 0.0,\n",
+       " 'loss': 0.44653598089066765}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trainer.evaluate(test_loader)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/cxr/chestxray14_multilabel_classification.ipynb
+++ b/examples/cxr/chestxray14_multilabel_classification.ipynb
@@ -1,0 +1,411 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5b1f2fc",
+   "metadata": {},
+   "source": [
+    "# Multilabel Classification Using the ChestX-ray14 Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef73c37a",
+   "metadata": {},
+   "source": [
+    "## Step 0: Install PyHealth"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89df5010",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install pyhealth ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ad732a0",
+   "metadata": {},
+   "source": [
+    "## Step 1: Load Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1f8f4f2a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading ./images_01.tar.gz...\n",
+      "Checking MD5 checksum for ./images_01.tar.gz...\n",
+      "Extracting ./images_01.tar.gz...\n",
+      "Deleting ./images_01.tar.gz...\n",
+      "Download complete\n",
+      "Initializing ChestX-ray14 dataset from . (dev mode: False)\n",
+      "No cache_dir provided. Using default cache dir: /root/.cache/pyhealth/fb6e8a46-32a1-580b-bb6c-4015d54b1bc1\n",
+      "Scanning table: chestxray14 from /root/chestxray14-metadata-pyhealth.csv\n",
+      "Caching event dataframe to /root/.cache/pyhealth/fb6e8a46-32a1-580b-bb6c-4015d54b1bc1/global_event_df.parquet...\n",
+      "Dataset: ChestX-ray14\n",
+      "Dev mode: False\n",
+      "Number of patients: 1335\n",
+      "Number of events: 4999\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyhealth.datasets import ChestXray14Dataset\n",
+    "\n",
+    "dataset = ChestXray14Dataset(download=True, partial=True)\n",
+    "dataset.stats()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "501af8c4",
+   "metadata": {},
+   "source": [
+    "## Step 2: Define Task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6cf188af",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting task ChestXray14MultilabelClassification for ChestX-ray14 base dataset...\n",
+      "Applying task transformations on data with 1 workers...\n",
+      "Detected Jupyter notebook environment, setting num_workers to 1\n",
+      "Single worker mode, processing sequentially\n",
+      "Worker 0 started processing 1335 patients. (Polars threads: 22)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/1335 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rank 0 inferred the following `['bytes']` data format.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1335/1335 [00:04<00:00, 298.99it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Worker 0 finished processing patients.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting processors on the dataset...\n",
+      "Label labels vocab: {'atelectasis': 0, 'cardiomegaly': 1, 'consolidation': 2, 'edema': 3, 'effusion': 4, 'emphysema': 5, 'fibrosis': 6, 'hernia': 7, 'infiltration': 8, 'mass': 9, 'nodule': 10, 'pleural_thickening': 11, 'pneumonia': 12, 'pneumothorax': 13}\n",
+      "Processing samples and saving to /root/.cache/pyhealth/fb6e8a46-32a1-580b-bb6c-4015d54b1bc1/tasks/ChestXray14MultilabelClassification_f8cedbe4-72a8-53c3-922d-4cc8730f4c2d/samples_e4cb1532-b4bc-5434-aac5-9269556ad11e.ld...\n",
+      "Applying processors on data with 1 workers...\n",
+      "Detected Jupyter notebook environment, setting num_workers to 1\n",
+      "Single worker mode, processing sequentially\n",
+      "Worker 0 started processing 4999 samples. (0 to 4999)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/4999 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rank 0 inferred the following `['tensor', 'no_header_tensor:1']` data format.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 4999/4999 [01:19<00:00, 62.88it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Worker 0 finished processing samples.\n",
+      "Cached processed samples to /root/.cache/pyhealth/fb6e8a46-32a1-580b-bb6c-4015d54b1bc1/tasks/ChestXray14MultilabelClassification_f8cedbe4-72a8-53c3-922d-4cc8730f4c2d/samples_e4cb1532-b4bc-5434-aac5-9269556ad11e.ld\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "samples = dataset.set_task()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eeb5d0fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyhealth.datasets import get_dataloader, split_by_sample\n",
+    "\n",
+    "train_dataset, val_dataset, test_dataset = split_by_sample(samples, [0.7, 0.1, 0.2])\n",
+    "\n",
+    "train_loader = get_dataloader(train_dataset, batch_size=16, shuffle=True)\n",
+    "val_loader = get_dataloader(val_dataset, batch_size=16, shuffle=False)\n",
+    "test_loader = get_dataloader(test_dataset, batch_size=16, shuffle=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "863fcec2",
+   "metadata": {},
+   "source": [
+    "## Step 3: Define Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1f0d27cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.13/site-packages/pyhealth/sampler/sage_sampler.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n",
+      "  import pkg_resources\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: No embedding created for field due to lack of compatible processor: image\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyhealth.models import CNN\n",
+    "\n",
+    "model = CNN(dataset=samples)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e1d3adc",
+   "metadata": {},
+   "source": [
+    "## Step 4: Train Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d932a8f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CNN(\n",
+      "  (embedding_model): EmbeddingModel(embedding_layers=ModuleDict())\n",
+      "  (cnn): ModuleDict(\n",
+      "    (image): CNNLayer(\n",
+      "      (cnn): ModuleList(\n",
+      "        (0): CNNBlock(\n",
+      "          (conv1): Sequential(\n",
+      "            (0): Conv2d(1, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "            (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+      "            (2): ReLU()\n",
+      "          )\n",
+      "          (conv2): Sequential(\n",
+      "            (0): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "            (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+      "          )\n",
+      "          (downsample): Sequential(\n",
+      "            (0): Conv2d(1, 128, kernel_size=(1, 1), stride=(1, 1))\n",
+      "            (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+      "          )\n",
+      "          (relu): ReLU()\n",
+      "        )\n",
+      "      )\n",
+      "      (pooling): AdaptiveAvgPool2d(output_size=1)\n",
+      "    )\n",
+      "  )\n",
+      "  (fc): Linear(in_features=128, out_features=14, bias=True)\n",
+      ")\n",
+      "Metrics: ['accuracy']\n",
+      "Device: cpu\n",
+      "\n",
+      "Training:\n",
+      "Batch size: 16\n",
+      "Optimizer: <class 'torch.optim.adam.Adam'>\n",
+      "Optimizer params: {'lr': 0.001}\n",
+      "Weight decay: 0.0\n",
+      "Max grad norm: None\n",
+      "Val dataloader: <torch.utils.data.dataloader.DataLoader object at 0x7fcd62f13c50>\n",
+      "Monitor: None\n",
+      "Monitor criterion: max\n",
+      "Epochs: 1\n",
+      "Patience: None\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "031d701ec469490a9cdde45fcb16ac87",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Epoch 0 / 1:   0%|          | 0/219 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Train epoch-0, step-219 ---\n",
+      "loss: 0.2072\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluation: 100%|██████████| 32/32 [00:24<00:00,  1.29it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Eval epoch-0, step-219 ---\n",
+      "accuracy: 0.9539\n",
+      "loss: 0.1717\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyhealth.trainer import Trainer\n",
+    "\n",
+    "# Only measure accurancy because with the \"partial\" dataset it is likely that\n",
+    "# there are not positive samples of every label present in the validation and test sets\n",
+    "trainer = Trainer(model=model, metrics=[\"accuracy\"])\n",
+    "trainer.train(train_dataloader=train_loader, val_dataloader=val_loader, epochs=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41eb3279",
+   "metadata": {},
+   "source": [
+    "## Step 5: Evaluate Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "fd83ff61",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluation: 100%|██████████| 63/63 [00:48<00:00,  1.30it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'accuracy': 0.9532857142857143, 'loss': 0.1734933808209404}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trainer.evaluate(test_loader)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
In #392, I added the `chestxray14_binary_classification.ipynb` and `chestxray14_multilabel_classification.ipynb` examples. This PR cleans up three issues with these example notebooks.

1. PyHealth Install
2. GitHub Display
3. Duplicate Output

## 1. PyHealth Install
Previously, these notebooks installed PyHealth from a branch in my fork. Now that #392 is merged AND 2.0.0 is released, that can be cleaned up.

**Before**
```py
!rm -rf PyHealth
!git clone https://github.com/EricSchrock/PyHealth.git
%cd PyHealth
!git checkout ChestX-ray14
!pip install -e .
```

**After**
```py
%pip install pyhealth ipywidgets
```

> [!CAUTION]
> Is it a surprise that `ipywidgets` must also be explicitly installed? I get an error in `base_dataset.py` if I just `pip install pyhealth`.

## 2. GitHub Display
I initially generated these notebooks in Google Colab. Apparently, this added a bunch of metadata, which wasn't compatible with the GitHub web UI. Trying to view the notebooks on GitHub would show the following. This PR should fix the issue.

<img width="587" height="224" alt="image" src="https://github.com/user-attachments/assets/7f664ee4-2807-46be-b323-a8344a9a039f" />

## 3. Duplicate Output
The old versions of the example notebooks printed every output twice, which makes the example much longer and less clear. Apparently, I didn't have Google Colab properly configured to work with the Python logger. This PR fixes the duplicate output.
