### PR TITLE
fix: improve research reliability — metrics mutation, eval mode, reproducible splits

### DIFF
--- a/pyhealth/datasets/splitter.py
+++ b/pyhealth/datasets/splitter.py
@@ -124,11 +124,10 @@ def split_by_visit(
         The original dataset can be accessed by `train_dataset.dataset`,
             `val_dataset.dataset`, and `test_dataset.dataset`.
     """
-    if seed is not None:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     assert sum(ratios) == 1.0, "ratios must sum to 1.0"
     index = np.arange(len(dataset))
-    np.random.shuffle(index)
+    rng.shuffle(index)
     train_index = index[: int(len(dataset) * ratios[0])]
     val_index = index[
         int(len(dataset) * ratios[0]) : int(len(dataset) * (ratios[0] + ratios[1]))
@@ -160,12 +159,11 @@ def split_by_patient(
         The original dataset can be accessed by `train_dataset.dataset`,
             `val_dataset.dataset`, and `test_dataset.dataset`.
     """
-    if seed is not None:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     assert sum(ratios) == 1.0, "ratios must sum to 1.0"
     patient_indx = list(dataset.patient_to_index.keys())
     num_patients = len(patient_indx)
-    np.random.shuffle(patient_indx)
+    rng.shuffle(patient_indx)
     train_patient_indx = patient_indx[: int(num_patients * ratios[0])]
     val_patient_indx = patient_indx[
         int(num_patients * ratios[0]) : int(num_patients * (ratios[0] + ratios[1]))
@@ -203,11 +201,10 @@ def split_by_sample(
         The original dataset can be accessed by `train_dataset.dataset`,
             `val_dataset.dataset`, and `test_dataset.dataset`.
     """
-    if seed is not None:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     assert sum(ratios) == 1.0, "ratios must sum to 1.0"
     index = np.arange(len(dataset))
-    np.random.shuffle(index)
+    rng.shuffle(index)
     train_index = index[: int(len(dataset) * ratios[0])]
     val_index = index[
         int(len(dataset) * ratios[0]) : int(len(dataset) * (ratios[0] + ratios[1]))
@@ -248,13 +245,12 @@ def split_by_visit_conformal(
             `val_dataset.dataset`, `cal_dataset.dataset`, and
             `test_dataset.dataset`.
     """
-    if seed is not None:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     assert len(ratios) == 4, "ratios must have 4 elements for train/val/cal/test"
     assert sum(ratios) == 1.0, "ratios must sum to 1.0"
 
     index = np.arange(len(dataset))
-    np.random.shuffle(index)
+    rng.shuffle(index)
 
     # Calculate split points
     train_end = int(len(dataset) * ratios[0])
@@ -295,14 +291,13 @@ def split_by_patient_conformal(
             `val_dataset.dataset`, `cal_dataset.dataset`, and
             `test_dataset.dataset`.
     """
-    if seed is not None:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     assert len(ratios) == 4, "ratios must have 4 elements for train/val/cal/test"
     assert sum(ratios) == 1.0, "ratios must sum to 1.0"
 
     patient_indx = list(dataset.patient_to_index.keys())
     num_patients = len(patient_indx)
-    np.random.shuffle(patient_indx)
+    rng.shuffle(patient_indx)
 
     # Calculate split points
     train_end = int(num_patients * ratios[0])
@@ -369,10 +364,9 @@ def split_by_sample_conformal_tuh(
             test_list.append(i)
 
     # shuffle only the train pool
-    if seed is not None:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     train_arr = np.array(train_pool)
-    np.random.shuffle(train_arr)
+    rng.shuffle(train_arr)
 
     # Slice into train / val / cal.
     n = len(train_arr)
@@ -424,13 +418,12 @@ def split_by_sample_conformal(
             `val_dataset.dataset`, `cal_dataset.dataset`, and
             `test_dataset.dataset`.
     """
-    if seed is not None:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     assert len(ratios) == 4, "ratios must have 4 elements for train/val/cal/test"
     assert sum(ratios) == 1.0, "ratios must sum to 1.0"
 
     index = np.arange(len(dataset))
-    np.random.shuffle(index)
+    rng.shuffle(index)
 
     # Calculate split points
     train_end = int(len(dataset) * ratios[0])

--- a/pyhealth/metrics/regression.py
+++ b/pyhealth/metrics/regression.py
@@ -50,11 +50,14 @@ def regression_metrics_fn(
     output = {}
     for metric in metrics:
         if metric == "kl_divergence":
-            x[x < 1e-6] = 1e-6
-            x_rec[x_rec < 1e-6] = 1e-6
-            x = x / np.sum(x)
-            x_rec = x_rec / np.sum(x_rec)
-            kl_divergence = np.sum(x_rec * np.log(x_rec / x))
+            # Work on copies to avoid mutating x/x_rec for subsequent metrics
+            x_kl = x.copy()
+            x_rec_kl = x_rec.copy()
+            x_kl[x_kl < 1e-6] = 1e-6
+            x_rec_kl[x_rec_kl < 1e-6] = 1e-6
+            x_kl = x_kl / np.sum(x_kl)
+            x_rec_kl = x_rec_kl / np.sum(x_rec_kl)
+            kl_divergence = np.sum(x_rec_kl * np.log(x_rec_kl / x_kl))
             output["kl_divergence"] = kl_divergence
         elif metric == "mse":
             mse = sklearn_metrics.mean_squared_error(x, x_rec)

--- a/pyhealth/trainer.py
+++ b/pyhealth/trainer.py
@@ -286,8 +286,8 @@ class Trainer:
         patient_ids = []
         if additional_outputs is not None:
             additional_outputs = {k: [] for k in additional_outputs}
+        self.model.eval()
         for data in tqdm(dataloader, desc="Evaluation"):
-            self.model.eval()
             with torch.no_grad():
                 output = self.model(**data)
                 loss = output["loss"]


### PR DESCRIPTION
## Summary

Three fixes that directly affect the trustworthiness of experimental results produced by PyHealth.

## 1. Regression metrics mutate input arrays (correctness bug)

**File:** `pyhealth/metrics/regression.py`

When computing `kl_divergence`, the function modifies `x` and `x_rec` **in-place** (clamping values < 1e-6 and normalizing). If multiple metrics are requested (the default is `["kl_divergence", "mse", "mae"]`), the subsequent `mse` and `mae` are computed on the clamped/normalized arrays, **not the original data**.

```python
# Before (mutates x for all subsequent metrics):
x[x < 1e-6] = 1e-6
x = x / np.sum(x)

# After (operates on isolated copy):
x_kl = x.copy()
x_kl[x_kl < 1e-6] = 1e-6
x_kl = x_kl / np.sum(x_kl)
```

**Impact:** MSE/MAE values reported alongside KL divergence in papers using PyHealth may be incorrect.

## 2. `model.eval()` called per-batch instead of per-evaluation

**File:** `pyhealth/trainer.py`

`self.model.eval()` was inside the `for data in dataloader` loop, redundantly setting eval mode on every batch. Moved before the loop — called once as intended.

## 3. `np.random.seed()` pollutes global random state

**File:** `pyhealth/datasets/splitter.py`

All 7 split functions (`split_by_visit`, `split_by_patient`, `split_by_sample`, and their conformal variants) used `np.random.seed(seed)` which mutates the **global** numpy random state. This means:
- Calling `split_by_patient(seed=42)` followed by `split_by_visit(seed=42)` produces different results than calling them in reverse order
- Any other numpy random calls between splits are affected
- Experiments are not truly reproducible

Replaced with `np.random.default_rng(seed)` which creates an **isolated** RNG instance per call. Note that `sample_balanced()` already used `default_rng` correctly — this brings the other functions to the same standard.

## Test plan

- [ ] `regression_metrics_fn(x, x_rec, metrics=["kl_divergence", "mse"])` — verify MSE is unchanged by KL computation
- [ ] `split_by_patient(seed=42)` called twice produces identical splits
- [ ] `split_by_patient(seed=42)` result is independent of prior `split_by_visit` calls