### PR TITLE
fix: prevent batch_size=1 crashes, secure torch.load, fix device/contiguity issues

### DIFF
--- a/pyhealth/medcode/pretrained_embeddings/kg_emb/models/kg_base.py
+++ b/pyhealth/medcode/pretrained_embeddings/kg_emb/models/kg_base.py
@@ -389,7 +389,7 @@ class KGEBaseModel(ABC, nn.Module):
 
     
     def from_pretrained(self, path):
-        state_dict = torch.load(path, map_location=self.device)
+        state_dict = torch.load(path, map_location=self.device, weights_only=True)
         self.update_embedding_size(state_dict)
         self.load_state_dict(state_dict)
         return

--- a/pyhealth/models/agent.py
+++ b/pyhealth/models/agent.py
@@ -462,15 +462,15 @@ class Agent(BaseModel):
             pred_prob = torch.sigmoid(pred)
             #reward=1-[true-pred_prob]
             #High reward when prediction matches label for both classes
-            rewards=(1-torch.abs(true.float()- pred_prob)).squeeze()
+            rewards = (1 - torch.abs(true.float() - pred_prob)).squeeze(dim=-1)
         elif self.mode == "multiclass":
             pred_prob = torch.softmax(pred, dim=-1)
             y_onehot = torch.zeros_like(pred_prob).scatter(1, true.unsqueeze(1), 1)
-            rewards = (pred_prob * y_onehot).sum(-1).squeeze()
+            rewards = (pred_prob * y_onehot).sum(dim=-1)
         elif self.mode == "multilabel":
             pred_prob = torch.sigmoid(pred)
-            #Reward based on how well predictions match all labels 
-            rewards = (1 - torch.abs(true.float() - pred_prob)).mean(dim=-1).squeeze()
+            # Reward based on how well predictions match all labels
+            rewards = (1 - torch.abs(true.float() - pred_prob)).mean(dim=-1)
         else:
             raise ValueError(f"Unsupported mode: {self.mode}")
 

--- a/pyhealth/models/biot.py
+++ b/pyhealth/models/biot.py
@@ -297,7 +297,7 @@ class BIOT(BaseModel):
         if map_location is None:
             map_location = str(self.device)
 
-        checkpoint = torch.load(checkpoint_path, map_location=map_location)
+        checkpoint = torch.load(checkpoint_path, map_location=map_location, weights_only=True)
 
         if "model_state_dict" in checkpoint:
             state_dict = checkpoint["model_state_dict"]

--- a/pyhealth/models/concare.py
+++ b/pyhealth/models/concare.py
@@ -126,7 +126,7 @@ class FinalAttentionQKV(nn.Module):
             q = torch.reshape(
                 input_q, (batch_size, self.attention_hidden_dim, 1)
             )  # [batch, hidden, 1]
-            e = torch.matmul(input_k, q).squeeze()  # [batch, time]
+            e = torch.matmul(input_k, q).squeeze(dim=-1)  # [batch, time]
 
         elif self.attention_type == "concat":
             q = input_q.unsqueeze(1).repeat(1, time_step, 1)  # [batch, time, hidden]
@@ -145,7 +145,7 @@ class FinalAttentionQKV(nn.Module):
         a = self.softmax(e)  # [batch, time]
         if self.dropout is not None:
             a = self.dropout(a)
-        v = torch.matmul(a.unsqueeze(1), input_v).squeeze()  # [batch, hidden]
+        v = torch.matmul(a.unsqueeze(1), input_v).squeeze(dim=1)  # [batch, hidden]
 
         return v, a
 

--- a/pyhealth/models/rnn.py
+++ b/pyhealth/models/rnn.py
@@ -110,7 +110,7 @@ class RNNLayer(nn.Module):
         else:
             lengths = torch.sum(mask.int(), dim=-1).cpu()
         x = rnn_utils.pack_padded_sequence(
-            x, lengths, batch_first=True, enforce_sorted=False
+            x.contiguous(), lengths, batch_first=True, enforce_sorted=False
         )
         outputs, _ = self.rnn(x)
         outputs, _ = rnn_utils.pad_packed_sequence(outputs, batch_first=True)

--- a/pyhealth/models/stagenet.py
+++ b/pyhealth/models/stagenet.py
@@ -169,11 +169,11 @@ class StageNetLayer(nn.Module):
         # rnn will only apply dropout between layers
         batch_size, time_step, feature_dim = x.size()
         device = x.device
-        if time == None:
-            time = torch.ones(batch_size, time_step)
+        if time is None:
+            time = torch.ones(batch_size, time_step, device=device)
         time = time.reshape(batch_size, time_step)
-        c_out = torch.zeros(batch_size, self.hidden_dim)
-        h_out = torch.zeros(batch_size, self.hidden_dim)
+        c_out = torch.zeros(batch_size, self.hidden_dim, device=device)
+        h_out = torch.zeros(batch_size, self.hidden_dim, device=device)
 
         tmp_h = (
             torch.zeros_like(h_out, dtype=torch.float32)

--- a/pyhealth/models/tfm_tokenizer.py
+++ b/pyhealth/models/tfm_tokenizer.py
@@ -927,10 +927,10 @@ class TFMTokenizer(BaseModel):
             map_location = str(self.device)
 
         # Load tokenizer weights
-        self.tokenizer.load_state_dict(torch.load(tokenizer_checkpoint_path, map_location=map_location), strict=strict)
+        self.tokenizer.load_state_dict(torch.load(tokenizer_checkpoint_path, map_location=map_location, weights_only=True), strict=strict)
 
         if classifier_checkpoint_path is not None and not is_masked_training:
-            self.classifier.load_state_dict(torch.load(classifier_checkpoint_path, map_location=map_location))
+            self.classifier.load_state_dict(torch.load(classifier_checkpoint_path, map_location=map_location, weights_only=True))
             print(f"✓ Successfully loaded weights from {classifier_checkpoint_path}")
         elif is_masked_training:
             load_embedding_weights(self.tokenizer, self.classifier)

--- a/pyhealth/trainer.py
+++ b/pyhealth/trainer.py
@@ -348,7 +348,7 @@ class Trainer:
 
     def load_ckpt(self, ckpt_path: str) -> None:
         """Saves the model checkpoint."""
-        state_dict = torch.load(ckpt_path, map_location=self.device)
+        state_dict = torch.load(ckpt_path, map_location=self.device, weights_only=True)
         self.model.load_state_dict(state_dict)
         return
 


### PR DESCRIPTION
## Summary

Four categories of bug fixes across 8 files, addressing silent correctness errors, security warnings, and device compatibility crashes.

## 1. Bare `.squeeze()` → explicit dim (prevents batch_size=1 crashes)

When `batch_size=1`, bare `.squeeze()` silently removes the batch dimension, causing all downstream operations to compute on wrong axes without any error.

| File | Line | Before | After |
|------|------|--------|-------|
| `concare.py` | 129 | `.squeeze()` | `.squeeze(dim=-1)` |
| `concare.py` | 148 | `.squeeze()` | `.squeeze(dim=1)` |
| `agent.py` | 465 | `.squeeze()` | `.squeeze(dim=-1)` |
| `agent.py` | 469 | `.sum(-1).squeeze()` | `.sum(dim=-1)` (already 1-D) |
| `agent.py` | 473 | `.mean(dim=-1).squeeze()` | `.mean(dim=-1)` (already 1-D) |

## 2. `torch.load()` + `weights_only=True` (5 call sites)

Since PyTorch 2.6, `torch.load()` defaults to `weights_only=True`. Without explicit opt-in, loading checkpoints produces deprecation warnings and will break in future versions. Also prevents arbitrary code execution via pickle deserialization (security).

Files: `trainer.py`, `biot.py`, `tfm_tokenizer.py` (×2), `kg_base.py`

## 3. RNN `.contiguous()` before `pack_padded_sequence` (fixes #800)

Non-contiguous tensors (from slicing/transposing) passed to `pack_padded_sequence` cause `CUDNN_STATUS_NOT_SUPPORTED` errors. Added `.contiguous()` call.

## 4. StageNet device mismatch fix

`torch.zeros()`/`torch.ones()` were created on CPU regardless of input device, causing device mismatch crashes during GPU training. Now created on `x.device`. Also fixed `time == None` → `time is None` (PEP8).

## Test plan

- [ ] Run ConCare with batch_size=1 — should produce correct predictions
- [ ] Load checkpoint with PyTorch 2.6+ — no deprecation warnings
- [ ] Train RNN model with non-contiguous input — no cuDNN error
- [ ] Train StageNet on GPU — no device mismatch