### PR TITLE
[Conformal EEG] Add TUEV + TFMTokenizer training notebook

### DIFF
--- a/examples/conformal_eeg/tfm_tokenizer_tuev.ipynb
+++ b/examples/conformal_eeg/tfm_tokenizer_tuev.ipynb
@@ -1,0 +1,538 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d88e26b3",
+   "metadata": {},
+   "source": [
+    "# TUEV + TFMTokenizer\n",
+    "\n",
+    "This notebook trains the `TFMTokenizer` on TUEV."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84c8a790",
+   "metadata": {},
+   "source": [
+    "## 1. Environment Setup\n",
+    "Seed randomness, import dependencies, and select compute device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0b4dcb10",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running on device: cuda\n"
+     ]
+    }
+   ],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import random\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "from einops import rearrange\n",
+    "\n",
+    "from pyhealth.datasets import TUEVDataset\n",
+    "from pyhealth.datasets.splitter import split_by_sample\n",
+    "from pyhealth.datasets.utils import get_dataloader\n",
+    "from pyhealth.models import TFMTokenizer\n",
+    "from pyhealth.tasks import EEGEventsTUEV\n",
+    "\n",
+    "SEED = 42\n",
+    "random.seed(SEED)\n",
+    "np.random.seed(SEED)\n",
+    "torch.manual_seed(SEED)\n",
+    "if torch.cuda.is_available():\n",
+    "    torch.cuda.manual_seed_all(SEED)\n",
+    "\n",
+    "DEVICE = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+    "print(f\"Running on device: {DEVICE}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26872e3c",
+   "metadata": {},
+   "source": [
+    "## 2. Configuration\n",
+    "Set dataset path and quick-run hyperparameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0cda5546",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'ROOT': '..\\\\..\\\\downloads\\\\tuev\\\\v2.0.1\\\\edf', 'RESAMPLING_RATE': 200, 'BATCH_SIZE': 8, 'EPOCHS': 20, 'LR': 0.0001, 'DEBUG_MAX_SAMPLES': 512}\n"
+     ]
+    }
+   ],
+   "source": [
+    "ROOT = Path(r\"../../downloads/tuev/v2.0.1/edf\")\n",
+    "CACHE_DIR = \"cache\"\n",
+    "\n",
+    "RESAMPLING_RATE = 200\n",
+    "BATCH_SIZE = 8\n",
+    "EPOCHS = 20\n",
+    "LR = 1e-4\n",
+    "\n",
+    "DEBUG_MAX_SAMPLES = 512  # set to None for full dataset\n",
+    "\n",
+    "if not ROOT.exists():\n",
+    "    raise FileNotFoundError(f\"TUEV root not found: {ROOT}. Update ROOT before running.\")\n",
+    "\n",
+    "print({\n",
+    "    \"ROOT\": str(ROOT),\n",
+    "    \"RESAMPLING_RATE\": RESAMPLING_RATE,\n",
+    "    \"BATCH_SIZE\": BATCH_SIZE,\n",
+    "    \"EPOCHS\": EPOCHS,\n",
+    "    \"LR\": LR,\n",
+    "    \"DEBUG_MAX_SAMPLES\": DEBUG_MAX_SAMPLES,\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9dd17ab",
+   "metadata": {},
+   "source": [
+    "## 3. Load and Split TUEV Dataset\n",
+    "Create task samples using `EEGEventsTUEV`, then split into train/val/test loaders."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ab0c2bf7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No config path provided, using default config\n",
+      "Using both train and eval subsets\n",
+      "Initializing tuev dataset from ..\\..\\downloads\\tuev\\v2.0.1\\edf (dev mode: True)\n",
+      "Setting task EEG_events for tuev base dataset...\n",
+      "Found cached processed samples at cache\\samples_47c27255-9fc0-5271-bd99-638ffecdb1cc.ld, skipping processing.\n",
+      "Total task samples: 512\n",
+      "Input schema: {'signal': 'tensor'}\n",
+      "Output schema: {'label': 'multiclass'}\n",
+      "Train/Val/Test sizes: 358, 51, 103\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "F:\\coding_projects\\pyhealth\\pyhealth\\datasets\\base_dataset.py:950: UserWarning: A newer version of litdata is available (0.2.60). Please consider upgrading with `pip install -U litdata`. Not all functionalities of the platform can be guaranteed to work with the current version.\n",
+      "  return SampleDataset(\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset = TUEVDataset(root=str(ROOT), subset=\"both\", dev=True)\n",
+    "sample_dataset = dataset.set_task(EEGEventsTUEV(), cache_dir=CACHE_DIR)\n",
+    "\n",
+    "if DEBUG_MAX_SAMPLES is not None:\n",
+    "    n = min(DEBUG_MAX_SAMPLES, len(sample_dataset))\n",
+    "    sample_dataset = sample_dataset.subset(list(range(n)))\n",
+    "\n",
+    "print(f\"Total task samples: {len(sample_dataset)}\")\n",
+    "print(f\"Input schema: {sample_dataset.input_schema}\")\n",
+    "print(f\"Output schema: {sample_dataset.output_schema}\")\n",
+    "\n",
+    "train_ds, val_ds, test_ds = split_by_sample(sample_dataset, [0.7, 0.1, 0.2], seed=SEED)\n",
+    "train_loader = get_dataloader(train_ds, batch_size=BATCH_SIZE, shuffle=True)\n",
+    "val_loader = get_dataloader(val_ds, batch_size=BATCH_SIZE, shuffle=False) if len(val_ds) else None\n",
+    "test_loader = get_dataloader(test_ds, batch_size=BATCH_SIZE, shuffle=False) if len(test_ds) else None\n",
+    "\n",
+    "print(f\"Train/Val/Test sizes: {len(train_ds)}, {len(val_ds)}, {len(test_ds)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95c82865",
+   "metadata": {},
+   "source": [
+    "## 4. STFT Function (Torch)\n",
+    "Use the exact STFT helper for multi-channel EEG batches."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f88bdfd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_stft_torch(X, resampling_rate = 200):\n",
+    "    B,C,T = X.shape\n",
+    "    x_temp = rearrange(X, 'B C T -> (B C) T')\n",
+    "    window = torch.hann_window(resampling_rate).to(x_temp.device)\n",
+    "    x_stft_temp = torch.abs(torch.stft(x_temp, n_fft=resampling_rate, hop_length=resampling_rate//2, \n",
+    "                          onesided = True,\n",
+    "                          return_complex=True, center = False,#normalized = True,\n",
+    "                          window = window)[:,:resampling_rate//2,:])\n",
+    "    \n",
+    "    x_stft_temp = rearrange(x_stft_temp, '(B C) F T -> B C F T', B=B)\n",
+    "    \n",
+    "    return x_stft_temp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "428de63c",
+   "metadata": {},
+   "source": [
+    "## 5. Inspect One Batch\n",
+    "Verify raw EEG batch shape and derived STFT shape before training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2c1729b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "signal shape: (8, 16, 1000) (B, C, T)\n",
+      "stft shape: (8, 16, 100, 9) (B, C, F, T_stft)\n",
+      "label shape: (8,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "batch0 = next(iter(train_loader))\n",
+    "x0 = batch0[\"signal\"].float().to(DEVICE)\n",
+    "x0_stft = get_stft_torch(x0, resampling_rate=RESAMPLING_RATE)\n",
+    "\n",
+    "print(\"signal shape:\", tuple(x0.shape), \"(B, C, T)\")\n",
+    "print(\"stft shape:\", tuple(x0_stft.shape), \"(B, C, F, T_stft)\")\n",
+    "print(\"label shape:\", tuple(batch0[\"label\"].shape))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "692f0556",
+   "metadata": {},
+   "source": [
+    "## 6. Initialize TFMTokenizer\n",
+    "Instantiate `TFMTokenizer` on the TUEV task dataset and optimizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fd60d768",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model parameters: 1,891,114\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = TFMTokenizer(\n",
+    "    dataset=sample_dataset,\n",
+    "    emb_size=64,\n",
+    "    code_book_size=8192,\n",
+    "    trans_freq_encoder_depth=2,\n",
+    "    trans_temporal_encoder_depth=2,\n",
+    "    trans_decoder_depth=8,\n",
+    "    use_classifier=True,\n",
+    ")\n",
+    "model = model.to(DEVICE)\n",
+    "\n",
+    "optimizer = torch.optim.Adam(model.parameters(), lr=LR)\n",
+    "criterion = model.get_loss_function()\n",
+    "\n",
+    "print(f\"Model parameters: {sum(p.numel() for p in model.parameters()):,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3f29203",
+   "metadata": {},
+   "source": [
+    "## 7. Training Utilities\n",
+    "Use STFT + multi-channel flattening in each training/eval step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0689d148",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_step(model, batch, training=True):\n",
+    "    x = batch[\"signal\"].float().to(DEVICE)          # (B, C, T)\n",
+    "    y = batch[\"label\"].long().to(DEVICE)\n",
+    "\n",
+    "    x_stft = get_stft_torch(x, resampling_rate=RESAMPLING_RATE)\n",
+    "\n",
+    "    x_stft = rearrange(x_stft, \"B C F T -> (B C) F T\")\n",
+    "    x = rearrange(x, \"B C T -> (B C) T\")\n",
+    "\n",
+    "    reconstructed, tokens_flat, quant_out, quant_in = model.tokenizer(x_stft, x)\n",
+    "    recon_loss = F.mse_loss(reconstructed, x_stft)\n",
+    "    vq_loss, _, _ = model.tokenizer.vec_quantizer_loss(quant_in, quant_out)\n",
+    "\n",
+    "    B, C = batch[\"signal\"].shape[0], batch[\"signal\"].shape[1]\n",
+    "    tokens_mc = tokens_flat.reshape(B, C, -1)\n",
+    "    logits = model.classifier(tokens_mc, num_ch=C)\n",
+    "\n",
+    "    cls_loss = criterion(logits, y)\n",
+    "    total_loss = recon_loss + vq_loss + cls_loss\n",
+    "\n",
+    "    if training:\n",
+    "        optimizer.zero_grad()\n",
+    "        total_loss.backward()\n",
+    "        optimizer.step()\n",
+    "\n",
+    "    preds = torch.argmax(logits, dim=1)\n",
+    "    acc = (preds == y).float().mean().item()\n",
+    "\n",
+    "    return {\n",
+    "        \"loss\": total_loss.item(),\n",
+    "        \"cls_loss\": cls_loss.item(),\n",
+    "        \"recon_loss\": recon_loss.item(),\n",
+    "        \"vq_loss\": vq_loss.item(),\n",
+    "        \"acc\": acc,\n",
+    "    }\n",
+    "\n",
+    "@torch.no_grad()\n",
+    "def evaluate(model, loader):\n",
+    "    if loader is None:\n",
+    "        return None\n",
+    "\n",
+    "    model.eval()\n",
+    "    stats = []\n",
+    "    for batch in loader:\n",
+    "        stats.append(run_step(model, batch, training=False))\n",
+    "\n",
+    "    keys = stats[0].keys()\n",
+    "    return {k: float(np.mean([s[k] for s in stats])) for k in keys}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "894e42f4",
+   "metadata": {},
+   "source": [
+    "## 8. Train\n",
+    "Run a short training loop and report train/val metrics per epoch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "16a35e4d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/20\n",
+      "  Train: {'loss': 11417.664046223957, 'cls_loss': 0.9261853244569567, 'recon_loss': 11416.726513671874, 'vq_loss': 0.011308995944758257, 'acc': 0.7638888888888888}\n",
+      "  Val:   {'loss': 7567.515973772322, 'cls_loss': 0.6936458434377398, 'recon_loss': 7566.812430245535, 'vq_loss': 0.009907172726733344, 'acc': 0.7738095266478402}\n",
+      "Epoch 2/20\n",
+      "  Train: {'loss': 11375.016617838543, 'cls_loss': 0.6516648951503966, 'recon_loss': 11374.355457899306, 'vq_loss': 0.009574467399054104, 'acc': 0.796296297179328}\n",
+      "  Val:   {'loss': 7536.031389508928, 'cls_loss': 0.6579780748912266, 'recon_loss': 7535.36408342634, 'vq_loss': 0.009364819686327661, 'acc': 0.7738095266478402}\n",
+      "Epoch 3/20\n",
+      "  Train: {'loss': 11349.942599826389, 'cls_loss': 0.6224249478843477, 'recon_loss': 11349.3109375, 'vq_loss': 0.009151072489718597, 'acc': 0.7972222222222223}\n",
+      "  Val:   {'loss': 7508.786865234375, 'cls_loss': 0.6490445605346135, 'recon_loss': 7508.128557477678, 'vq_loss': 0.009073269353913409, 'acc': 0.7738095266478402}\n",
+      "Epoch 4/20\n",
+      "  Train: {'loss': 11317.67685546875, 'cls_loss': 0.6109958132108052, 'recon_loss': 11317.056911892361, 'vq_loss': 0.008929671647234096, 'acc': 0.796296297179328}\n",
+      "  Val:   {'loss': 7483.695521763393, 'cls_loss': 0.6292583644390106, 'recon_loss': 7483.057477678572, 'vq_loss': 0.008893666655889578, 'acc': 0.7738095266478402}\n",
+      "Epoch 5/20\n",
+      "  Train: {'loss': 11344.310861545138, 'cls_loss': 0.5990023056666056, 'recon_loss': 11343.703092447917, 'vq_loss': 0.008779866310457388, 'acc': 0.796296297179328}\n",
+      "  Val:   {'loss': 7459.583879743303, 'cls_loss': 0.6463788109166282, 'recon_loss': 7458.928745814732, 'vq_loss': 0.008786304920379604, 'acc': 0.7738095266478402}\n",
+      "Epoch 6/20\n",
+      "  Train: {'loss': 11318.427804904513, 'cls_loss': 0.5933047029707167, 'recon_loss': 11317.825797526042, 'vq_loss': 0.008701306115835906, 'acc': 0.7944444444444444}\n",
+      "  Val:   {'loss': 7436.10724748884, 'cls_loss': 0.6043939888477325, 'recon_loss': 7435.494280133928, 'vq_loss': 0.008712283934333495, 'acc': 0.7738095266478402}\n",
+      "Epoch 7/20\n",
+      "  Train: {'loss': 11272.754790581597, 'cls_loss': 0.6026422687702708, 'recon_loss': 11272.1435546875, 'vq_loss': 0.008640000958823495, 'acc': 0.796296297179328}\n",
+      "  Val:   {'loss': 7412.95556640625, 'cls_loss': 0.5874462766306741, 'recon_loss': 7412.359444754465, 'vq_loss': 0.008652745413460903, 'acc': 0.7738095266478402}\n",
+      "Epoch 8/20\n",
+      "  Train: {'loss': 11225.567789713541, 'cls_loss': 0.5428769869936837, 'recon_loss': 11225.016395399305, 'vq_loss': 0.008564704439292352, 'acc': 0.796296297179328}\n",
+      "  Val:   {'loss': 7390.159458705357, 'cls_loss': 0.5684658118656704, 'recon_loss': 7389.58234514509, 'vq_loss': 0.008608917306576456, 'acc': 0.7738095266478402}\n",
+      "Epoch 9/20\n",
+      "  Train: {'loss': 11193.370551215277, 'cls_loss': 0.4761423465278414, 'recon_loss': 11192.885904947916, 'vq_loss': 0.008525023630095854, 'acc': 0.8305555555555556}\n",
+      "  Val:   {'loss': 7367.655657087053, 'cls_loss': 0.3876007944345474, 'recon_loss': 7367.259556361607, 'vq_loss': 0.008569220080971718, 'acc': 0.8452380980764117}\n",
+      "Epoch 10/20\n",
+      "  Train: {'loss': 11178.627821180555, 'cls_loss': 0.3798190053138468, 'recon_loss': 11178.239485677082, 'vq_loss': 0.008489290873209635, 'acc': 0.8638888888888889}\n",
+      "  Val:   {'loss': 7345.917410714285, 'cls_loss': 0.2663117434297289, 'recon_loss': 7345.642543247768, 'vq_loss': 0.008526393744562353, 'acc': 0.9107142857142857}\n",
+      "Epoch 11/20\n",
+      "  Train: {'loss': 11148.627859157987, 'cls_loss': 0.30707172035343117, 'recon_loss': 11148.312234157986, 'vq_loss': 0.008448639646586445, 'acc': 0.8833333333333333}\n",
+      "  Val:   {'loss': 7324.28972516741, 'cls_loss': 0.28058445719735964, 'recon_loss': 7324.000732421875, 'vq_loss': 0.008494529074856214, 'acc': 0.8928571428571429}\n",
+      "Epoch 12/20\n",
+      "  Train: {'loss': 11116.252067057292, 'cls_loss': 0.24718714283986223, 'recon_loss': 11115.996500651041, 'vq_loss': 0.008424378041591908, 'acc': 0.9138888888888889}\n",
+      "  Val:   {'loss': 7302.787248883928, 'cls_loss': 0.20785772427916527, 'recon_loss': 7302.571044921875, 'vq_loss': 0.008469955130879368, 'acc': 0.9285714285714286}\n",
+      "Epoch 13/20\n",
+      "  Train: {'loss': 11104.589312065973, 'cls_loss': 0.2489925965666771, 'recon_loss': 11104.331792534722, 'vq_loss': 0.008410526201542881, 'acc': 0.9185185194015503}\n",
+      "  Val:   {'loss': 7281.893415178572, 'cls_loss': 0.165241113198655, 'recon_loss': 7281.719761439732, 'vq_loss': 0.0084478343570871, 'acc': 0.9464285714285714}\n",
+      "Epoch 14/20\n",
+      "  Train: {'loss': 11072.396126302083, 'cls_loss': 0.2198597172068225, 'recon_loss': 11072.167838541667, 'vq_loss': 0.008394798833049007, 'acc': 0.921296297179328}\n",
+      "  Val:   {'loss': 7260.85773577009, 'cls_loss': 0.15927166917494365, 'recon_loss': 7260.690080915178, 'vq_loss': 0.008426498754748277, 'acc': 0.9464285714285714}\n",
+      "Epoch 15/20\n",
+      "  Train: {'loss': 11077.032855902778, 'cls_loss': 0.22693890465630426, 'recon_loss': 11076.797802734374, 'vq_loss': 0.008362838946696784, 'acc': 0.9333333333333333}\n",
+      "  Val:   {'loss': 7240.28240094866, 'cls_loss': 0.19016143653009618, 'recon_loss': 7240.083879743303, 'vq_loss': 0.008403371021683727, 'acc': 0.9464285714285714}\n",
+      "Epoch 16/20\n",
+      "  Train: {'loss': 11033.98876953125, 'cls_loss': 0.1517088901044594, 'recon_loss': 11033.828754340278, 'vq_loss': 0.008347393065277074, 'acc': 0.95}\n",
+      "  Val:   {'loss': 7219.935511997768, 'cls_loss': 0.23125106721584285, 'recon_loss': 7219.695870535715, 'vq_loss': 0.008389036570276533, 'acc': 0.9285714285714286}\n",
+      "Epoch 17/20\n",
+      "  Train: {'loss': 11354.567881944444, 'cls_loss': 0.14896071922654908, 'recon_loss': 11354.410763888889, 'vq_loss': 0.008331479680620962, 'acc': 0.95}\n",
+      "  Val:   {'loss': 7199.626708984375, 'cls_loss': 0.09712629312915462, 'recon_loss': 7199.521275111607, 'vq_loss': 0.008372561074793339, 'acc': 0.9821428571428571}\n",
+      "Epoch 18/20\n",
+      "  Train: {'loss': 10994.676763237847, 'cls_loss': 0.11473368173465133, 'recon_loss': 10994.553889973959, 'vq_loss': 0.008304806136422687, 'acc': 0.9694444444444444}\n",
+      "  Val:   {'loss': 7179.752022879465, 'cls_loss': 0.09537882038525172, 'recon_loss': 7179.648367745535, 'vq_loss': 0.00836009146379573, 'acc': 0.9642857142857143}\n",
+      "Epoch 19/20\n",
+      "  Train: {'loss': 10989.745860460069, 'cls_loss': 0.12156760888174176, 'recon_loss': 10989.616156684027, 'vq_loss': 0.008291221451428202, 'acc': 0.9694444444444444}\n",
+      "  Val:   {'loss': 7160.111537388393, 'cls_loss': 0.17991249968430825, 'recon_loss': 7159.923200334822, 'vq_loss': 0.008350488064544541, 'acc': 0.9642857142857143}\n",
+      "Epoch 20/20\n",
+      "  Train: {'loss': 10989.768766276042, 'cls_loss': 0.08508425168693065, 'recon_loss': 10989.675412326389, 'vq_loss': 0.008286384358588193, 'acc': 0.960185186068217}\n",
+      "  Val:   {'loss': 7140.761439732143, 'cls_loss': 0.13536975798862322, 'recon_loss': 7140.617745535715, 'vq_loss': 0.008339400802339827, 'acc': 0.9464285714285714}\n"
+     ]
+    }
+   ],
+   "source": [
+    "for epoch in range(1, EPOCHS + 1):\n",
+    "    model.train()\n",
+    "    train_stats = []\n",
+    "\n",
+    "    for batch in train_loader:\n",
+    "        train_stats.append(run_step(model, batch, training=True))\n",
+    "\n",
+    "    train_mean = {k: float(np.mean([s[k] for s in train_stats])) for k in train_stats[0].keys()}\n",
+    "    val_mean = evaluate(model, val_loader)\n",
+    "\n",
+    "    print(f\"Epoch {epoch}/{EPOCHS}\")\n",
+    "    print(\"  Train:\", train_mean)\n",
+    "    if val_mean is not None:\n",
+    "        print(\"  Val:  \", val_mean)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66008d1f",
+   "metadata": {},
+   "source": [
+    "## 9. Test Evaluation\n",
+    "Evaluate the trained model on the test split."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e1804b0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test metrics: {'loss': 10736.539438100961, 'cls_loss': 0.09225075351647459, 'recon_loss': 10736.439077524039, 'vq_loss': 0.007972102218235914, 'acc': 0.9711538461538461}\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_mean = evaluate(model, test_loader)\n",
+    "print(\"Test metrics:\", test_mean)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a35ec01",
+   "metadata": {},
+   "source": [
+    "## 10. Extract Tokens (Optional)\n",
+    "Extract flattened multi-channel tokens from one test batch for downstream conformal workflows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2d9fb454",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Token batch shape: (8, 16, 9) (B, C, T_tokens)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@torch.no_grad()\n",
+    "def extract_tokens_one_batch(model, loader):\n",
+    "    model.eval()\n",
+    "    batch = next(iter(loader))\n",
+    "\n",
+    "    x = batch[\"signal\"].float().to(DEVICE)\n",
+    "    x_stft = get_stft_torch(x, resampling_rate=RESAMPLING_RATE)\n",
+    "\n",
+    "    B, C = x.shape[0], x.shape[1]\n",
+    "    x_stft = rearrange(x_stft, \"B C F T -> (B C) F T\")\n",
+    "    x = rearrange(x, \"B C T -> (B C) T\")\n",
+    "\n",
+    "    _, tokens_flat, _, _ = model.tokenizer(x_stft, x)\n",
+    "    tokens_mc = tokens_flat.reshape(B, C, -1)\n",
+    "    return tokens_mc.cpu()\n",
+    "\n",
+    "if test_loader is not None and len(test_ds) > 0:\n",
+    "    token_batch = extract_tokens_one_batch(model, test_loader)\n",
+    "    print(\"Token batch shape:\", tuple(token_batch.shape), \"(B, C, T_tokens)\")\n",
+    "else:\n",
+    "    print(\"No test data available for token extraction.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.13.11)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
**Contributor:** Sayeed Sajjad Razin ([razin93937@gmail.com](mailto:razin93937@gmail.com))  
**Contribution Type:** Examples

**Description**  
Adds a runnable Jupyter notebook that trains and evaluates the TFMTokenizer on the TUEV EEG Events task.

**Files to review**
- `examples/conformal_eeg/tfm_tokenizer_tuev.ipynb` - New notebook: TUEV data configuration, training/evaluation loop, and token extraction.