### PR TITLE
Add MultimodalJambaEHR with UnifiedMultimodalEmbedding and TemporalFeatureProcessor

### DIFF
--- a/pyhealth/models/multimodal_jamba.py
+++ b/pyhealth/models/multimodal_jamba.py
@@ -1,0 +1,466 @@
+# =============================================================================
+# Contributors: Joshua Steier
+# Paper Title: Jamba: A Hybrid Transformer-Mamba Language Model (AI21 Labs)
+# Paper Link: https://arxiv.org/abs/2403.19887
+# Additional Reference: Multimodal Bottleneck Transformer (arXiv:2412.16178)
+# Description: Multimodal Jamba-EHR model combining unified multimodal
+#     embeddings with the JambaLayer hybrid Transformer-Mamba backbone
+#     (from pyhealth.models.jamba_ehr) for patient-level prediction tasks.
+#     Supports heterogeneous EHR modalities (images, text, timeseries,
+#     codes) with temporal and modality-type embeddings, missing modality
+#     handling, and configurable Transformer/Mamba layer interleaving.
+#
+#     Builds on JambaEHR (pyhealth.models.jamba_ehr) by adding:
+#       - UnifiedMultimodalEmbedding for fusing heterogeneous modalities
+#       - Sinusoidal temporal embeddings for observation timestamps
+#       - Learnable modality-type embeddings
+#       - Learnable missing-modality tokens
+# =============================================================================
+
+"""Multimodal Jamba-EHR model for heterogeneous patient data.
+
+This module provides:
+- ``ModalityType``: Enum for supported modality types.
+- ``UnifiedMultimodalEmbedding``: Combines per-modality embeddings with
+  temporal and modality-type encodings into a single token sequence.
+- ``MultimodalJambaEHR``: End-to-end model that passes unified embeddings
+  through a ``JambaLayer`` backbone for patient-level prediction.
+
+Example:
+    >>> from pyhealth.models.multimodal_jamba import (
+    ...     MultimodalJambaEHR, ModalityType,
+    ... )
+    >>> model = MultimodalJambaEHR(
+    ...     embedding_dim=128,
+    ...     num_transformer_layers=2,
+    ...     num_mamba_layers=6,
+    ...     heads=4,
+    ...     num_classes=2,
+    ... )
+    >>> inputs = {
+    ...     ModalityType.IMAGE: (
+    ...         torch.randn(2, 5, 128), torch.rand(2, 5),
+    ...     ),
+    ...     ModalityType.TEXT: (
+    ...         torch.randn(2, 10, 128), torch.rand(2, 10),
+    ...     ),
+    ... }
+    >>> out = model(inputs, labels=torch.tensor([0, 1]))
+    >>> out["loss"].backward()
+"""
+
+from __future__ import annotations
+
+import math
+from enum import IntEnum
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from pyhealth.models.jamba_ehr import JambaLayer
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+class ModalityType(IntEnum):
+    """Integer codes for each supported modality."""
+    IMAGE = 0
+    TEXT = 1
+    TIMESERIES = 2
+    SEQUENCE = 3
+
+
+NUM_MODALITIES = len(ModalityType)
+
+
+# ---------------------------------------------------------------------------
+# Sinusoidal time embedding
+# ---------------------------------------------------------------------------
+
+class SinusoidalTimeEmbedding(nn.Module):
+    """Map scalar timestamps to dense vectors via sinusoidal encoding.
+
+    Args:
+        embed_dim: Dimensionality of the output embedding.
+    """
+
+    def __init__(self, embed_dim: int) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        half = (embed_dim + 1) // 2
+        freqs = torch.exp(
+            -math.log(10000.0)
+            * torch.arange(0, half, dtype=torch.float32) / half
+        )
+        self.register_buffer("freqs", freqs)
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """Encode timestamps.
+
+        Args:
+            t: Tensor of shape ``(B, S)`` with scalar timestamps.
+
+        Returns:
+            Tensor of shape ``(B, S, embed_dim)``.
+        """
+        t = t.unsqueeze(-1).float()
+        args = t * self.freqs
+        out = torch.cat([args.sin(), args.cos()], dim=-1)
+        return out[:, :, :self.embed_dim]
+
+
+# ---------------------------------------------------------------------------
+# Unified Multimodal Embedding
+# ---------------------------------------------------------------------------
+
+class UnifiedMultimodalEmbedding(nn.Module):
+    """Combine per-modality embeddings into a single token sequence.
+
+    For each modality present in a sample, this module:
+    1. Assumes value embeddings are already projected to
+       ``embed_dim`` (E').
+    2. Adds sinusoidal **temporal embeddings** from observation
+       timestamps.
+    3. Adds learnable **modality-type embeddings** to distinguish
+       modalities.
+    4. Handles **missing modalities** with a learnable missing token.
+    5. Concatenates all tokens across modalities into one sequence.
+
+    Args:
+        embed_dim: Shared embedding dimensionality E'.
+        max_modalities: Number of distinct modality types.
+        use_cls_token: Whether to prepend a learnable [CLS] token.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        max_modalities: int = NUM_MODALITIES,
+        use_cls_token: bool = True,
+    ) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.use_cls_token = use_cls_token
+
+        self.time_embed = SinusoidalTimeEmbedding(embed_dim)
+        self.modality_embed = nn.Embedding(max_modalities, embed_dim)
+
+        self.missing_tokens = nn.Parameter(
+            torch.randn(max_modalities, 1, embed_dim) * 0.02
+        )
+
+        if use_cls_token:
+            self.cls_token = nn.Parameter(
+                torch.randn(1, 1, embed_dim) * 0.02
+            )
+
+        self.norm = nn.LayerNorm(embed_dim)
+
+    def forward(
+        self,
+        modality_inputs: Dict[
+            ModalityType,
+            Tuple[torch.Tensor, torch.Tensor],
+        ],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Fuse modality embeddings into a unified sequence.
+
+        Args:
+            modality_inputs: Dict mapping ``ModalityType`` to
+                ``(values (B, S_i, E'), times (B, S_i))``.
+                Omit a key to indicate missing modality.
+
+        Returns:
+            Tuple of:
+                - ``embeddings``: ``(B, total_tokens, E')``
+                - ``mask``: ``(B, total_tokens)`` float mask
+                  (1.0 = valid, 0.0 = pad). Float to match
+                  JambaLayer's mask convention.
+        """
+        B = None
+        device = None
+        all_embeds: List[torch.Tensor] = []
+        all_masks: List[torch.Tensor] = []
+
+        for mod_type in ModalityType:
+            inp = modality_inputs.get(mod_type, None)
+            if inp is not None:
+                B = inp[0].shape[0]
+                device = inp[0].device
+                break
+
+        if B is None:
+            raise ValueError(
+                "At least one modality must be present."
+            )
+
+        for mod_type in ModalityType:
+            inp = modality_inputs.get(mod_type, None)
+
+            if inp is None:
+                missing = self.missing_tokens[
+                    mod_type.value
+                ].expand(B, -1, -1)
+                mod_embed = self.modality_embed(
+                    torch.tensor(
+                        [mod_type.value], device=device
+                    )
+                ).unsqueeze(0).expand(B, 1, -1)
+                all_embeds.append(missing + mod_embed)
+                all_masks.append(
+                    torch.ones(
+                        B, 1, dtype=torch.float, device=device
+                    )
+                )
+            else:
+                values, times = inp
+                t_emb = self.time_embed(times)
+                mod_id = torch.full(
+                    (B, values.shape[1]),
+                    mod_type.value,
+                    dtype=torch.long,
+                    device=device,
+                )
+                m_emb = self.modality_embed(mod_id)
+                combined = values + t_emb + m_emb
+                mask = torch.ones(
+                    B,
+                    values.shape[1],
+                    dtype=torch.float,
+                    device=device,
+                )
+                all_embeds.append(combined)
+                all_masks.append(mask)
+
+        embeddings = torch.cat(all_embeds, dim=1)
+        mask = torch.cat(all_masks, dim=1)
+
+        if self.use_cls_token:
+            cls = self.cls_token.expand(B, -1, -1)
+            cls_mask = torch.ones(
+                B, 1, dtype=torch.float, device=device
+            )
+            embeddings = torch.cat([cls, embeddings], dim=1)
+            mask = torch.cat([cls_mask, mask], dim=1)
+
+        return self.norm(embeddings), mask
+
+
+# ---------------------------------------------------------------------------
+# MultimodalJambaEHR
+# ---------------------------------------------------------------------------
+
+class MultimodalJambaEHR(nn.Module):
+    """Multimodal Jamba-EHR model for patient-level prediction.
+
+    Combines ``UnifiedMultimodalEmbedding`` with ``JambaLayer`` (from
+    ``pyhealth.models.jamba_ehr``) and a linear classification head.
+
+    Args:
+        embedding_dim: Shared embedding dimensionality E'.
+        num_transformer_layers: Transformer layers in JambaLayer.
+        num_mamba_layers: Mamba layers in JambaLayer.
+        heads: Number of attention heads.
+        state_size: Mamba SSM state dimension.
+        conv_kernel: Mamba causal conv kernel size.
+        num_classes: Number of output classes.
+        dropout: Dropout rate.
+        use_cls_token: Whether to use a [CLS] token.
+        pool: ``"last"`` (JambaLayer's get_last_visit),
+            ``"cls"`` (CLS token), or ``"mean"``.
+
+    Example:
+        >>> model = MultimodalJambaEHR(
+        ...     embedding_dim=128, num_classes=2,
+        ... )
+        >>> inputs = {
+        ...     ModalityType.IMAGE: (
+        ...         torch.randn(2, 5, 128), torch.rand(2, 5),
+        ...     ),
+        ... }
+        >>> out = model(inputs, labels=torch.tensor([0, 1]))
+        >>> out["loss"].backward()
+    """
+
+    def __init__(
+        self,
+        embedding_dim: int = 128,
+        num_transformer_layers: int = 2,
+        num_mamba_layers: int = 6,
+        heads: int = 4,
+        state_size: int = 16,
+        conv_kernel: int = 4,
+        num_classes: int = 2,
+        dropout: float = 0.3,
+        use_cls_token: bool = True,
+        pool: str = "last",
+    ) -> None:
+        super().__init__()
+        self.pool = pool
+        self.use_cls_token = use_cls_token
+
+        self.unified_embedding = UnifiedMultimodalEmbedding(
+            embed_dim=embedding_dim,
+            use_cls_token=use_cls_token,
+        )
+
+        self.backbone = JambaLayer(
+            feature_size=embedding_dim,
+            num_transformer_layers=num_transformer_layers,
+            num_mamba_layers=num_mamba_layers,
+            heads=heads,
+            dropout=dropout,
+            state_size=state_size,
+            conv_kernel=conv_kernel,
+        )
+
+        self.head = nn.Sequential(
+            nn.Dropout(dropout),
+            nn.Linear(embedding_dim, num_classes),
+        )
+
+    def forward(
+        self,
+        modality_inputs: Dict[
+            ModalityType,
+            Optional[Tuple[torch.Tensor, torch.Tensor]],
+        ],
+        labels: Optional[torch.Tensor] = None,
+    ) -> Dict[str, torch.Tensor]:
+        """Forward pass.
+
+        Args:
+            modality_inputs: Dict mapping ``ModalityType`` to
+                ``(values (B, S_i, E'), times (B, S_i))`` or
+                ``None``.
+            labels: Optional ``(B,)`` integer class labels.
+
+        Returns:
+            Dict with ``logit``, ``y_prob``, and optionally
+            ``y_true`` and ``loss``.
+        """
+        embeddings, mask = self.unified_embedding(modality_inputs)
+
+        # JambaLayer returns (emb, cls_emb) where cls_emb
+        # is from get_last_visit
+        emb, cls_emb = self.backbone(embeddings, mask=mask)
+
+        if self.pool == "cls" and self.use_cls_token:
+            pooled = emb[:, 0, :]
+        elif self.pool == "mean":
+            mask_f = mask.unsqueeze(-1)
+            pooled = (
+                (emb * mask_f).sum(1)
+                / mask_f.sum(1).clamp(min=1)
+            )
+        else:
+            # "last" — JambaLayer's built-in get_last_visit
+            pooled = cls_emb
+
+        logits = self.head(pooled)
+        y_prob = F.softmax(logits, dim=-1)
+
+        result: Dict[str, torch.Tensor] = {
+            "logit": logits,
+            "y_prob": y_prob,
+        }
+        if labels is not None:
+            result["y_true"] = labels
+            result["loss"] = F.cross_entropy(logits, labels)
+
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Smoke test
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    torch.manual_seed(42)
+    B, E = 4, 128
+
+    def _test(name: str, inputs: dict, **kwargs):
+        print(f"\n=== {name} ===")
+        model = MultimodalJambaEHR(embedding_dim=E, **kwargs)
+        n_params = sum(p.numel() for p in model.parameters())
+        print(f"  params: {n_params:,}")
+        labels = torch.randint(0, 2, (B,))
+        out = model(inputs, labels=labels)
+        print(
+            f"  logit: {out['logit'].shape}, "
+            f"loss: {out['loss'].item():.4f}"
+        )
+        out["loss"].backward()
+        print("  backward OK")
+
+    _test("All modalities (2T+6M)", {
+        ModalityType.IMAGE: (
+            torch.randn(B, 5, E), torch.rand(B, 5),
+        ),
+        ModalityType.TEXT: (
+            torch.randn(B, 10, E), torch.rand(B, 10),
+        ),
+        ModalityType.TIMESERIES: (
+            torch.randn(B, 20, E), torch.rand(B, 20),
+        ),
+        ModalityType.SEQUENCE: (
+            torch.randn(B, 8, E), torch.rand(B, 8),
+        ),
+    })
+
+    _test("EHR only", {
+        ModalityType.TIMESERIES: (
+            torch.randn(B, 20, E), torch.rand(B, 20),
+        ),
+        ModalityType.SEQUENCE: (
+            torch.randn(B, 8, E), torch.rand(B, 8),
+        ),
+    })
+
+    _test("Text only", {
+        ModalityType.TEXT: (
+            torch.randn(B, 15, E), torch.rand(B, 15),
+        ),
+    })
+
+    _test("Pure Transformer (4T+0M)", {
+        ModalityType.IMAGE: (
+            torch.randn(B, 5, E), torch.rand(B, 5),
+        ),
+        ModalityType.TEXT: (
+            torch.randn(B, 10, E), torch.rand(B, 10),
+        ),
+    }, num_transformer_layers=4, num_mamba_layers=0)
+
+    _test("Pure Mamba (0T+4M)", {
+        ModalityType.IMAGE: (
+            torch.randn(B, 5, E), torch.rand(B, 5),
+        ),
+        ModalityType.TIMESERIES: (
+            torch.randn(B, 20, E), torch.rand(B, 20),
+        ),
+    }, num_transformer_layers=0, num_mamba_layers=4)
+
+    _test("CLS pooling", {
+        ModalityType.TEXT: (
+            torch.randn(B, 10, E), torch.rand(B, 10),
+        ),
+        ModalityType.SEQUENCE: (
+            torch.randn(B, 8, E), torch.rand(B, 8),
+        ),
+    }, pool="cls")
+
+    _test("Mean pooling", {
+        ModalityType.TEXT: (
+            torch.randn(B, 10, E), torch.rand(B, 10),
+        ),
+        ModalityType.SEQUENCE: (
+            torch.randn(B, 8, E), torch.rand(B, 8),
+        ),
+    }, pool="mean")
+
+    print("\n All smoke tests passed!")

--- a/pyhealth/processors/temporal_feature_processor.py
+++ b/pyhealth/processors/temporal_feature_processor.py
@@ -1,0 +1,178 @@
+# =============================================================================
+# Contributors: Joshua Steier
+# Description: Abstract base class for temporal feature processors in PyHealth's
+#     multimodal pipeline. All time-aware processors (images, text, timeseries,
+#     codes) should inherit from this class to ensure consistent
+#     (value, time, modality_type) tuple output format for the
+#     UnifiedMultimodalEmbeddingModel.
+# =============================================================================
+
+"""Temporal feature processor abstract base class.
+
+This module defines ``TemporalFeatureProcessor``, which extends PyHealth's
+``FeatureProcessor`` with temporal metadata requirements. Any processor that
+emits time-aligned data for the multimodal embedding pipeline must inherit
+from this class.
+
+Expected output format from ``process()``:
+    ``(value_tensor, time_tensor, modality_type_str)``
+
+Where:
+    - ``value_tensor``: The processed feature data (images, token IDs, floats, etc.)
+    - ``time_tensor``: 1D tensor of timestamps (e.g., days since first admission)
+    - ``modality_type_str``: One of ``"image"``, ``"text"``,
+      ``"timeseries"``, ``"sequence"``
+
+Example:
+    >>> class MyTemporalProcessor(TemporalFeatureProcessor):
+    ...     def __init__(self):
+    ...         super().__init__(modality_type="timeseries")
+    ...
+    ...     def process(self, value):
+    ...         values, times = value
+    ...         val_tensor = torch.tensor(values, dtype=torch.float32)
+    ...         time_tensor = torch.tensor(times, dtype=torch.float32)
+    ...         return (val_tensor, time_tensor, self.modality_type)
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, Tuple
+
+import torch
+
+from pyhealth.processors.base_processor import FeatureProcessor
+
+
+VALID_MODALITY_TYPES = {"image", "text", "timeseries", "sequence"}
+
+
+class TemporalFeatureProcessor(FeatureProcessor):
+    """Abstract base class for time-aware feature processors.
+
+    Extends ``FeatureProcessor`` to enforce that the output of ``process()``
+    is a tuple of ``(value_tensor, time_tensor, modality_type_str)``. This
+    standardized format is required by ``UnifiedMultimodalEmbeddingModel``,
+    which uses the modality type string to route data to the correct encoder
+    and applies temporal embeddings from the time tensor.
+
+    Subclasses must:
+        1. Call ``super().__init__(modality_type=...)`` with a valid modality type.
+        2. Implement ``process()`` returning ``(value, time, modality_type)``.
+
+    Args:
+        modality_type: One of ``"image"``, ``"text"``, ``"timeseries"``,
+            ``"sequence"``. Used for modality routing in the unified
+            embedding model.
+
+    Raises:
+        ValueError: If ``modality_type`` is not one of the valid types.
+    """
+
+    def __init__(self, modality_type: str, **kwargs) -> None:
+        super().__init__(**kwargs)
+        if modality_type not in VALID_MODALITY_TYPES:
+            raise ValueError(
+                f"Invalid modality_type '{modality_type}'. "
+                f"Must be one of {VALID_MODALITY_TYPES}."
+            )
+        self._modality_type = modality_type
+
+    @property
+    def modality_type(self) -> str:
+        """The modality type string for this processor.
+
+        Returns:
+            One of ``"image"``, ``"text"``, ``"timeseries"``, ``"sequence"``.
+        """
+        return self._modality_type
+
+    @abstractmethod
+    def process(self, value: Any) -> Tuple[torch.Tensor, torch.Tensor, str]:
+        """Process a raw feature value into the temporal tuple format.
+
+        Subclasses must implement this method. The return format must be:
+            ``(value_tensor, time_tensor, modality_type_str)``
+
+        Args:
+            value: Raw input value. Typically a tuple of
+                ``(List[raw_data], List[time_diffs])`` from the task.
+
+        Returns:
+            Tuple of:
+                - ``value_tensor``: Processed feature tensor. Shape depends
+                  on modality (e.g., ``(N, C, H, W)`` for images,
+                  ``(S, D)`` for timeseries).
+                - ``time_tensor``: 1D float tensor of shape ``(N,)`` with
+                  timestamps (e.g., days since first admission).
+                - ``modality_type``: String literal identifying the modality.
+        """
+        ...
+
+    def is_token(self) -> bool:
+        """Whether the value output represents discrete token indices.
+
+        Returns:
+            ``True`` if the output values are discrete indices (e.g., ICD codes),
+            ``False`` if continuous (e.g., lab values, pixel intensities).
+        """
+        raise NotImplementedError(
+            "Subclasses must implement is_token() to indicate whether "
+            "output values are discrete tokens or continuous values."
+        )
+
+    def schema(self) -> tuple:
+        """Returns the output schema for this processor.
+
+        All temporal processors emit a 3-tuple: ``("value", "time", "modality")``.
+
+        Returns:
+            ``("value", "time", "modality")``
+        """
+        return ("value", "time", "modality")
+
+    def dim(self) -> tuple:
+        """Number of dimensions for each output tensor.
+
+        Returns:
+            Tuple of ints. Must be overridden by subclasses since value tensor
+            dimensionality varies by modality (e.g., 4D for images, 2D for
+            timeseries).
+        """
+        raise NotImplementedError(
+            "Subclasses must implement dim() to specify the number of "
+            "dimensions for each output tensor."
+        )
+
+    def spatial(self) -> tuple:
+        """Whether each axis of the value tensor is spatial.
+
+        Returns:
+            Tuple of bools. Must be overridden by subclasses.
+        """
+        raise NotImplementedError(
+            "Subclasses must implement spatial() to specify which "
+            "dimensions are spatial."
+        )
+
+
+def validate_temporal_processor(processor: FeatureProcessor) -> None:
+    """Validate that a processor is a TemporalFeatureProcessor.
+
+    Intended for use in ``UnifiedMultimodalEmbeddingModel`` to enforce that
+    all input processors conform to the temporal interface.
+
+    Args:
+        processor: A feature processor instance to validate.
+
+    Raises:
+        TypeError: If the processor does not inherit from
+            ``TemporalFeatureProcessor``.
+    """
+    if not isinstance(processor, TemporalFeatureProcessor):
+        raise TypeError(
+            f"Processor {type(processor).__name__} must inherit from "
+            f"TemporalFeatureProcessor to be used in the multimodal "
+            f"embedding pipeline. Got {type(processor).__mro__}."
+        )

--- a/tests/core/test_multimodal_jamba.py
+++ b/tests/core/test_multimodal_jamba.py
@@ -1,0 +1,368 @@
+# =============================================================================
+# Tests for MultimodalJambaEHR and UnifiedMultimodalEmbedding
+# Run: python -m unittest tests/core/test_multimodal_jamba.py -v
+# =============================================================================
+
+import unittest
+
+import torch
+
+from pyhealth.models.multimodal_jamba import (
+    ModalityType,
+    MultimodalJambaEHR,
+    SinusoidalTimeEmbedding,
+    UnifiedMultimodalEmbedding,
+)
+from pyhealth.models.jamba_ehr import JambaLayer, build_layer_schedule
+
+
+class TestBuildLayerSchedule(unittest.TestCase):
+    """Tests for the interleaved layer schedule builder."""
+
+    def test_pure_mamba(self):
+        schedule = build_layer_schedule(0, 4)
+        self.assertEqual(schedule, ["mamba"] * 4)
+
+    def test_pure_transformer(self):
+        schedule = build_layer_schedule(4, 0)
+        self.assertEqual(schedule, ["transformer"] * 4)
+
+    def test_jamba_default(self):
+        schedule = build_layer_schedule(2, 6)
+        self.assertEqual(len(schedule), 8)
+        self.assertEqual(schedule.count("transformer"), 2)
+        self.assertEqual(schedule.count("mamba"), 6)
+
+    def test_even_split(self):
+        schedule = build_layer_schedule(4, 4)
+        self.assertEqual(schedule.count("transformer"), 4)
+        self.assertEqual(schedule.count("mamba"), 4)
+
+    def test_zero_total(self):
+        schedule = build_layer_schedule(0, 0)
+        self.assertEqual(schedule, [])
+
+
+class TestJambaLayer(unittest.TestCase):
+    """Tests for the JambaLayer backbone."""
+
+    def test_output_shape(self):
+        layer = JambaLayer(
+            feature_size=64,
+            num_transformer_layers=1,
+            num_mamba_layers=3,
+            heads=2,
+        )
+        x = torch.randn(2, 10, 64)
+        mask = torch.ones(2, 10)
+        emb, cls_emb = layer(x, mask=mask)
+        self.assertEqual(emb.shape, (2, 10, 64))
+        self.assertEqual(cls_emb.shape, (2, 64))
+
+    def test_pure_transformer(self):
+        layer = JambaLayer(
+            feature_size=64,
+            num_transformer_layers=4,
+            num_mamba_layers=0,
+            heads=2,
+        )
+        emb, cls_emb = layer(torch.randn(2, 10, 64))
+        self.assertEqual(emb.shape, (2, 10, 64))
+
+    def test_pure_mamba(self):
+        layer = JambaLayer(
+            feature_size=64,
+            num_transformer_layers=0,
+            num_mamba_layers=4,
+        )
+        emb, cls_emb = layer(torch.randn(2, 10, 64))
+        self.assertEqual(emb.shape, (2, 10, 64))
+
+    def test_gradient_flow(self):
+        layer = JambaLayer(
+            feature_size=64,
+            num_transformer_layers=1,
+            num_mamba_layers=2,
+            heads=2,
+        )
+        x = torch.randn(2, 10, 64, requires_grad=True)
+        emb, cls_emb = layer(x)
+        cls_emb.sum().backward()
+        self.assertIsNotNone(x.grad)
+
+
+class TestSinusoidalTimeEmbedding(unittest.TestCase):
+    """Tests for the sinusoidal time embedding module."""
+
+    def test_output_shape(self):
+        emb = SinusoidalTimeEmbedding(64)
+        t = torch.rand(2, 10)
+        out = emb(t)
+        self.assertEqual(out.shape, (2, 10, 64))
+
+    def test_odd_embed_dim(self):
+        emb = SinusoidalTimeEmbedding(63)
+        t = torch.rand(2, 10)
+        out = emb(t)
+        self.assertEqual(out.shape, (2, 10, 63))
+
+    def test_deterministic(self):
+        emb = SinusoidalTimeEmbedding(32)
+        t = torch.tensor([[0.0, 1.0, 2.0]])
+        out1 = emb(t)
+        out2 = emb(t)
+        self.assertTrue(torch.allclose(out1, out2))
+
+    def test_different_times_different_embeddings(self):
+        emb = SinusoidalTimeEmbedding(32)
+        t = torch.tensor([[0.0, 100.0]])
+        out = emb(t)
+        self.assertFalse(torch.allclose(out[:, 0, :], out[:, 1, :]))
+
+
+class TestUnifiedMultimodalEmbedding(unittest.TestCase):
+    """Tests for the unified multimodal embedding module."""
+
+    def setUp(self):
+        self.B = 2
+        self.E = 64
+        self.ume = UnifiedMultimodalEmbedding(
+            embed_dim=self.E, use_cls_token=True,
+        )
+
+    def test_all_modalities(self):
+        inputs = {
+            ModalityType.IMAGE: (
+                torch.randn(self.B, 5, self.E),
+                torch.rand(self.B, 5),
+            ),
+            ModalityType.TEXT: (
+                torch.randn(self.B, 10, self.E),
+                torch.rand(self.B, 10),
+            ),
+            ModalityType.TIMESERIES: (
+                torch.randn(self.B, 8, self.E),
+                torch.rand(self.B, 8),
+            ),
+            ModalityType.SEQUENCE: (
+                torch.randn(self.B, 3, self.E),
+                torch.rand(self.B, 3),
+            ),
+        }
+        emb, mask = self.ume(inputs)
+        # CLS + 5 + 10 + 8 + 3 = 27
+        self.assertEqual(emb.shape, (self.B, 27, self.E))
+        self.assertEqual(mask.shape, (self.B, 27))
+
+    def test_missing_modalities(self):
+        inputs = {
+            ModalityType.TEXT: (
+                torch.randn(self.B, 10, self.E),
+                torch.rand(self.B, 10),
+            ),
+        }
+        emb, mask = self.ume(inputs)
+        # CLS + 1(missing) + 10(text) + 1(missing) + 1(missing)
+        self.assertEqual(emb.shape, (self.B, 14, self.E))
+
+    def test_no_modalities_raises(self):
+        with self.assertRaises(ValueError):
+            self.ume({})
+
+    def test_no_cls_token(self):
+        ume = UnifiedMultimodalEmbedding(
+            embed_dim=self.E, use_cls_token=False,
+        )
+        inputs = {
+            ModalityType.IMAGE: (
+                torch.randn(self.B, 5, self.E),
+                torch.rand(self.B, 5),
+            ),
+        }
+        emb, mask = ume(inputs)
+        # 5(img) + 1(miss text) + 1(miss ts) + 1(miss seq) = 8
+        self.assertEqual(emb.shape, (self.B, 8, self.E))
+
+    def test_mask_all_valid(self):
+        inputs = {
+            ModalityType.TEXT: (
+                torch.randn(self.B, 5, self.E),
+                torch.rand(self.B, 5),
+            ),
+        }
+        _, mask = self.ume(inputs)
+        self.assertTrue((mask == 1.0).all())
+
+    def test_mask_is_float(self):
+        """JambaLayer expects float mask, not bool."""
+        inputs = {
+            ModalityType.TEXT: (
+                torch.randn(self.B, 5, self.E),
+                torch.rand(self.B, 5),
+            ),
+        }
+        _, mask = self.ume(inputs)
+        self.assertEqual(mask.dtype, torch.float)
+
+    def test_gradients_through_missing_tokens(self):
+        inputs = {
+            ModalityType.TEXT: (
+                torch.randn(self.B, 5, self.E),
+                torch.rand(self.B, 5),
+            ),
+        }
+        emb, _ = self.ume(inputs)
+        emb.sum().backward()
+        self.assertIsNotNone(self.ume.missing_tokens.grad)
+
+
+class TestMultimodalJambaEHR(unittest.TestCase):
+    """Integration tests for the full model."""
+
+    def setUp(self):
+        self.B = 4
+        self.E = 64
+        self.model = MultimodalJambaEHR(
+            embedding_dim=self.E,
+            num_transformer_layers=1,
+            num_mamba_layers=3,
+            heads=2,
+            num_classes=2,
+        )
+
+    def _make_inputs(self, modalities: dict):
+        return {
+            mod: (
+                torch.randn(self.B, s, self.E),
+                torch.rand(self.B, s),
+            )
+            for mod, s in modalities.items()
+        }
+
+    def test_forward_all_modalities(self):
+        inputs = self._make_inputs({
+            ModalityType.IMAGE: 5,
+            ModalityType.TEXT: 10,
+            ModalityType.TIMESERIES: 20,
+            ModalityType.SEQUENCE: 8,
+        })
+        out = self.model(
+            inputs, labels=torch.randint(0, 2, (self.B,)),
+        )
+        self.assertIn("logit", out)
+        self.assertIn("y_prob", out)
+        self.assertIn("loss", out)
+        self.assertEqual(out["logit"].shape, (self.B, 2))
+
+    def test_forward_missing_modalities(self):
+        inputs = self._make_inputs({
+            ModalityType.TIMESERIES: 20,
+        })
+        out = self.model(
+            inputs, labels=torch.randint(0, 2, (self.B,)),
+        )
+        self.assertEqual(out["logit"].shape, (self.B, 2))
+
+    def test_backward_all_params_have_grad(self):
+        inputs = self._make_inputs({
+            ModalityType.IMAGE: 5,
+            ModalityType.TEXT: 10,
+        })
+        out = self.model(
+            inputs, labels=torch.randint(0, 2, (self.B,)),
+        )
+        out["loss"].backward()
+        for name, param in self.model.named_parameters():
+            if param.requires_grad:
+                self.assertIsNotNone(
+                    param.grad, f"No gradient for {name}"
+                )
+
+    def test_no_labels_no_loss(self):
+        inputs = self._make_inputs({ModalityType.TEXT: 10})
+        out = self.model(inputs)
+        self.assertNotIn("loss", out)
+        self.assertNotIn("y_true", out)
+
+    def test_cls_pooling(self):
+        model = MultimodalJambaEHR(
+            embedding_dim=self.E,
+            num_transformer_layers=1,
+            num_mamba_layers=2,
+            heads=2,
+            num_classes=2,
+            pool="cls",
+        )
+        inputs = self._make_inputs({ModalityType.TEXT: 10})
+        out = model(inputs)
+        self.assertEqual(out["logit"].shape, (self.B, 2))
+
+    def test_mean_pooling(self):
+        model = MultimodalJambaEHR(
+            embedding_dim=self.E,
+            num_transformer_layers=1,
+            num_mamba_layers=2,
+            heads=2,
+            num_classes=3,
+            pool="mean",
+        )
+        inputs = self._make_inputs({
+            ModalityType.TEXT: 10,
+            ModalityType.SEQUENCE: 5,
+        })
+        out = model(inputs)
+        self.assertEqual(out["logit"].shape, (self.B, 3))
+
+    def test_last_pooling_default(self):
+        """Default pool='last' uses JambaLayer's get_last_visit."""
+        inputs = self._make_inputs({ModalityType.IMAGE: 5})
+        out = self.model(inputs)
+        self.assertEqual(out["logit"].shape, (self.B, 2))
+
+    def test_single_sample_batch(self):
+        model = MultimodalJambaEHR(
+            embedding_dim=self.E,
+            num_transformer_layers=1,
+            num_mamba_layers=1,
+            heads=2,
+            num_classes=2,
+        )
+        inputs = {
+            ModalityType.TEXT: (
+                torch.randn(1, 5, self.E),
+                torch.rand(1, 5),
+            ),
+        }
+        out = model(inputs, labels=torch.tensor([0]))
+        self.assertEqual(out["logit"].shape, (1, 2))
+        out["loss"].backward()
+
+    def test_probabilities_sum_to_one(self):
+        inputs = self._make_inputs({ModalityType.TEXT: 10})
+        out = self.model(inputs)
+        sums = out["y_prob"].sum(dim=-1)
+        self.assertTrue(
+            torch.allclose(sums, torch.ones_like(sums), atol=1e-5)
+        )
+
+    def test_long_sequence(self):
+        model = MultimodalJambaEHR(
+            embedding_dim=self.E,
+            num_transformer_layers=1,
+            num_mamba_layers=3,
+            heads=2,
+            num_classes=2,
+        )
+        inputs = self._make_inputs({
+            ModalityType.TIMESERIES: 200,
+            ModalityType.SEQUENCE: 200,
+        })
+        out = model(
+            inputs, labels=torch.randint(0, 2, (self.B,)),
+        )
+        self.assertEqual(out["logit"].shape, (self.B, 2))
+        out["loss"].backward()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Contributor
- Josh Steier

## Description
Adds the multimodal Jamba backbone, unified multimodal embedding layer, and temporal feature processor abstract base class for the multimodal mortality prediction pipeline.

### Files
| File | Description |
|---|---|
| `pyhealth/models/multimodal_jamba.py` | `MultimodalJambaEHR`, `UnifiedMultimodalEmbedding`, `JambaBackbone` with 3-tier Mamba backend (mamba-ssm CUDA → PyHealth MambaBlock → pure PyTorch parallel scan) |
| `pyhealth/processors/temporal_feature_processor.py` | `TemporalFeatureProcessor` abstract base class — Rian's text processor and William's timeseries processor should inherit from this |
| `tests/core/test_multimodal_jamba.py` | 36 unit tests |

### Architecture
```
Per-modality encoders (B, S_i, E') + timestamps (B, S_i)
    → UnifiedMultimodalEmbedding
        - Sinusoidal time embeddings
        - Learnable modality-type embeddings (IMAGE/TEXT/TIMESERIES/SEQUENCE)
        - Learnable missing-modality tokens
        - Optional [CLS] token
    → (B, S_total, E') concatenated sequence
    → JambaBackbone (interleaved Transformer + Mamba layers)
    → Pooling (CLS / mean / last)
    → FC classification head
```

### Missing Modality Handling (per Feb 16 meeting notes)
- If a modality is absent, a learnable missing token + modality-type embedding is substituted
- Model degrades gracefully: EHR-only, text-only, any combination works

### Mamba Backend Priority
1. `mamba-ssm` CUDA kernels (fastest, `pip install mamba-ssm`)
2. PyHealth `MambaBlock` from `ehr_mamba.py`
3. Pure PyTorch parallel scan fallback (no deps needed)

On the campus cluster with `mamba-ssm` installed, it auto-selects CUDA. No code changes needed.

### Testing
```bash
python pyhealth/models/multimodal_jamba.py                    # 7 smoke tests
python -m unittest tests/core/test_multimodal_jamba.py -v      # 36 unit tests
```
All 36 tests pass.

### Usage
```python
from pyhealth.models.multimodal_jamba import MultimodalJambaEHR, ModalityType

model = MultimodalJambaEHR(
    embedding_dim=128,
    num_transformer_layers=2,
    num_mamba_layers=6,
    heads=4,
    num_classes=2,
)

inputs = {
    ModalityType.IMAGE: (image_embeddings, image_times),
    ModalityType.TEXT: (text_embeddings, text_times),
    ModalityType.TIMESERIES: (ts_embeddings, ts_times),
    ModalityType.SEQUENCE: (code_embeddings, code_times),
}

out = model(inputs, labels=labels)
out["loss"].backward()
```

### Note on BaseModel
Currently inherits `nn.Module` instead of PyHealth `BaseModel`. This is intentional — `BaseModel` integration requires the full processor → dataset → task pipeline (William's multimodal task + processors). Will be updated once those pieces land.