### PR TITLE
fix: resolve eval mode from output processors, fix weighted loss aggregation

### DIFF
--- a/pyhealth/datasets/base_dataset.py
+++ b/pyhealth/datasets/base_dataset.py
@@ -961,9 +961,10 @@ class BaseDataset(ABC):
             f"Setting task {task.task_name} for {self.dataset_name} base dataset..."
         )
 
+        task_init_args = vars(task)
         task_params = json.dumps(
             {
-                **vars(task),
+                **task_init_args,
                 "input_schema": task.input_schema,
                 "output_schema": task.output_schema,
             },
@@ -971,11 +972,13 @@ class BaseDataset(ABC):
             default=str,
         )
 
-        cache_dir = (
-            self.cache_dir
-            / "tasks"
-            / f"{task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params)}"
+        task_hash = str(uuid.uuid5(uuid.NAMESPACE_DNS, task_params))
+        logger.info(
+            f"Task cache hash ({task_hash}) computed from init args: "
+            f"{task_init_args}"
         )
+
+        cache_dir = self.cache_dir / "tasks" / f"{task.task_name}_{task_hash}"
         cache_dir.mkdir(parents=True, exist_ok=True)
 
         proc_params = json.dumps(

--- a/pyhealth/trainer.py
+++ b/pyhealth/trainer.py
@@ -64,6 +64,12 @@ class Trainer:
         enable_logging: Whether to enable logging. Default is True.
         output_path: Path to save the output. Default is "./output".
         exp_name: Name of the experiment. Default is current datetime.
+
+    Note:
+        The evaluation mode (binary, multiclass, multilabel, regression) is
+        resolved from the model's dataset output processors when available,
+        falling back to the legacy ``model.mode`` attribute for backward
+        compatibility.
     """
 
     def __init__(
@@ -109,6 +115,35 @@ class Trainer:
 
         logger.info("")
         return
+
+    def _resolve_mode(self) -> Optional[str]:
+        """Resolve evaluation mode from the model's output processors.
+
+        Attempts to infer the mode (binary, multiclass, multilabel, regression)
+        from the model's dataset output schema via the processor registry,
+        falling back to the legacy ``model.mode`` attribute for backward
+        compatibility with non-BaseModel models.
+
+        Returns:
+            The resolved mode string, or None if no mode can be determined.
+        """
+        if (
+            hasattr(self.model, '_resolve_mode')
+            and hasattr(self.model, 'dataset')
+            and self.model.dataset is not None
+            and hasattr(self.model, 'label_keys')
+            and len(self.model.label_keys) == 1
+        ):
+            label_key = self.model.label_keys[0]
+            try:
+                mode = self.model._resolve_mode(
+                    self.model.dataset.output_schema[label_key]
+                )
+                if mode in ("binary", "multiclass", "multilabel", "regression"):
+                    return mode
+            except (KeyError, ValueError):
+                pass
+        return getattr(self.model, 'mode', None)
 
     def train(
         self,
@@ -301,7 +336,12 @@ class Trainer:
                         additional_outputs[key].append(output[key].cpu().numpy())
             if return_patient_ids:
                 patient_ids.extend(data["patient_id"])
-        loss_mean = sum(loss_all) / len(loss_all)
+        # Weighted average: account for potentially uneven last batch
+        batch_sizes = [arr.shape[0] for arr in y_true_all]
+        total_samples = sum(batch_sizes)
+        loss_mean = (
+            sum(l * n for l, n in zip(loss_all, batch_sizes)) / total_samples
+        )
         y_true_all = np.concatenate(y_true_all, axis=0)
         y_prob_all = np.concatenate(y_prob_all, axis=0)
         outputs = [y_true_all, y_prob_all, loss_mean]
@@ -322,16 +362,16 @@ class Trainer:
         Returns:
             scores: a dictionary of scores.
         """
-        if self.model.mode is not None:
+        mode = self._resolve_mode()
+        if mode is not None:
             y_true_all, y_prob_all, loss_mean = self.inference(dataloader)
-            mode = self.model.mode
             metrics_fn = get_metrics_fn(mode)
             scores = metrics_fn(y_true_all, y_prob_all, metrics=self.metrics)
             scores["loss"] = loss_mean
         else:
+            self.model.eval()
             loss_all = []
             for data in tqdm(dataloader, desc="Evaluation"):
-                self.model.eval()
                 with torch.no_grad():
                     output = self.model(**data)
                     loss = output["loss"]


### PR DESCRIPTION
## Summary

- **#914**: Replace direct `self.model.mode` access in `Trainer.evaluate()` with a new `_resolve_mode()` method that infers mode (binary/multiclass/multilabel/regression) from the model's dataset output schema via the processor registry. Falls back to the legacy `model.mode` attribute for backward compatibility with non-`BaseModel` models.
- **#859**: Fix loss aggregation in `Trainer.inference()` to use a weighted average by batch size, so the potentially smaller last batch does not disproportionately influence the reported loss. When all batches are equal size, results are identical to the previous behavior.
- **#916**: Add logging in `BaseDataset.set_task()` to notify users which task init args are included in the cache hash, improving cache transparency.

## Changes

| File | Change | Issue |
|------|--------|-------|
| `trainer.py` | Add `_resolve_mode()` — resolves mode from `model.dataset.output_schema` via processor registry | #914 |
| `trainer.py` | `evaluate()` uses `_resolve_mode()` instead of `self.model.mode` | #914 |
| `trainer.py` | `inference()` loss weighted by batch size: `Σ(loss_i × n_i) / Σ(n_i)` | #859 |
| `trainer.py` | Move `model.eval()` before the loop in fallback branch | #859 |
| `base_dataset.py` | Log task cache hash and init args in `set_task()` | #916 |

## Design decisions

1. **Backward compatible**: `_resolve_mode()` checks for `_resolve_mode`, `dataset`, and `label_keys` via `hasattr` — vanilla `nn.Module` models that set `self.mode` directly (e.g., the MNIST example in `trainer.py`) continue to work unchanged.
2. **Minimal scope**: `BaseModel.mode` attribute is left untouched; only the Trainer no longer depends on it. This avoids breaking downstream code that reads `model.mode`.
3. **Weighted loss is a no-op for equal batches**: When `drop_last=True` or the dataset divides evenly, the weighted and unweighted averages are identical.

## Test plan

- [ ] Verify `_resolve_mode()` returns correct mode for BaseModel with string schema ("binary", "multiclass", etc.)
- [ ] Verify `_resolve_mode()` falls back to `model.mode` for non-BaseModel models
- [ ] Verify `_resolve_mode()` returns None when no mode is available
- [ ] Verify weighted loss equals unweighted loss when all batches have equal size
- [ ] Verify weighted loss gives correct result when last batch is smaller
- [ ] Run existing tests: `test_legacy_mode_resolution.py`, `test_early_stopping.py`

Closes #914. Addresses #859 and #916.