### PR TITLE
feat: add optional dependency groups for graph and NLP extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,16 +46,6 @@ dependencies = [
   "einops>=0.8.0",
   "linear-attention-transformer>=0.19.1",
 ]
-[project.optional-dependencies]
-graph = [
-  "torch-geometric>=2.6.0",
-]
-nlp = [
-  "editdistance~=0.8.1",
-  "rouge_score~=0.1.2",
-  "nltk~=3.9.1",
-]
-
 license = "BSD-3-Clause"
 license-files = ["LICENSE.md"]
 keywords = [
@@ -67,6 +57,16 @@ keywords = [
   "data mining",
   "neural networks",
   "deep learning",
+]
+
+[project.optional-dependencies]
+graph = [
+  "torch-geometric>=2.6.0",
+]
+nlp = [
+  "editdistance~=0.8.1",
+  "rouge_score~=0.1.2",
+  "nltk~=3.9.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Add `[project.optional-dependencies]` to `pyproject.toml` so users can install domain-specific dependencies via standard pip extras.

Closes #890

## Usage

```bash
pip install pyhealth[graph]   # for GraphCare, knowledge graphs
pip install pyhealth[nlp]     # for NLP metrics (BLEU, ROUGE, edit distance)
```

## Groups added

### `graph`
- `torch-geometric>=2.6.0`

Used by: `graphcare.py`, `bat_gnn.py`, `knowledge_graph.py`, `graph_processor.py`, `datasets/utils.py`

The codebase already has `try/except ImportError` guards with `HAS_PYG` flags — this just makes the dependency installable through standard packaging.

### `nlp`
- `editdistance~=0.8.1`
- `rouge_score~=0.1.2`
- `nltk~=3.9.1`

Used by: `pyhealth/nlp/metrics.py` (EditDistance, BLEU, ROUGE scorers)

Version pins match the requirements already declared in each scorer class's `packages()` method.

## No breaking changes

Existing `pip install pyhealth` behavior is unchanged — these are optional extras that users opt into explicitly.