### PR TITLE
[Contribution] JambaEHR: Hybrid Transformer-Mamba model for EHR prediction

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -22,6 +22,7 @@ We implement the following models for supporting multiple healthcare predictive 
     models/pyhealth.models.MoleRec
     models/pyhealth.models.Deepr
     models/pyhealth.models.EHRMamba
+    models/pyhealth.models.JambaEHR
     models/pyhealth.models.ContraWR
     models/pyhealth.models.SparcNet
     models/pyhealth.models.StageNet

--- a/docs/api/models/pyhealth.models.JambaEHR.rst
+++ b/docs/api/models/pyhealth.models.JambaEHR.rst
@@ -1,0 +1,18 @@
+pyhealth.models.JambaEHR
+=========================
+
+Overview
+--------
+
+Hybrid Transformer-Mamba model for EHR clinical prediction, inspired by
+Jamba (AI21 Labs, ICLR 2025). Interleaves self-attention and selective
+SSM layers for each feature stream, combining attention's global context
+with SSM's linear-time efficiency for long patient histories.
+
+API Reference
+-------------
+
+.. automodule:: pyhealth.models.jamba_ehr
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -7,6 +7,7 @@ from .contrawr import ContraWR, ResBlock2D
 from .deepr import Deepr, DeeprLayer
 from .embedding import EmbeddingModel
 from .gamenet import GAMENet, GAMENetLayer
+from .jamba_ehr import JambaEHR, JambaLayer
 from .logistic_regression import LogisticRegression
 from .gan import GAN
 from .gnn import GAT, GCN

--- a/pyhealth/models/jamba_ehr.py
+++ b/pyhealth/models/jamba_ehr.py
@@ -1,0 +1,481 @@
+# Author: Joshua Steier
+# Paper title: Jamba: A Hybrid Transformer-Mamba Language Model (AI21 Labs)
+# Paper link: https://arxiv.org/abs/2403.19887
+# Description: Hybrid Transformer-Mamba model for EHR sequential clinical
+#     prediction tasks. Interleaves PyHealth's TransformerBlock (self-attention)
+#     and MambaBlock (selective SSM) in a configurable ratio following the Jamba
+#     architecture, combining attention's long-range dependency modeling with
+#     SSM's linear-time efficiency for long patient histories.
+
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
+
+import torch
+import torch.nn as nn
+
+from pyhealth.datasets import SampleDataset
+from pyhealth.models import BaseModel
+from pyhealth.models.embedding import EmbeddingModel
+from pyhealth.models.transformer import TransformerBlock
+from pyhealth.models.ehrmamba import MambaBlock
+from pyhealth.models.utils import get_last_visit
+
+
+def build_layer_schedule(
+    num_transformer_layers: int,
+    num_mamba_layers: int,
+) -> List[str]:
+    """Build an interleaved layer schedule distributing Transformer layers evenly.
+
+    Follows the Jamba design principle of spacing attention layers throughout
+    the stack rather than clustering them. For example, with 2 Transformer
+    and 6 Mamba layers the schedule becomes:
+        ``['mamba', 'mamba', 'mamba', 'transformer', 'mamba', 'mamba',
+          'mamba', 'transformer']``
+
+    Args:
+        num_transformer_layers (int): Number of Transformer (attention) layers.
+        num_mamba_layers (int): Number of Mamba (SSM) layers.
+
+    Returns:
+        List[str]: Ordered list of ``"transformer"`` or ``"mamba"`` strings.
+
+    Example:
+        >>> build_layer_schedule(2, 6)
+        ['mamba', 'mamba', 'mamba', 'transformer', 'mamba', 'mamba', 'mamba', 'transformer']
+    """
+    total = num_transformer_layers + num_mamba_layers
+    if total == 0:
+        return []
+    if num_transformer_layers == 0:
+        return ["mamba"] * num_mamba_layers
+    if num_mamba_layers == 0:
+        return ["transformer"] * num_transformer_layers
+
+    schedule = ["mamba"] * total
+    stride = total / num_transformer_layers
+    for i in range(num_transformer_layers):
+        idx = int((i + 1) * stride) - 1
+        idx = min(idx, total - 1)
+        schedule[idx] = "transformer"
+
+    return schedule
+
+
+class JambaLayer(nn.Module):
+    """Hybrid Transformer-Mamba encoder stack.
+
+    Interleaves :class:`TransformerBlock` and :class:`MambaBlock` layers
+    following a configurable schedule derived from the Jamba architecture
+    (AI21 Labs, 2024). Both layer types operate on ``(batch, seq_len, hidden)``
+    tensors, making them composable within a single sequential stack.
+
+    Args:
+        feature_size (int): Hidden dimension shared by all layers.
+        num_transformer_layers (int): Number of attention layers. Default 2.
+        num_mamba_layers (int): Number of SSM layers. Default 6.
+        heads (int): Attention heads for Transformer layers. Default 4.
+        dropout (float): Dropout rate for Transformer layers. Default 0.3.
+        state_size (int): SSM state size for Mamba layers. Default 16.
+        conv_kernel (int): Causal conv kernel for Mamba layers. Default 4.
+
+    Examples:
+        >>> from pyhealth.models.jamba_ehr import JambaLayer
+        >>> x = torch.randn(3, 128, 64)
+        >>> layer = JambaLayer(64, num_transformer_layers=1, num_mamba_layers=3)
+        >>> emb, cls_emb = layer(x)
+        >>> emb.shape
+        torch.Size([3, 128, 64])
+        >>> cls_emb.shape
+        torch.Size([3, 64])
+    """
+
+    def __init__(
+        self,
+        feature_size: int,
+        num_transformer_layers: int = 2,
+        num_mamba_layers: int = 6,
+        heads: int = 4,
+        dropout: float = 0.3,
+        state_size: int = 16,
+        conv_kernel: int = 4,
+    ):
+        super(JambaLayer, self).__init__()
+        self.feature_size = feature_size
+        self.num_transformer_layers = num_transformer_layers
+        self.num_mamba_layers = num_mamba_layers
+
+        self.schedule = build_layer_schedule(
+            num_transformer_layers, num_mamba_layers
+        )
+
+        self.layers = nn.ModuleList()
+        for layer_type in self.schedule:
+            if layer_type == "transformer":
+                self.layers.append(
+                    TransformerBlock(
+                        hidden=feature_size,
+                        attn_heads=heads,
+                        dropout=dropout,
+                    )
+                )
+            else:
+                self.layers.append(
+                    MambaBlock(
+                        d_model=feature_size,
+                        state_size=state_size,
+                        conv_kernel=conv_kernel,
+                    )
+                )
+
+        self.final_norm = nn.LayerNorm(feature_size)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Forward propagation through the hybrid layer stack.
+
+        Args:
+            x (torch.Tensor): Input of shape ``[batch, seq_len, feature_size]``.
+            mask (Optional[torch.Tensor]): Padding mask ``[batch, seq_len]``
+                where 1 = valid, 0 = pad.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]:
+                - ``emb``: ``[batch, seq_len, feature_size]`` per-step features.
+                - ``cls_emb``: ``[batch, feature_size]`` from last valid step.
+        """
+        attn_mask = None
+        if mask is not None:
+            attn_mask = torch.einsum("ab,ac->abc", mask, mask)
+
+        for i, layer in enumerate(self.layers):
+            if self.schedule[i] == "transformer":
+                x = layer(x, attn_mask)
+            else:
+                x = layer(x)
+
+        x = self.final_norm(x)
+        emb = x
+        cls_emb = get_last_visit(x, mask)
+        return emb, cls_emb
+
+
+class JambaEHR(BaseModel):
+    """JambaEHR: Hybrid Transformer-Mamba model for clinical EHR prediction.
+
+    Paper: Lieber et al. Jamba: A Hybrid Transformer-Mamba Language Model.
+    arXiv 2403.19887, 2024.
+
+    This model interleaves Transformer self-attention and Mamba selective-SSM
+    layers for each feature stream. Configurable layer counts control the
+    attention-to-SSM ratio, trading off between global dependency modeling
+    and linear-time sequence processing for long EHR histories.
+
+    Each feature stream is embedded with :class:`EmbeddingModel` and encoded
+    by an independent :class:`JambaLayer`. The resulting patient embeddings
+    are concatenated and projected through a classification head.
+
+    Args:
+        dataset (SampleDataset): Dataset providing processed inputs.
+        embedding_dim (int): Embedding and hidden dimension. Default 128.
+        num_transformer_layers (int): Transformer layers per stream. Default 2.
+        num_mamba_layers (int): Mamba layers per stream. Default 6.
+        heads (int): Attention heads per Transformer block. Default 4.
+        dropout (float): Dropout rate. Default 0.3.
+        state_size (int): SSM state size in Mamba blocks. Default 16.
+        conv_kernel (int): Causal conv kernel in Mamba blocks. Default 4.
+
+    Examples:
+        >>> from pyhealth.datasets import create_sample_dataset, get_dataloader
+        >>> samples = [
+        ...     {
+        ...         "patient_id": "patient-0",
+        ...         "visit_id": "visit-0",
+        ...         "diagnoses": ["A", "B", "C"],
+        ...         "procedures": ["X", "Y"],
+        ...         "label": 1,
+        ...     },
+        ...     {
+        ...         "patient_id": "patient-1",
+        ...         "visit_id": "visit-0",
+        ...         "diagnoses": ["D"],
+        ...         "procedures": ["Z", "Y"],
+        ...         "label": 0,
+        ...     },
+        ... ]
+        >>> input_schema = {
+        ...     "diagnoses": "sequence",
+        ...     "procedures": "sequence",
+        ... }
+        >>> output_schema = {"label": "binary"}
+        >>> dataset = create_sample_dataset(
+        ...     samples,
+        ...     input_schema,
+        ...     output_schema,
+        ...     dataset_name="demo",
+        ... )
+        >>> model = JambaEHR(dataset=dataset, embedding_dim=64)
+        >>> loader = get_dataloader(dataset, batch_size=2, shuffle=True)
+        >>> batch = next(iter(loader))
+        >>> output = model(**batch)
+        >>> sorted(output.keys())
+        ['logit', 'loss', 'y_prob', 'y_true']
+    """
+
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        embedding_dim: int = 128,
+        num_transformer_layers: int = 2,
+        num_mamba_layers: int = 6,
+        heads: int = 4,
+        dropout: float = 0.3,
+        state_size: int = 16,
+        conv_kernel: int = 4,
+    ):
+        super(JambaEHR, self).__init__(dataset=dataset)
+        self.embedding_dim = embedding_dim
+        self.num_transformer_layers = num_transformer_layers
+        self.num_mamba_layers = num_mamba_layers
+        self.heads = heads
+        self.dropout_rate = dropout
+        self.state_size = state_size
+        self.conv_kernel = conv_kernel
+
+        assert (
+            len(self.label_keys) == 1
+        ), "Only one label key is supported if JambaEHR is initialized"
+        self.label_key = self.label_keys[0]
+        self.mode = self.dataset.output_schema[self.label_key]
+
+        self.embedding_model = EmbeddingModel(dataset, embedding_dim)
+
+        self.jamba: nn.ModuleDict = nn.ModuleDict()
+        for feature_key in self.feature_keys:
+            self.jamba[feature_key] = JambaLayer(
+                feature_size=embedding_dim,
+                num_transformer_layers=num_transformer_layers,
+                num_mamba_layers=num_mamba_layers,
+                heads=heads,
+                dropout=dropout,
+                state_size=state_size,
+                conv_kernel=conv_kernel,
+            )
+
+        output_size = self.get_output_size()
+        self.dropout = nn.Dropout(dropout)
+        self.fc = nn.Linear(
+            len(self.feature_keys) * embedding_dim, output_size
+        )
+
+    @staticmethod
+    def _pool_embedding(x: torch.Tensor) -> torch.Tensor:
+        """Collapse nested embeddings to ``[batch, seq_len, hidden]``.
+
+        Handles 4-D inputs from categorical processors by summing over the
+        inner token dimension, and 2-D inputs by adding a length-1 sequence
+        dimension.
+
+        Args:
+            x (torch.Tensor): Embedded tensor from EmbeddingModel.
+
+        Returns:
+            torch.Tensor: 3-D tensor ``[batch, seq_len, hidden]``.
+        """
+        if x.dim() == 4:
+            x = x.sum(dim=2)
+        if x.dim() == 2:
+            x = x.unsqueeze(1)
+        return x
+
+    @staticmethod
+    def _mask_from_embeddings(x: torch.Tensor) -> torch.Tensor:
+        """Derive a padding mask from embedded representations.
+
+        Marks positions where all hidden features are zero as invalid. Ensures
+        at least one position per sample is valid (sets index 0 if needed).
+
+        Args:
+            x (torch.Tensor): Embedded tensor ``[batch, seq_len, hidden]``.
+
+        Returns:
+            torch.Tensor: Boolean mask ``[batch, seq_len]``.
+        """
+        mask = torch.any(torch.abs(x) > 0, dim=-1)
+        if mask.dim() == 1:
+            mask = mask.unsqueeze(1)
+        invalid_rows = ~mask.any(dim=1)
+        if invalid_rows.any():
+            mask[invalid_rows, 0] = True
+        return mask.bool()
+
+    def forward(
+        self,
+        **kwargs: torch.Tensor | tuple[torch.Tensor, ...],
+    ) -> Dict[str, torch.Tensor]:
+        """Forward propagation.
+
+        Embeds each feature stream, encodes through the hybrid
+        Transformer-Mamba stack, concatenates per-stream patient
+        representations, and projects to label space.
+
+        Args:
+            **kwargs: Must include all feature keys (tensors or tuples
+                following processor schema) and the label key.
+
+        Returns:
+            Dict[str, torch.Tensor]: Dictionary with keys ``loss``,
+                ``y_prob``, ``y_true``, ``logit``, and optionally
+                ``embed`` if ``kwargs["embed"] is True``.
+        """
+        patient_emb = []
+
+        for feature_key in self.feature_keys:
+            feature = kwargs[feature_key]
+
+            if isinstance(feature, torch.Tensor):
+                feature = (feature,)
+
+            schema = self.dataset.input_processors[feature_key].schema()
+
+            value = (
+                feature[schema.index("value")]
+                if "value" in schema
+                else None
+            )
+            mask = (
+                feature[schema.index("mask")]
+                if "mask" in schema
+                else None
+            )
+
+            if len(feature) == len(schema) + 1 and mask is None:
+                mask = feature[-1]
+
+            if value is None:
+                raise ValueError(
+                    f"Feature '{feature_key}' must contain 'value' "
+                    f"in the schema."
+                )
+            else:
+                value = value.to(self.device)
+
+            value = self.embedding_model(
+                {feature_key: value}
+            )[feature_key]
+            value = self._pool_embedding(value)
+
+            if mask is not None:
+                mask = mask.to(self.device)
+                if mask.dim() == value.dim():
+                    mask = mask.any(dim=-1)
+                mask = mask.float()
+            else:
+                mask = self._mask_from_embeddings(value).float()
+
+            _, cls_emb = self.jamba[feature_key](value, mask)
+            patient_emb.append(cls_emb)
+
+        patient_emb = torch.cat(patient_emb, dim=1)
+        logits = self.fc(self.dropout(patient_emb))
+        y_prob = self.prepare_y_prob(logits)
+
+        results = {
+            "logit": logits,
+            "y_prob": y_prob,
+        }
+
+        if self.label_key in kwargs:
+            y_true = cast(
+                torch.Tensor, kwargs[self.label_key]
+            ).to(self.device)
+            loss = self.get_loss_function()(logits, y_true)
+            results["loss"] = loss
+            results["y_true"] = y_true
+
+        if kwargs.get("embed", False):
+            results["embed"] = patient_emb
+
+        return results
+
+
+if __name__ == "__main__":
+    from pyhealth.datasets import create_sample_dataset, get_dataloader
+
+    samples = [
+        {
+            "patient_id": "patient-0",
+            "visit_id": "visit-0",
+            "diagnoses": ["A", "B", "C"],
+            "procedures": ["X", "Y"],
+            "label": 1,
+        },
+        {
+            "patient_id": "patient-1",
+            "visit_id": "visit-0",
+            "diagnoses": ["D", "E"],
+            "procedures": ["Z"],
+            "label": 0,
+        },
+    ]
+
+    input_schema = {
+        "diagnoses": "sequence",
+        "procedures": "sequence",
+    }
+    output_schema = {"label": "binary"}
+
+    dataset = create_sample_dataset(
+        samples=samples,
+        input_schema=input_schema,
+        output_schema=output_schema,
+        dataset_name="test",
+    )
+
+    # Default Jamba ratio: 2 Transformer + 6 Mamba
+    print("=== JambaEHR (2T + 6M) ===")
+    model = JambaEHR(
+        dataset=dataset,
+        embedding_dim=64,
+        num_transformer_layers=2,
+        num_mamba_layers=6,
+        heads=2,
+    )
+    loader = get_dataloader(dataset, batch_size=2, shuffle=True)
+    batch = next(iter(loader))
+    out = model(**batch)
+    print("keys:", sorted(out.keys()))
+    print("logit shape:", out["logit"].shape)
+    out["loss"].backward()
+    print("backward OK\n")
+
+    # Pure Transformer fallback
+    print("=== JambaEHR pure Transformer (4T + 0M) ===")
+    model_t = JambaEHR(
+        dataset=dataset,
+        embedding_dim=64,
+        num_transformer_layers=4,
+        num_mamba_layers=0,
+        heads=2,
+    )
+    batch = next(iter(get_dataloader(dataset, batch_size=2, shuffle=True)))
+    out = model_t(**batch)
+    print("keys:", sorted(out.keys()))
+    out["loss"].backward()
+    print("backward OK\n")
+
+    # Pure Mamba fallback
+    print("=== JambaEHR pure Mamba (0T + 4M) ===")
+    model_m = JambaEHR(
+        dataset=dataset,
+        embedding_dim=64,
+        num_transformer_layers=0,
+        num_mamba_layers=4,
+    )
+    batch = next(iter(get_dataloader(dataset, batch_size=2, shuffle=True)))
+    out = model_m(**batch)
+    print("keys:", sorted(out.keys()))
+    out["loss"].backward()
+    print("backward OK")

--- a/tests/core/test_jamba_ehr.py
+++ b/tests/core/test_jamba_ehr.py
@@ -1,0 +1,343 @@
+"""Unit tests for JambaEHR hybrid Transformer-Mamba model.
+
+Author: Joshua Steier
+
+Tests cover:
+    - Layer schedule generation
+    - JambaLayer forward pass shapes
+    - JambaEHR model init/forward/backward with various ratios
+    - Edge cases: pure Transformer, pure Mamba, single-layer configs
+    - Compatibility with PyHealth Trainer pipeline
+"""
+
+import unittest
+
+import torch
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models.jamba_ehr import (
+    JambaEHR,
+    JambaLayer,
+    build_layer_schedule,
+)
+
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+def _make_sample_dataset():
+    """Create a minimal PyHealth SampleDataset for testing."""
+    samples = [
+        {
+            "patient_id": "p0",
+            "visit_id": "v0",
+            "diagnoses": ["A", "B", "C"],
+            "procedures": ["X", "Y"],
+            "label": 1,
+        },
+        {
+            "patient_id": "p1",
+            "visit_id": "v0",
+            "diagnoses": ["D"],
+            "procedures": ["Z", "Y"],
+            "label": 0,
+        },
+    ]
+    input_schema = {
+        "diagnoses": "sequence",
+        "procedures": "sequence",
+    }
+    output_schema = {"label": "binary"}
+    return create_sample_dataset(
+        samples=samples,
+        input_schema=input_schema,
+        output_schema=output_schema,
+        dataset_name="test_jamba",
+    )
+
+
+def _make_batch(dataset):
+    """Get a single batch from the sample dataset."""
+    loader = get_dataloader(dataset, batch_size=2, shuffle=False)
+    return next(iter(loader))
+
+
+# ------------------------------------------------------------------ #
+# build_layer_schedule tests
+# ------------------------------------------------------------------ #
+
+class TestBuildLayerSchedule(unittest.TestCase):
+    """Tests for the layer interleaving schedule builder."""
+
+    def test_default_jamba_ratio(self):
+        """1:7 ratio produces correct distribution."""
+        schedule = build_layer_schedule(1, 7)
+        self.assertEqual(len(schedule), 8)
+        self.assertEqual(schedule.count("transformer"), 1)
+        self.assertEqual(schedule.count("mamba"), 7)
+
+    def test_two_transformer_six_mamba(self):
+        """2:6 ratio distributes Transformer layers evenly."""
+        schedule = build_layer_schedule(2, 6)
+        self.assertEqual(len(schedule), 8)
+        self.assertEqual(schedule.count("transformer"), 2)
+        self.assertEqual(schedule.count("mamba"), 6)
+        # Transformer layers should not be adjacent
+        t_indices = [i for i, s in enumerate(schedule) if s == "transformer"]
+        self.assertGreaterEqual(t_indices[1] - t_indices[0], 2)
+
+    def test_pure_transformer(self):
+        """All Transformer layers when num_mamba=0."""
+        schedule = build_layer_schedule(4, 0)
+        self.assertEqual(schedule, ["transformer"] * 4)
+
+    def test_pure_mamba(self):
+        """All Mamba layers when num_transformer=0."""
+        schedule = build_layer_schedule(0, 4)
+        self.assertEqual(schedule, ["mamba"] * 4)
+
+    def test_empty(self):
+        """Empty schedule when both counts are 0."""
+        self.assertEqual(build_layer_schedule(0, 0), [])
+
+    def test_even_split(self):
+        """Equal number of both layer types."""
+        schedule = build_layer_schedule(4, 4)
+        self.assertEqual(len(schedule), 8)
+        self.assertEqual(schedule.count("transformer"), 4)
+        self.assertEqual(schedule.count("mamba"), 4)
+
+    def test_single_each(self):
+        """Minimal case: one of each."""
+        schedule = build_layer_schedule(1, 1)
+        self.assertEqual(len(schedule), 2)
+        self.assertEqual(schedule.count("transformer"), 1)
+        self.assertEqual(schedule.count("mamba"), 1)
+
+
+# ------------------------------------------------------------------ #
+# JambaLayer tests
+# ------------------------------------------------------------------ #
+
+class TestJambaLayer(unittest.TestCase):
+    """Tests for the hybrid encoder layer stack."""
+
+    def test_output_shapes(self):
+        """Output tensors have correct shapes."""
+        layer = JambaLayer(
+            feature_size=32,
+            num_transformer_layers=1,
+            num_mamba_layers=3,
+            heads=2,
+        )
+        x = torch.randn(4, 10, 32)
+        emb, cls_emb = layer(x)
+        self.assertEqual(emb.shape, (4, 10, 32))
+        self.assertEqual(cls_emb.shape, (4, 32))
+
+    def test_with_mask(self):
+        """Forward pass works with a padding mask."""
+        layer = JambaLayer(
+            feature_size=64,
+            num_transformer_layers=1,
+            num_mamba_layers=2,
+            heads=4,
+        )
+        x = torch.randn(3, 8, 64)
+        mask = torch.ones(3, 8)
+        mask[0, 5:] = 0  # pad last 3 positions for first sample
+        emb, cls_emb = layer(x, mask)
+        self.assertEqual(emb.shape, (3, 8, 64))
+        self.assertEqual(cls_emb.shape, (3, 64))
+
+    def test_pure_transformer_layer(self):
+        """JambaLayer with 0 Mamba layers is pure Transformer."""
+        layer = JambaLayer(
+            feature_size=32,
+            num_transformer_layers=3,
+            num_mamba_layers=0,
+            heads=2,
+        )
+        self.assertEqual(len(layer.layers), 3)
+        self.assertTrue(all(s == "transformer" for s in layer.schedule))
+        x = torch.randn(2, 5, 32)
+        emb, cls_emb = layer(x)
+        self.assertEqual(emb.shape, (2, 5, 32))
+
+    def test_pure_mamba_layer(self):
+        """JambaLayer with 0 Transformer layers is pure Mamba."""
+        layer = JambaLayer(
+            feature_size=32,
+            num_transformer_layers=0,
+            num_mamba_layers=3,
+        )
+        self.assertEqual(len(layer.layers), 3)
+        self.assertTrue(all(s == "mamba" for s in layer.schedule))
+        x = torch.randn(2, 5, 32)
+        emb, cls_emb = layer(x)
+        self.assertEqual(emb.shape, (2, 5, 32))
+
+    def test_gradient_flow(self):
+        """Gradients flow through all layer types."""
+        layer = JambaLayer(
+            feature_size=32,
+            num_transformer_layers=1,
+            num_mamba_layers=2,
+            heads=2,
+        )
+        x = torch.randn(2, 5, 32, requires_grad=True)
+        emb, cls_emb = layer(x)
+        cls_emb.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertGreater(x.grad.abs().sum().item(), 0)
+
+
+# ------------------------------------------------------------------ #
+# JambaEHR model tests
+# ------------------------------------------------------------------ #
+
+class TestJambaEHR(unittest.TestCase):
+    """Tests for the full JambaEHR model."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create shared dataset and batch for all tests."""
+        cls.dataset = _make_sample_dataset()
+        cls.batch = _make_batch(cls.dataset)
+
+    def _make_model(self, **kwargs):
+        """Helper to create JambaEHR with default test params."""
+        defaults = dict(
+            dataset=self.dataset,
+            embedding_dim=32,
+            num_transformer_layers=1,
+            num_mamba_layers=2,
+            heads=2,
+        )
+        defaults.update(kwargs)
+        return JambaEHR(**defaults)
+
+    def test_forward_keys(self):
+        """Output dict contains expected keys."""
+        model = self._make_model()
+        out = model(**self.batch)
+        self.assertIn("loss", out)
+        self.assertIn("y_prob", out)
+        self.assertIn("y_true", out)
+        self.assertIn("logit", out)
+
+    def test_backward(self):
+        """Loss backward pass succeeds."""
+        model = self._make_model()
+        out = model(**self.batch)
+        out["loss"].backward()
+
+    def test_output_shapes(self):
+        """Logit and probability shapes match label size."""
+        model = self._make_model()
+        out = model(**self.batch)
+        batch_size = self.batch["label"].shape[0]
+        self.assertEqual(out["logit"].shape[0], batch_size)
+        self.assertEqual(out["y_prob"].shape[0], batch_size)
+
+    def test_embed_flag(self):
+        """embed=True returns the patient embedding."""
+        model = self._make_model(
+            num_transformer_layers=1,
+            num_mamba_layers=1,
+        )
+        batch = dict(self.batch)
+        batch["embed"] = True
+        out = model(**batch)
+        self.assertIn("embed", out)
+        batch_size = self.batch["label"].shape[0]
+        num_features = len(self.dataset.input_schema)
+        self.assertEqual(out["embed"].shape, (batch_size, num_features * 32))
+
+    def test_pure_transformer_config(self):
+        """Model works with 0 Mamba layers (pure Transformer)."""
+        model = self._make_model(
+            num_transformer_layers=3,
+            num_mamba_layers=0,
+        )
+        out = model(**self.batch)
+        out["loss"].backward()
+
+    def test_pure_mamba_config(self):
+        """Model works with 0 Transformer layers (pure Mamba)."""
+        model = self._make_model(
+            num_transformer_layers=0,
+            num_mamba_layers=3,
+        )
+        out = model(**self.batch)
+        out["loss"].backward()
+
+    def test_jamba_default_ratio(self):
+        """Default 2:6 ratio (Jamba-like) works end to end."""
+        model = self._make_model(
+            embedding_dim=64,
+            num_transformer_layers=2,
+            num_mamba_layers=6,
+            heads=4,
+        )
+        out = model(**self.batch)
+        self.assertTrue(out["loss"].isfinite())
+        out["loss"].backward()
+
+    def test_single_feature_key(self):
+        """Model works with a single feature key."""
+        samples = [
+            {
+                "patient_id": "p0",
+                "visit_id": "v0",
+                "codes": ["A", "B"],
+                "label": 1,
+            },
+            {
+                "patient_id": "p1",
+                "visit_id": "v0",
+                "codes": ["C"],
+                "label": 0,
+            },
+        ]
+        ds = create_sample_dataset(
+            samples=samples,
+            input_schema={"codes": "sequence"},
+            output_schema={"label": "binary"},
+            dataset_name="test_single",
+        )
+        model = JambaEHR(
+            dataset=ds,
+            embedding_dim=32,
+            num_transformer_layers=1,
+            num_mamba_layers=1,
+            heads=2,
+        )
+        loader = get_dataloader(ds, batch_size=2, shuffle=False)
+        batch = next(iter(loader))
+        out = model(**batch)
+        self.assertTrue(out["loss"].isfinite())
+        out["loss"].backward()
+
+    def test_custom_hyperparameters(self):
+        """Test JambaEHR with custom hyperparameters."""
+        model = self._make_model(
+            embedding_dim=64,
+            num_transformer_layers=3,
+            num_mamba_layers=5,
+            heads=8,
+            dropout=0.5,
+        )
+        out = model(**self.batch)
+        self.assertIn("loss", out)
+
+    def test_model_initialization(self):
+        """Test that the JambaEHR model initializes correctly."""
+        model = self._make_model()
+        self.assertIsInstance(model, JambaEHR)
+        self.assertEqual(model.label_key, "label")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Contributor Information</h2>
<ul>
<li><strong>Name:</strong> Joshua Steier</li>
<li><strong>Contribution Type:</strong> Model + Tests + Documentation</li>
</ul>
<h2>Description</h2>
<p>Added <code>JambaEHR</code>, a hybrid Transformer-Mamba model for EHR clinical prediction inspired by Jamba (AI21 Labs, ICLR 2025). Interleaves existing PyHealth <code>TransformerBlock</code> and <code>MambaBlock</code> layers in a configurable ratio, combining attention's global context modeling with SSM's linear-time efficiency for long patient histories.</p>
<p><strong>Key features:</strong></p>
<ul>
<li>Reuses existing <code>TransformerBlock</code> and <code>MambaBlock</code> — zero code duplication</li>
<li>Configurable <code>num_transformer_layers</code> + <code>num_mamba_layers</code> parameters</li>
<li>Evenly distributes attention layers through the SSM stack (Jamba design)</li>
<li>Degrades gracefully to pure Transformer or pure Mamba with 0-count params</li>
<li>Compatible with all existing PyHealth processors and Trainer</li>
<li>Uses <code>get_last_visit</code> pooling (same as EHRMamba)</li>
</ul>
<p><strong>Paper:</strong> <a href="https://arxiv.org/abs/2403.19887">Jamba: A Hybrid Transformer-Mamba Language Model</a> (AI21 Labs, 2024)</p>
<p>This model is part of the multimodal embedding pipeline:</p>
<pre><code>TemporalFeatureProcessor → Modality Encoders → JambaEHR backbone → Prediction Head
</code></pre>
<h2>Files to Review</h2>

File | Description
-- | --
pyhealth/models/jamba_ehr.py | Model implementation (JambaLayer + JambaEHR)
pyhealth/models/__init__.py | Added JambaEHR, JambaLayer exports
tests/core/test_jamba_ehr.py | 17 unit tests
docs/api/models/pyhealth.models.JambaEHR.rst | API docs
docs/api/models.rst | Added to toctree


<h2>Testing</h2>
<pre><code class="language-bash"># Run model smoke test (tests 4 configurations)
python pyhealth/models/jamba_ehr.py

# Run unit tests
python -m pytest tests/models/test_jamba_ehr.py -v
# Result: 17 passed
</code></pre>
<h2>Architecture</h2>
<pre><code>Input: (B, S, E) per feature key
         │
    EmbeddingModel (shared)
         │
    JambaLayer per feature key:
      [Mamba, Mamba, Mamba, Transformer, Mamba, Mamba, Mamba, Transformer]
         │              (configurable schedule)
    get_last_visit pooling → concat → dropout → FC head
         │
Output: {loss, y_prob, y_true, logit}
</code></pre>
<h2>Usage</h2>
<pre><code class="language-python">from pyhealth.models import JambaEHR

model = JambaEHR(
    dataset=dataset,
    embedding_dim=128,
    num_transformer_layers=2,   # attention layers
    num_mamba_layers=6,         # SSM layers
    heads=4,
)
