### PR TITLE
Update MIMIC3 example python scripts

### DIFF
--- a/examples/drug_recommendation/drug_recommendation_mimic3_gamenet.py
+++ b/examples/drug_recommendation/drug_recommendation_mimic3_gamenet.py
@@ -1,47 +1,49 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset
 from pyhealth.datasets import split_by_patient, get_dataloader
 from pyhealth.models import GAMENet
-from pyhealth.tasks import drug_recommendation_mimic3_fn
+from pyhealth.tasks import DrugRecommendationMIMIC3
 from pyhealth.trainer import Trainer
 
-# STEP 1: load data
-base_dataset = MIMIC3Dataset(
-    root="/srv/local/data/physionet.org/files/mimiciii/1.4",
-    tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-    code_mapping={"NDC": ("ATC", {"target_kwargs": {"level": 3}})},
-    dev=True,
-    refresh_cache=False,
-)
-base_dataset.stat()
+if __name__ == "__main__":
+    # STEP 1: load data
+    base_dataset = MIMIC3Dataset(
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
+        tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
+    )
+    base_dataset.stats()
 
-# STEP 2: set task
-sample_dataset = base_dataset.set_task(drug_recommendation_mimic3_fn)
-sample_dataset.stat()
+    # STEP 2: set task
+    task = DrugRecommendationMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
-train_dataset, val_dataset, test_dataset = split_by_patient(
-    sample_dataset, [0.8, 0.1, 0.1]
-)
-train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
-val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
-test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
+    train_dataset, val_dataset, test_dataset = split_by_patient(
+        sample_dataset, [0.8, 0.1, 0.1]
+    )
+    train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
+    val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
+    test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
 
-# STEP 3: define model
-model = GAMENet(
-    sample_dataset,
-)
+    # STEP 3: define model
+    model = GAMENet(
+        sample_dataset,
+    )
 
-# STEP 4: define trainer
-trainer = Trainer(
-    model=model,
-    metrics=["jaccard_samples", "f1_samples", "pr_auc_samples", "ddi"],
-)
+    # STEP 4: define trainer
+    trainer = Trainer(
+        model=model,
+        metrics=["jaccard_samples", "f1_samples", "pr_auc_samples", "ddi"],
+    )
 
-trainer.train(
-    train_dataloader=train_dataloader,
-    val_dataloader=val_dataloader,
-    epochs=20,
-    monitor="pr_auc_samples",
-)
+    trainer.train(
+        train_dataloader=train_dataloader,
+        val_dataloader=val_dataloader,
+        epochs=1,
+        monitor="pr_auc_samples",
+    )
 
-# STEP 5: evaluate
-print (trainer.evaluate(test_dataloader))
+    # STEP 5: evaluate
+    print(trainer.evaluate(test_dataloader))

--- a/examples/drug_recommendation/drug_recommendation_mimic3_molerec.py
+++ b/examples/drug_recommendation/drug_recommendation_mimic3_molerec.py
@@ -1,50 +1,49 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset
 from pyhealth.datasets import split_by_patient, get_dataloader
 from pyhealth.models import MoleRec
-from pyhealth.tasks import drug_recommendation_mimic3_fn
+from pyhealth.tasks import DrugRecommendationMIMIC3
 from pyhealth.trainer import Trainer
 
-# STEP 1: load data
-base_dataset = MIMIC3Dataset(
-    root="/srv/local/data/physionet.org/files/mimiciii/1.4",
-    tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-    code_mapping={"NDC": ("ATC", {"target_kwargs": {"level": 3}})},
-    dev=True,
-    refresh_cache=False,
-)
-base_dataset.stat()
+if __name__ == "__main__":
+    # STEP 1: load data
+    base_dataset = MIMIC3Dataset(
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
+        tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
+    )
+    base_dataset.stats()
 
-# STEP 2: set task
-sample_dataset = base_dataset.set_task(drug_recommendation_mimic3_fn)
-sample_dataset.stat()
+    # STEP 2: set task
+    task = DrugRecommendationMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
-train_dataset, val_dataset, test_dataset = split_by_patient(
-    sample_dataset, [0.8, 0.1, 0.1]
-)
-train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
-val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
-test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
+    train_dataset, val_dataset, test_dataset = split_by_patient(
+        sample_dataset, [0.8, 0.1, 0.1]
+    )
+    train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
+    val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
+    test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
 
-# STEP 3: define model
-model = MoleRec(
-    sample_dataset,
-    feature_keys=["conditions", "procedures"],
-    label_key="drugs",
-    mode="multilabel",
-)
+    # STEP 3: define model
+    model = MoleRec(
+        sample_dataset,
+    )
 
-# STEP 4: define trainer
-trainer = Trainer(
-    model=model,
-    metrics=["jaccard_samples", "f1_samples", "pr_auc_samples", "ddi"],
-)
+    # STEP 4: define trainer
+    trainer = Trainer(
+        model=model,
+        metrics=["jaccard_samples", "f1_samples", "pr_auc_samples", "ddi"],
+    )
 
-trainer.train(
-    train_dataloader=train_dataloader,
-    val_dataloader=val_dataloader,
-    epochs=3,
-    monitor="pr_auc_samples",
-)
+    trainer.train(
+        train_dataloader=train_dataloader,
+        val_dataloader=val_dataloader,
+        epochs=1,
+        monitor="pr_auc_samples",
+    )
 
-# STEP 5: evaluate
-print (trainer.evaluate(test_dataloader))
+    # STEP 5: evaluate
+    print(trainer.evaluate(test_dataloader))

--- a/examples/drug_recommendation/drug_recommendation_mimic3_safedrug.py
+++ b/examples/drug_recommendation/drug_recommendation_mimic3_safedrug.py
@@ -1,47 +1,49 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset
 from pyhealth.datasets import split_by_patient, get_dataloader
 from pyhealth.models import SafeDrug
-from pyhealth.tasks import drug_recommendation_mimic3_fn
+from pyhealth.tasks import DrugRecommendationMIMIC3
 from pyhealth.trainer import Trainer
 
-# STEP 1: load data
-base_dataset = MIMIC3Dataset(
-    root="/srv/local/data/physionet.org/files/mimiciii/1.4",
-    tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-    code_mapping={"NDC": ("ATC", {"target_kwargs": {"level": 3}})},
-    dev=True,
-    refresh_cache=False,
-)
-base_dataset.stat()
+if __name__ == "__main__":
+    # STEP 1: load data
+    base_dataset = MIMIC3Dataset(
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
+        tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
+    )
+    base_dataset.stats()
 
-# STEP 2: set task
-sample_dataset = base_dataset.set_task(drug_recommendation_mimic3_fn)
-sample_dataset.stat()
+    # STEP 2: set task
+    task = DrugRecommendationMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
-train_dataset, val_dataset, test_dataset = split_by_patient(
-    sample_dataset, [0.8, 0.1, 0.1]
-)
-train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
-val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
-test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
+    train_dataset, val_dataset, test_dataset = split_by_patient(
+        sample_dataset, [0.8, 0.1, 0.1]
+    )
+    train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
+    val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
+    test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
 
-# STEP 3: define model
-model = SafeDrug(
-    sample_dataset,
-)
+    # STEP 3: define model
+    model = SafeDrug(
+        sample_dataset,
+    )
 
-# STEP 4: define trainer
-trainer = Trainer(
-    model=model,
-    metrics=["jaccard_samples", "f1_samples", "pr_auc_samples", "ddi"],
-)
+    # STEP 4: define trainer
+    trainer = Trainer(
+        model=model,
+        metrics=["jaccard_samples", "f1_samples", "pr_auc_samples", "ddi"],
+    )
 
-trainer.train(
-    train_dataloader=train_dataloader,
-    val_dataloader=val_dataloader,
-    epochs=25,
-    monitor="pr_auc_samples",
-)
+    trainer.train(
+        train_dataloader=train_dataloader,
+        val_dataloader=val_dataloader,
+        epochs=1,
+        monitor="pr_auc_samples",
+    )
 
-# STEP 5: evaluate
-print (trainer.evaluate(test_dataloader))
+    # STEP 5: evaluate
+    print(trainer.evaluate(test_dataloader))

--- a/examples/drug_recommendation/drug_recommendation_mimic3_transformer.py
+++ b/examples/drug_recommendation/drug_recommendation_mimic3_transformer.py
@@ -1,51 +1,49 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset
 from pyhealth.datasets import split_by_patient, get_dataloader
 from pyhealth.models import Transformer
-from pyhealth.tasks import drug_recommendation_mimic3_fn
+from pyhealth.tasks import DrugRecommendationMIMIC3
 from pyhealth.trainer import Trainer
 
-# STEP 1: load data
-base_dataset = MIMIC3Dataset(
-    root="/srv/local/data/physionet.org/files/mimiciii/1.4",
-    tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-    code_mapping={"NDC": ("ATC", {"target_kwargs": {"level": 3}})},
-    dev=True,
-    refresh_cache=True,
-)
+if __name__ == "__main__":
+    # STEP 1: load data
+    base_dataset = MIMIC3Dataset(
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
+        tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
+    )
+    base_dataset.stats()
 
-base_dataset.stat()
+    # STEP 2: set task
+    task = DrugRecommendationMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
-# STEP 2: set task
-sample_dataset = base_dataset.set_task(drug_recommendation_mimic3_fn)
-sample_dataset.stat()
+    train_dataset, val_dataset, test_dataset = split_by_patient(
+        sample_dataset, [0.8, 0.1, 0.1]
+    )
+    train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
+    val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
+    test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
 
-train_dataset, val_dataset, test_dataset = split_by_patient(
-    sample_dataset, [0.8, 0.1, 0.1]
-)
-train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
-val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
-test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
+    # STEP 3: define model
+    model = Transformer(
+        dataset=sample_dataset,
+    )
 
-# STEP 3: define model
-model = Transformer(
-    dataset=sample_dataset,
-    feature_keys=["conditions", "procedures"],
-    label_key="drugs",
-    mode="multilabel",
-)
+    # STEP 4: define trainer
+    trainer = Trainer(
+        model=model,
+        metrics=["jaccard_samples", "f1_samples", "pr_auc_samples"],
+    )
 
-# STEP 4: define trainer
-trainer = Trainer(
-    model=model,
-    metrics=["jaccard_samples", "f1_samples", "pr_auc_samples"],
-)
+    trainer.train(
+        train_dataloader=train_dataloader,
+        val_dataloader=val_dataloader,
+        epochs=1,
+        monitor="pr_auc_samples",
+    )
 
-trainer.train(
-    train_dataloader=train_dataloader,
-    val_dataloader=val_dataloader,
-    epochs=20,
-    monitor="pr_auc_samples",
-)
-
-# STEP 5: evaluate
-print (trainer.evaluate(test_dataloader))
+    # STEP 5: evaluate
+    print(trainer.evaluate(test_dataloader))

--- a/examples/length_of_stay/length_of_stay_mimic3_rnn.py
+++ b/examples/length_of_stay/length_of_stay_mimic3_rnn.py
@@ -1,45 +1,50 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset, get_dataloader, split_by_patient
 from pyhealth.models import RNN
 from pyhealth.tasks import LengthOfStayPredictionMIMIC3
 from pyhealth.trainer import Trainer
 
-# STEP 1: load data
-base_dataset = MIMIC3Dataset(
-    root="/srv/local/data/physionet.org/files/mimiciii/1.4",
-    tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-    dev=False,
-)
-base_dataset.stats()
+if __name__ == "__main__":
+    # STEP 1: load data
+    base_dataset = MIMIC3Dataset(
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
+        tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
+    )
+    base_dataset.stats()
 
-# STEP 2: set task
-sample_dataset = base_dataset.set_task(LengthOfStayPredictionMIMIC3())
+    # STEP 2: set task
+    task = LengthOfStayPredictionMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
-train_dataset, val_dataset, test_dataset = split_by_patient(
-    sample_dataset, [0.8, 0.1, 0.1]
-)
-train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
-val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
-test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
+    train_dataset, val_dataset, test_dataset = split_by_patient(
+        sample_dataset, [0.8, 0.1, 0.1]
+    )
+    train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
+    val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
+    test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
 
-# STEP 3: define model
-model = RNN(
-    dataset=sample_dataset,
-)
+    # STEP 3: define model
+    model = RNN(
+        dataset=sample_dataset,
+    )
 
-# STEP 4: define trainer
-trainer = Trainer(
-    model=model,
-    metrics=["accuracy", "f1_weighted", "f1_macro", "f1_micro"],
-)
-trainer.train(
-    train_dataloader=train_dataloader,
-    val_dataloader=val_dataloader,
-    epochs=50,
-    monitor="accuracy",
-)
+    # STEP 4: define trainer
+    trainer = Trainer(
+        model=model,
+        metrics=["accuracy", "f1_weighted", "f1_macro", "f1_micro"],
+    )
+    trainer.train(
+        train_dataloader=train_dataloader,
+        val_dataloader=val_dataloader,
+        epochs=1,
+        monitor="accuracy",
+    )
 
-# STEP 5: evaluate
-results = trainer.evaluate(test_dataloader)
-print("\nTest Results:")
-for metric, value in results.items():
-    print(f"  {metric}: {value:.4f}")
+    # STEP 5: evaluate
+    results = trainer.evaluate(test_dataloader)
+    print("\nTest Results:")
+    for metric, value in results.items():
+        print(f"  {metric}: {value:.4f}")

--- a/examples/mortality_prediction/mortality_mimic3_agent.py
+++ b/examples/mortality_prediction/mortality_mimic3_agent.py
@@ -1,23 +1,24 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset
 from pyhealth.datasets import split_by_patient, get_dataloader
 from pyhealth.models import Agent
-from pyhealth.tasks import mortality_prediction_mimic3_fn
+from pyhealth.tasks import MortalityPredictionMIMIC3
 from pyhealth.trainer import Trainer
 
 if __name__ == "__main__":
     # STEP 1: load data
     base_dataset = MIMIC3Dataset(
-        root="/srv/local/data/physionet.org/files/mimiciii/1.4",
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
         tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-        code_mapping={"ICD9CM": "CCSCM", "ICD9PROC": "CCSPROC", "NDC": "ATC"},
-        dev=False,
-        refresh_cache=False,
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
     )
-    base_dataset.stat()
+    base_dataset.stats()
 
     # STEP 2: set task
-    sample_dataset = base_dataset.set_task(mortality_prediction_mimic3_fn)
-    sample_dataset.stat()
+    task = MortalityPredictionMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
     train_dataset, val_dataset, test_dataset = split_by_patient(
         sample_dataset, [0.8, 0.1, 0.1]
@@ -29,9 +30,6 @@ if __name__ == "__main__":
     # STEP 3: define model
     model = Agent(
         dataset=sample_dataset,
-        feature_keys=["conditions", "procedures"],
-        label_key="label",
-        mode="binary",
         embedding_dim=32,
         hidden_dim=32,
     )
@@ -41,7 +39,7 @@ if __name__ == "__main__":
     trainer.train(
         train_dataloader=train_dataloader,
         val_dataloader=val_dataloader,
-        epochs=50,
+        epochs=1,
         monitor="roc_auc",
     )
 

--- a/examples/mortality_prediction/mortality_mimic3_concare.py
+++ b/examples/mortality_prediction/mortality_mimic3_concare.py
@@ -1,23 +1,24 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset
 from pyhealth.datasets import split_by_patient, get_dataloader
 from pyhealth.models import ConCare
-from pyhealth.tasks import mortality_prediction_mimic3_fn
+from pyhealth.tasks import MortalityPredictionMIMIC3
 from pyhealth.trainer import Trainer
 
 if __name__ == "__main__":
     # STEP 1: load data
     base_dataset = MIMIC3Dataset(
-        root="/srv/local/data/physionet.org/files/mimiciii/1.4",
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
         tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-        code_mapping={"ICD9CM": "CCSCM", "ICD9PROC": "CCSPROC", "NDC": "ATC"},
-        dev=False,
-        refresh_cache=False,
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
     )
-    base_dataset.stat()
+    base_dataset.stats()
 
     # STEP 2: set task
-    sample_dataset = base_dataset.set_task(mortality_prediction_mimic3_fn)
-    sample_dataset.stat()
+    task = MortalityPredictionMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
     train_dataset, val_dataset, test_dataset = split_by_patient(
         sample_dataset, [0.8, 0.1, 0.1]
@@ -29,10 +30,6 @@ if __name__ == "__main__":
     # STEP 3: define model
     model = ConCare(
         dataset=sample_dataset,
-        feature_keys=["conditions", "procedures"],
-        label_key="label",
-        mode="binary",
-        use_embedding=[True, True, True],
         hidden_dim=32,
     )
 
@@ -41,7 +38,7 @@ if __name__ == "__main__":
     trainer.train(
         train_dataloader=train_dataloader,
         val_dataloader=val_dataloader,
-        epochs=3,
+        epochs=1,
         monitor="roc_auc",
     )
 

--- a/examples/mortality_prediction/mortality_mimic3_rnn.py
+++ b/examples/mortality_prediction/mortality_mimic3_rnn.py
@@ -1,46 +1,45 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset
 from pyhealth.datasets import split_by_patient, get_dataloader
 from pyhealth.models import RNN
-from pyhealth.tasks import mortality_prediction_mimic3_fn
+from pyhealth.tasks import MortalityPredictionMIMIC3
 from pyhealth.trainer import Trainer
 
-# STEP 1: load data
-base_dataset = MIMIC3Dataset(
-    root="/srv/local/data/physionet.org/files/mimiciii/1.4",
-    tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-    code_mapping={"ICD9CM": "CCSCM", "ICD9PROC": "CCSPROC", "NDC": "ATC"},
-    dev=False,
-    refresh_cache=False,
-)
-base_dataset.stat()
+if __name__ == "__main__":
+    # STEP 1: load data
+    base_dataset = MIMIC3Dataset(
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
+        tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
+    )
+    base_dataset.stats()
 
-# STEP 2: set task
-sample_dataset = base_dataset.set_task(mortality_prediction_mimic3_fn)
-sample_dataset.stat()
+    # STEP 2: set task
+    task = MortalityPredictionMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
-train_dataset, val_dataset, test_dataset = split_by_patient(
-    sample_dataset, [0.8, 0.1, 0.1]
-)
-train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
-val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
-test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
+    train_dataset, val_dataset, test_dataset = split_by_patient(
+        sample_dataset, [0.8, 0.1, 0.1]
+    )
+    train_dataloader = get_dataloader(train_dataset, batch_size=32, shuffle=True)
+    val_dataloader = get_dataloader(val_dataset, batch_size=32, shuffle=False)
+    test_dataloader = get_dataloader(test_dataset, batch_size=32, shuffle=False)
 
-# STEP 3: define model
-model = RNN(
-    dataset=sample_dataset,
-    feature_keys=["conditions", "procedures", "drugs"],
-    label_key="label",
-    mode="binary",
-)
+    # STEP 3: define model
+    model = RNN(
+        dataset=sample_dataset,
+    )
 
-# STEP 4: define trainer
-trainer = Trainer(model=model)
-trainer.train(
-    train_dataloader=train_dataloader,
-    val_dataloader=val_dataloader,
-    epochs=50,
-    monitor="roc_auc",
-)
+    # STEP 4: define trainer
+    trainer = Trainer(model=model)
+    trainer.train(
+        train_dataloader=train_dataloader,
+        val_dataloader=val_dataloader,
+        epochs=1,
+        monitor="roc_auc",
+    )
 
-# STEP 5: evaluate
-print(trainer.evaluate(test_dataloader))
+    # STEP 5: evaluate
+    print(trainer.evaluate(test_dataloader))

--- a/examples/mortality_prediction/mortality_mimic3_stagenet.py
+++ b/examples/mortality_prediction/mortality_mimic3_stagenet.py
@@ -1,23 +1,24 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset
 from pyhealth.datasets import split_by_patient, get_dataloader
 from pyhealth.models import StageNet
-from pyhealth.tasks import mortality_prediction_mimic3_fn
+from pyhealth.tasks import MortalityPredictionMIMIC3
 from pyhealth.trainer import Trainer
 
 if __name__ == "__main__":
     # STEP 1: load data
     base_dataset = MIMIC3Dataset(
-        root="/srv/local/data/physionet.org/files/mimiciii/1.4",
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
         tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-        code_mapping={"ICD9CM": "CCSCM", "ICD9PROC": "CCSPROC", "NDC": "ATC"},
-        dev=False,
-        refresh_cache=False,
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
     )
-    base_dataset.stat()
+    base_dataset.stats()
 
     # STEP 2: set task
-    sample_dataset = base_dataset.set_task(mortality_prediction_mimic3_fn)
-    sample_dataset.stat()
+    task = MortalityPredictionMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
     train_dataset, val_dataset, test_dataset = split_by_patient(
         sample_dataset, [0.8, 0.1, 0.1]
@@ -29,9 +30,6 @@ if __name__ == "__main__":
     # STEP 3: define model
     model = StageNet(
         dataset=sample_dataset,
-        feature_keys=["conditions", "procedures"],
-        label_key="label",
-        mode="binary",
         embedding_dim=32,
     )
 
@@ -40,7 +38,7 @@ if __name__ == "__main__":
     trainer.train(
         train_dataloader=train_dataloader,
         val_dataloader=val_dataloader,
-        epochs=50,
+        epochs=1,
         monitor="roc_auc",
     )
 

--- a/examples/mortality_prediction/mortality_mimic3_tcn.py
+++ b/examples/mortality_prediction/mortality_mimic3_tcn.py
@@ -1,23 +1,24 @@
+import tempfile
+
 from pyhealth.datasets import MIMIC3Dataset
 from pyhealth.datasets import split_by_patient, get_dataloader
 from pyhealth.models import TCN
-from pyhealth.tasks import mortality_prediction_mimic3_fn
+from pyhealth.tasks import MortalityPredictionMIMIC3
 from pyhealth.trainer import Trainer
 
 if __name__ == "__main__":
     # STEP 1: load data
     base_dataset = MIMIC3Dataset(
-        root="/srv/local/data/physionet.org/files/mimiciii/1.4",
+        root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III",
         tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-        code_mapping={"ICD9CM": "CCSCM", "ICD9PROC": "CCSPROC", "NDC": "ATC"},
-        dev=False,
-        refresh_cache=False,
+        cache_dir=tempfile.TemporaryDirectory().name,
+        dev=True,
     )
-    base_dataset.stat()
+    base_dataset.stats()
 
     # STEP 2: set task
-    sample_dataset = base_dataset.set_task(mortality_prediction_mimic3_fn)
-    sample_dataset.stat()
+    task = MortalityPredictionMIMIC3()
+    sample_dataset = base_dataset.set_task(task)
 
     train_dataset, val_dataset, test_dataset = split_by_patient(
         sample_dataset, [0.8, 0.1, 0.1]
@@ -29,9 +30,6 @@ if __name__ == "__main__":
     # STEP 3: define model
     model = TCN(
         dataset=sample_dataset,
-        feature_keys=["conditions", "procedures"],
-        label_key="label",
-        mode="binary",
         embedding_dim=32,
     )
 
@@ -40,7 +38,7 @@ if __name__ == "__main__":
     trainer.train(
         train_dataloader=train_dataloader,
         val_dataloader=val_dataloader,
-        epochs=50,
+        epochs=1,
         monitor="roc_auc",
     )
 


### PR DESCRIPTION
## Overview
This PR updates most of the MIMIC3 example scripts to work with PyHealth 2.0. It does NOT update any MIMIC3 Jupyter notebook examples. It also excludes the following examples, which rely on models or metrics that are not fully working with PyHealth 2.0 (or maybe the examples just need more extensive updates to get working again).

1. `examples/patient_linkage_mimic3_medlink.py`
2. `examples/drug_recommendation/drug_recommendation_mimic3_micron.py`
3. `examples/mortality_prediction/mortality_mimic3_grasp.py`
4. `examples/readmission/readmission_mimic3_fairness.py`

If these changes look good, I can make similar updates to the following.

1. MIMIC3 Jupyter notebook examples
2. MIMIC4 examples
3. OMOP examples

## Updates for PyHealth 2.0

- Wrap all examples in main guards
- Replace 1.x task functions with 2.0 task classes
- Update to 2.0 dataset and task methods and params
- Remove the `feature_keys`, `label_key`, and `mode` input params from model init

## Updates for Ease of Use
My thought is that examples should work out of the box, handle any sharp edges, and run quickly. This enables people to quickly gain confidence that they have properly installed PyHealth.

Additionally, making the examples run quickly and without changes (e.g. to paths) allows us to quickly regression test them for releases. We could even consider adding them to the automated test pipeline (but maybe only trigger when generating release?).

- Set `dev=True` and `epochs=1` for speed
- Set `cache_dir=tempfile.TemporaryDirectory().name` to avoid any confusion if people run the same example twice
- Set `root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III"` so that the example works out of the box

> [!important]
> Discussion: I used `root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III"` to make the examples work out of the box. Would it be better to use `root="https://physionet.org/files/mimiciii-demo/1.4/"`?

## Testing
All updated example scripts ran locally without error.