### PR TITLE
fix: correct type annotations, docstrings, and bare except blocks

### DIFF
--- a/pyhealth/datasets/base_dataset.py
+++ b/pyhealth/datasets/base_dataset.py
@@ -769,7 +769,7 @@ class BaseDataset(ABC):
                         while not result.ready():
                             try:
                                 progress.update(queue.get(timeout=1))
-                            except:
+                            except Exception:
                                 pass
 
                         # remaining items
@@ -819,7 +819,7 @@ class BaseDataset(ABC):
                         while not result.ready():
                             try:
                                 progress.update(queue.get(timeout=1))
-                            except:
+                            except Exception:
                                 pass
 
                         # remaining items

--- a/pyhealth/datasets/mimic3.py
+++ b/pyhealth/datasets/mimic3.py
@@ -42,7 +42,7 @@ class MIMIC3Dataset(BaseDataset):
         **kwargs,
     ) -> None:
         """
-        Initializes the MIMIC4Dataset with the specified parameters.
+        Initializes the MIMIC3Dataset with the specified parameters.
 
         Args:
             root (str): The root directory where the dataset is stored.

--- a/pyhealth/models/adacare.py
+++ b/pyhealth/models/adacare.py
@@ -214,9 +214,9 @@ class AdaCareLayer(nn.Module):
 
     def forward(
         self,
-        x: torch.tensor,
-        mask: Optional[torch.tensor] = None,
-    ) -> Tuple[torch.tensor, torch.tensor, torch.tensor]:
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Forward propagation.
 
         Args:

--- a/pyhealth/models/gamenet.py
+++ b/pyhealth/models/gamenet.py
@@ -43,7 +43,7 @@ class GCNLayer(nn.Module):
         if self.bias is not None:
             self.bias.data.uniform_(-stdv, stdv)
 
-    def forward(self, input: torch.tensor, adj: torch.tensor) -> torch.tensor:
+    def forward(self, input: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
         """
         Args:
             input: input feature tensor of shape [num_nodes, in_features].
@@ -74,7 +74,7 @@ class GCN(nn.Module):
         dropout: dropout rate. Default is 0.5.
     """
 
-    def __init__(self, adj: torch.tensor, hidden_size: int, dropout: float = 0.5):
+    def __init__(self, adj: torch.Tensor, hidden_size: int, dropout: float = 0.5):
         super(GCN, self).__init__()
         self.emb_dim = hidden_size
         self.dropout = dropout
@@ -89,7 +89,7 @@ class GCN(nn.Module):
         self.dropout_layer = nn.Dropout(p=dropout)
         self.gcn2 = GCNLayer(hidden_size, hidden_size)
 
-    def normalize(self, mx: torch.tensor) -> torch.tensor:
+    def normalize(self, mx: torch.Tensor) -> torch.Tensor:
         """Normalizes the matrix row-wise."""
         rowsum = mx.sum(1)
         r_inv = torch.pow(rowsum, -1).flatten()
@@ -98,7 +98,7 @@ class GCN(nn.Module):
         mx = torch.mm(r_mat_inv, mx)
         return mx
 
-    def forward(self) -> torch.tensor:
+    def forward(self) -> torch.Tensor:
         """Forward propagation.
 
         Returns:
@@ -144,8 +144,8 @@ class GAMENetLayer(nn.Module):
     def __init__(
         self,
         hidden_size: int,
-        ehr_adj: torch.tensor,
-        ddi_adj: torch.tensor,
+        ehr_adj: torch.Tensor,
+        ddi_adj: torch.Tensor,
         dropout: float = 0.5,
     ):
         super(GAMENetLayer, self).__init__()
@@ -163,11 +163,11 @@ class GAMENetLayer(nn.Module):
 
     def forward(
         self,
-        queries: torch.tensor,
-        prev_drugs: torch.tensor,
-        curr_drugs: torch.tensor,
-        mask: Optional[torch.tensor] = None,
-    ) -> Tuple[torch.tensor, torch.tensor]:
+        queries: torch.Tensor,
+        prev_drugs: torch.Tensor,
+        curr_drugs: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Forward propagation.
 
         Args:
@@ -355,7 +355,7 @@ class GAMENet(BaseModel):
         # save ddi adj
         np.save(os.path.join(CACHE_PATH, "ddi_adj.npy"), ddi_adj.numpy())
 
-    def generate_ehr_adj(self) -> torch.tensor:
+    def generate_ehr_adj(self) -> torch.Tensor:
         """Generates the EHR graph adjacency matrix."""
         label_vocab = self.dataset.output_processors[self.label_key].label_vocab
         label_size = len(label_vocab)
@@ -376,7 +376,7 @@ class GAMENet(BaseModel):
                     ehr_adj[med2, med1] = 1
         return ehr_adj
 
-    def generate_ddi_adj(self) -> torch.tensor:
+    def generate_ddi_adj(self) -> torch.Tensor:
         """Generates the DDI graph adjacency matrix."""
         atc = ATC()
         ddi = atc.get_ddi(gamenet_ddi=True)

--- a/pyhealth/models/grasp.py
+++ b/pyhealth/models/grasp.py
@@ -264,10 +264,10 @@ class GRASPLayer(nn.Module):
 
     def forward(
         self,
-        x: torch.tensor,
-        static: Optional[torch.tensor] = None,
-        mask: Optional[torch.tensor] = None,
-    ) -> torch.tensor:
+        x: torch.Tensor,
+        static: Optional[torch.Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         """Forward propagation.
 
         Args:

--- a/pyhealth/models/micron.py
+++ b/pyhealth/models/micron.py
@@ -61,8 +61,8 @@ class MICRONLayer(nn.Module):
 
     @staticmethod
     def compute_reconstruction_loss(
-        logits: torch.tensor, logits_residual: torch.tensor, mask: torch.tensor
-    ) -> torch.tensor:
+        logits: torch.Tensor, logits_residual: torch.Tensor, mask: torch.Tensor
+    ) -> torch.Tensor:
         """Compute reconstruction loss between predicted and actual medication changes.
 
         The reconstruction loss measures how well the model captures medication changes
@@ -70,12 +70,12 @@ class MICRONLayer(nn.Module):
         connections) with actual changes in prescriptions.
 
         Args:
-            logits (torch.tensor): Raw logits for medication predictions across all visits.
-            logits_residual (torch.tensor): Residual logits representing predicted changes.
-            mask (torch.tensor): Boolean mask indicating valid visits.
+            logits (torch.Tensor): Raw logits for medication predictions across all visits.
+            logits_residual (torch.Tensor): Residual logits representing predicted changes.
+            mask (torch.Tensor): Boolean mask indicating valid visits.
 
         Returns:
-            torch.tensor: Mean squared reconstruction loss value.
+            torch.Tensor: Mean squared reconstruction loss value.
         """
         rec_loss = torch.mean(
             torch.square(
@@ -88,10 +88,10 @@ class MICRONLayer(nn.Module):
 
     def forward(
         self,
-        patient_emb: torch.tensor,
-        drugs: torch.tensor,
-        mask: Optional[torch.tensor] = None,
-    ) -> Tuple[torch.tensor, torch.tensor]:
+        patient_emb: torch.Tensor,
+        drugs: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Forward propagation.
 
         Args:

--- a/pyhealth/models/molerec.py
+++ b/pyhealth/models/molerec.py
@@ -409,7 +409,7 @@ class MoleRecLayer(torch.nn.Module):
         substructure_mask: torch.Tensor,
         substructure_graph: Union[StaticParaDict, Dict[str, Union[int, torch.Tensor]]],
         molecule_graph: Union[StaticParaDict, Dict[str, Union[int, torch.Tensor]]],
-        mask: Optional[torch.tensor] = None,
+        mask: Optional[torch.Tensor] = None,
         drug_indexes: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Forward propagation.

--- a/pyhealth/models/retain.py
+++ b/pyhealth/models/retain.py
@@ -78,9 +78,9 @@ class RETAINLayer(nn.Module):
 
     def forward(
         self,
-        x: torch.tensor,
-        mask: Optional[torch.tensor] = None,
-    ) -> Tuple[torch.tensor, torch.tensor]:
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Forward propagation.
 
         Args:

--- a/pyhealth/models/safedrug.py
+++ b/pyhealth/models/safedrug.py
@@ -50,7 +50,7 @@ class MaskLinear(nn.Module):
         if self.bias is not None:
             self.bias.data.uniform_(-stdv, stdv)
 
-    def forward(self, input: torch.tensor, mask: torch.tensor) -> torch.tensor:
+    def forward(self, input: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
         """
         Args:
             input: input feature tensor of shape [batch size, ..., input_size].
@@ -139,8 +139,8 @@ class SafeDrugLayer(nn.Module):
         ddi_adj: an adjacency tensor of shape [num_drugs, num_drugs].
         num_fingerprints: total number of different fingerprints.
         molecule_set: a list of molecule tuples (A, B, C) of length num_molecules.
-            - A <torch.tensor>: fingerprints of atoms in the molecule
-            - B <torch.tensor>: adjacency matrix of the molecule
+            - A <torch.Tensor>: fingerprints of atoms in the molecule
+            - B <torch.Tensor>: adjacency matrix of the molecule
             - C <int>: molecular_size
         average_projection: a tensor of shape [num_drugs, num_molecules] representing
             the average projection for aggregating multiple molecules of the
@@ -257,10 +257,10 @@ class SafeDrugLayer(nn.Module):
 
     def forward(
         self,
-        patient_emb: torch.tensor,
-        drugs: torch.tensor,
-        mask: Optional[torch.tensor] = None,
-    ) -> Tuple[torch.tensor, torch.tensor]:
+        patient_emb: torch.Tensor,
+        drugs: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Forward propagation.
 
         Args:
@@ -433,7 +433,7 @@ class SafeDrug(BaseModel):
         ddi_adj = self.generate_ddi_adj()
         np.save(os.path.join(CACHE_PATH, "ddi_adj.npy"), ddi_adj.numpy())
 
-    def generate_ddi_adj(self) -> torch.tensor:
+    def generate_ddi_adj(self) -> torch.Tensor:
         """Generates the DDI graph adjacency matrix."""
         atc = ATC()
         ddi = atc.get_ddi(gamenet_ddi=True)
@@ -472,7 +472,7 @@ class SafeDrug(BaseModel):
                 all_smiles_list[index] += smiles_list
         return all_smiles_list
 
-    def generate_mask_H(self) -> torch.tensor:
+    def generate_mask_H(self) -> torch.Tensor:
         """Generates the molecular segmentation mask H."""
         all_substructures_list = [[] for _ in range(self.label_size)]
         for index, smiles_list in enumerate(self.all_smiles_list):

--- a/pyhealth/models/utils.py
+++ b/pyhealth/models/utils.py
@@ -3,7 +3,7 @@ from typing import List
 import torch
 
 
-def batch_to_multihot(label: List[List[int]], num_labels: int) -> torch.tensor:
+def batch_to_multihot(label: List[List[int]], num_labels: int) -> torch.Tensor:
     """Converts label to multihot format.
 
     Args:

--- a/pyhealth/trainer.py
+++ b/pyhealth/trainer.py
@@ -347,7 +347,7 @@ class Trainer:
         return
 
     def load_ckpt(self, ckpt_path: str) -> None:
-        """Saves the model checkpoint."""
+        """Loads the model checkpoint."""
         state_dict = torch.load(ckpt_path, map_location=self.device, weights_only=True)
         self.model.load_state_dict(state_dict)
         return


### PR DESCRIPTION
## Summary

- **Fix `torch.tensor` → `torch.Tensor` in type annotations** across 8 model files (`safedrug`, `gamenet`, `micron`, `adacare`, `retain`, `grasp`, `molerec`, `models/utils`). `torch.tensor` is a constructor function, not a type class — using it as an annotation confuses type checkers and is semantically incorrect. All `torch.tensor(...)` function calls are left untouched.

- **Fix copy-paste docstring errors:**
  - `Trainer.load_ckpt`: docstring said "Saves the model checkpoint" — corrected to "Loads"
  - `MIMIC3Dataset.__init__`: docstring said "Initializes the MIMIC4Dataset" — corrected to "MIMIC3Dataset"

- **Replace bare `except:` with `except Exception:`** in `base_dataset.py` (2 occurrences in multiprocessing progress-tracking loops). Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, which prevents users from interrupting long-running dataset processing with Ctrl+C.

## Files changed (11)

| File | Change |
|------|--------|
| `pyhealth/trainer.py` | Docstring fix |
| `pyhealth/datasets/mimic3.py` | Docstring fix |
| `pyhealth/datasets/base_dataset.py` | `except:` → `except Exception:` (×2) |
| `pyhealth/models/safedrug.py` | `torch.tensor` → `torch.Tensor` in annotations |
| `pyhealth/models/gamenet.py` | `torch.tensor` → `torch.Tensor` in annotations |
| `pyhealth/models/micron.py` | `torch.tensor` → `torch.Tensor` in annotations + docstrings |
| `pyhealth/models/adacare.py` | `torch.tensor` → `torch.Tensor` in annotations |
| `pyhealth/models/retain.py` | `torch.tensor` → `torch.Tensor` in annotations |
| `pyhealth/models/grasp.py` | `torch.tensor` → `torch.Tensor` in annotations |
| `pyhealth/models/molerec.py` | `torch.tensor` → `torch.Tensor` in annotations |
| `pyhealth/models/utils.py` | `torch.tensor` → `torch.Tensor` in annotations |

## Test plan

- [ ] These are annotation-only and docstring-only changes — no runtime behavior is affected
- [ ] Verified `torch.tensor(...)` constructor calls are untouched in mixed files (`micron.py`, `grasp.py`)
- [ ] Existing tests should pass without modification