### PR TITLE
Improve task cache keys and document cache/split conventions

### DIFF
--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -132,6 +132,92 @@ Initialization Parameters
   seconds rather than minutes. Switch to ``dev=False`` for your final training
   run.
 
+Cache Directory Behavior
+-------------------------
+
+PyHealth derives the dataset cache UUID from the combination of:
+
+- ``root``
+- ``tables`` (sorted before hashing)
+- ``dataset_name``
+- ``dev``
+
+This applies even when you pass ``cache_dir`` explicitly. In that case,
+PyHealth treats your ``cache_dir`` as the parent folder and still appends a
+configuration-specific UUID, so multiple dataset variants do not overwrite
+each other.
+
+Task caches live inside ``<cache_dir>/<dataset_uuid>/tasks/``. Their cache
+key includes the task name, task class/module, task instance attributes
+(``vars(task)``), plus the task input/output schemas. The final processed
+sample cache additionally includes the input/output processor configuration.
+If you change task code without changing those cache inputs, clear the stale
+task cache before re-running.
+
+Source and Compatibility Matrix
+--------------------------------
+
+The most common built-in datasets expect the following roots and files. For
+custom datasets, the authoritative source of truth is your own
+``config.yaml``: PyHealth will only look for the files referenced by
+``file_path`` there.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 24 56
+
+   * - Dataset class
+     - Expected root
+     - Minimum compatible files / notes
+   * - ``MIMIC3Dataset``
+     - PhysioNet MIMIC-III v1.4 root
+     - Always requires ``PATIENTS.csv.gz``, ``ADMISSIONS.csv.gz``, and
+       ``ICUSTAYS.csv.gz``. Optional tables map directly to
+       ``DIAGNOSES_ICD.csv.gz``, ``PROCEDURES_ICD.csv.gz``,
+       ``PRESCRIPTIONS.csv.gz``, ``LABEVENTS.csv.gz`` plus
+       ``D_LABITEMS.csv.gz``, and ``NOTEEVENTS.csv.gz``.
+   * - ``MIMIC4EHRDataset``
+     - MIMIC-IV v2.2 EHR root
+     - Requires the ``hosp/`` and ``icu/`` subdirectories. Core files are
+       ``hosp/patients.csv.gz``, ``hosp/admissions.csv.gz``, and
+       ``icu/icustays.csv.gz``. Optional tables include
+       ``hosp/diagnoses_icd.csv.gz``, ``hosp/procedures_icd.csv.gz``,
+       ``hosp/prescriptions.csv.gz``, ``hosp/labevents.csv.gz`` plus
+       ``hosp/d_labitems.csv.gz``, and ``hosp/hcpcsevents.csv.gz``.
+   * - ``MIMIC4NoteDataset``
+     - MIMIC-IV-Note v2.2 root
+     - Requires the ``note/`` subdirectory. Supported tables are
+       ``note/discharge.csv.gz``, ``note/discharge_detail.csv.gz``,
+       ``note/radiology.csv.gz``, and ``note/radiology_detail.csv.gz``.
+       Use this with a notes root, not the EHR root.
+   * - ``MIMIC4CXRDataset``
+     - MIMIC-CXR-JPG root
+     - Requires ``mimic-cxr-2.0.0-metadata.csv.gz`` and the JPEG ``files/``
+       tree so PyHealth can build ``image_path`` entries. Optional labels and
+       splits come from ``mimic-cxr-2.0.0-chexpert.csv.gz``,
+       ``mimic-cxr-2.0.0-negbio.csv.gz``,
+       ``mimic-cxr-2.1.0-test-set-labeled.csv``, and
+       ``mimic-cxr-2.0.0-split.csv.gz``. PyHealth generates
+       ``mimic-cxr-2.0.0-metadata-pyhealth.csv`` on first load. DICOM-only
+       MIMIC-CXR exports are not sufficient for this loader.
+   * - ``MIMIC4Dataset``
+     - Combined MIMIC-IV roots
+     - Pass any combination of ``ehr_root``, ``note_root``, and ``cxr_root``.
+       Each supplied root must satisfy the compatibility requirements of the
+       corresponding child dataset above.
+   * - ``eICUDataset``
+     - eICU-CRD v2.0 root
+     - Requires ``patient.csv``. Additional supported files are
+       ``hospital.csv``, ``diagnosis.csv``, ``medication.csv``,
+       ``treatment.csv``, ``lab.csv``, ``physicalExam.csv``, and
+       ``admissionDx.csv``.
+   * - ``OMOPDataset``
+     - OMOP CDM v5.3 export root
+     - Requires ``person.csv``, ``visit_occurrence.csv``, and ``death.csv``.
+       Additional supported files are ``condition_occurrence.csv``,
+       ``procedure_occurrence.csv``, ``drug_exposure.csv``, and
+       ``measurement.csv``.
+
 config.yaml for Custom Datasets
 ---------------------------------
 

--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -184,6 +184,26 @@ PyHealth detects the existing cache and skips reprocessing. During
 development it is useful to set ``dev=True`` on the dataset, which limits
 processing to 1 000 patients so iterations are fast.
 
+Task caches are keyed by:
+
+- ``task.task_name``
+- the task class and module
+- the task instance attributes returned by ``vars(task)`` (which usually
+  correspond to constructor arguments stored on ``self``)
+- ``input_schema`` and ``output_schema``
+
+The final processed sample cache is additionally keyed by any explicitly
+provided input/output processor configurations. If a constructor argument
+should change caching behaviour, make sure your task stores it on ``self``.
+If you change task logic without changing its stored state, clear the old
+task cache before re-running.
+
+For benchmark datasets with an official split, keep the split definition
+close to the dataset/task code that creates the samples and carry the split
+through as a ``sample["split"]`` field. Reserve
+``pyhealth.datasets.splitter`` for reusable split helpers that operate on
+generic sample metadata rather than dataset-specific file layout.
+
 .. note::
 
    **A note on multiprocessing.** ``set_task()`` can spawn worker processes

--- a/docs/how_to_contribute.rst
+++ b/docs/how_to_contribute.rst
@@ -421,6 +421,26 @@ Task tests should verify:
 
 Use synthetic ``Patient`` objects or minimal datasets (2-5 patients) to test task logic quickly.
 
+**Where Predefined Splits Should Live:**
+
+- Put generic reusable split helpers in ``pyhealth/datasets/splitter.py``.
+- Put dataset-owned official splits next to the dataset loader when the split
+  comes from raw files or shared dataset metadata.
+- Put task-owned official splits next to the task when the split label is
+  attached during sample construction.
+- Do not move dataset-specific file layout logic into ``splitter.py`` unless
+  the helper only consumes a standard sample field such as ``sample["split"]``.
+
+For example, TUH EEG metadata preparation belongs with the dataset/task code,
+while reusable helpers that consume the emitted ``split`` field can live in
+``splitter.py``.
+
+When contributing a dataset or task with official splits:
+
+- document the source of the split (benchmark release, metadata CSV, etc.)
+- preserve the original split labels on the produced samples whenever possible
+- add a synthetic test that verifies the split field or split helper behaviour
+
 Contributing a New Model: File Checklist
 -----------------------------------------
 

--- a/pyhealth/datasets/base_dataset.py
+++ b/pyhealth/datasets/base_dataset.py
@@ -419,6 +419,19 @@ class BaseDataset(ABC):
         tmp_dir.mkdir(parents=True, exist_ok=True)
         return tmp_dir
 
+    @staticmethod
+    def _task_cache_signature(task: BaseTask) -> Dict[str, Any]:
+        """Return the stable task signature used for task cache keys."""
+        return {
+            "task_name": task.task_name,
+            "task_class": task.__class__.__name__,
+            "task_module": task.__class__.__module__,
+            # Task instance attributes usually mirror constructor arguments.
+            "task_state": vars(task),
+            "input_schema": task.input_schema,
+            "output_schema": task.output_schema,
+        }
+
     def clean_tmpdir(self) -> None:
         """Cleans up the temporary directory within the cache."""
         tmp_dir = self.cache_dir / "tmp"
@@ -961,15 +974,19 @@ class BaseDataset(ABC):
             f"Setting task {task.task_name} for {self.dataset_name} base dataset..."
         )
 
-        task_params = json.dumps(
-            {
-                **vars(task),
-                "input_schema": task.input_schema,
-                "output_schema": task.output_schema,
-            },
-            sort_keys=True,
-            default=str,
+        task_signature = self._task_cache_signature(task)
+        logger.info(
+            "Task cache key for %s is derived from task_name=%s, task_class=%s, "
+            "task_module=%s, task_state=%s, input_schema=%s, output_schema=%s",
+            task.task_name,
+            task_signature["task_name"],
+            task_signature["task_class"],
+            task_signature["task_module"],
+            task_signature["task_state"],
+            task_signature["input_schema"],
+            task_signature["output_schema"],
         )
+        task_params = json.dumps(task_signature, sort_keys=True, default=str)
 
         cache_dir = (
             self.cache_dir

--- a/tests/core/test_caching.py
+++ b/tests/core/test_caching.py
@@ -66,6 +66,11 @@ class MockTask2(BaseTask):
         return samples
 
 
+class MockTaskAlias(MockTask):
+    """Task with the same task_name/state/schema as MockTask but a different class."""
+    pass
+
+
 class MockDataset(BaseDataset):
     """Mock dataset for testing purposes."""
 
@@ -110,6 +115,14 @@ class TestCachingFunctionality(BaseTestCase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
+    def _task_cache_dir(self, task):
+        task_params = json.dumps(
+            self.dataset._task_cache_signature(task),
+            sort_keys=True,
+            default=str,
+        )
+        return self.dataset.cache_dir / "tasks" / f"{task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params)}"
+
     def test_set_task_signature(self):
         """Test that set_task has the correct method signature."""
         import inspect
@@ -141,12 +154,7 @@ class TestCachingFunctionality(BaseTestCase):
             self.assertEqual(len(sample_dataset), 4)
 
             # Ensure intermediate cache files are created in default location
-            task_params = json.dumps(
-                {"input_schema": {"test_attribute": "raw"}, "output_schema": {"test_label": "binary"}, "param": 0},
-                sort_keys=True,
-                default=str
-            )
-            task_cache_dir = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params)}"
+            task_cache_dir = self._task_cache_dir(self.task)
             self.assertTrue((task_cache_dir / "task_df.ld" / "index.json").exists())
 
             # Cache artifacts should be present for StreamingDataset
@@ -177,13 +185,7 @@ class TestCachingFunctionality(BaseTestCase):
 
     def test_default_cache_dir_is_used(self):
         """When cache_dir is omitted, default cache dir should be used."""
-        task_params = json.dumps(
-            {"input_schema": {"test_attribute": "raw"}, "output_schema": {"test_label": "binary"}, "param": 0},
-            sort_keys=True,
-            default=str
-        )
-
-        task_cache = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params)}"
+        task_cache = self._task_cache_dir(self.task)
         sample_dataset = self.dataset.set_task(self.task)
 
         self.assertTrue(task_cache.exists())
@@ -208,25 +210,15 @@ class TestCachingFunctionality(BaseTestCase):
         cached_dataset.close()
 
     def test_tasks_with_diff_param_values_get_diff_caches(self):
-        sample_dataset1 = self.dataset.set_task(MockTask(param=1))
-        sample_dataset2 = self.dataset.set_task(MockTask(param=2))
+        task1 = MockTask(param=1)
+        task2 = MockTask(param=2)
+        sample_dataset1 = self.dataset.set_task(task1)
+        sample_dataset2 = self.dataset.set_task(task2)
 
         self.assertNotEqual(sample_dataset1.path, sample_dataset2.path)
 
-        task_params1 = json.dumps(
-            {"input_schema": {"test_attribute": "raw"}, "output_schema": {"test_label": "binary"}, "param": 1},
-            sort_keys=True,
-            default=str
-        )
-
-        task_params2 = json.dumps(
-            {"input_schema": {"test_attribute": "raw"}, "output_schema": {"test_label": "binary"}, "param": 2},
-            sort_keys=True,
-            default=str
-        )
-
-        task_cache1 = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params1)}"
-        task_cache2 = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params2)}"
+        task_cache1 = self._task_cache_dir(task1)
+        task_cache2 = self._task_cache_dir(task2)
 
         self.assertTrue(task_cache1.exists())
         self.assertTrue(task_cache2.exists())
@@ -240,25 +232,15 @@ class TestCachingFunctionality(BaseTestCase):
         sample_dataset2.close()
 
     def test_tasks_with_diff_output_schemas_get_diff_caches(self):
-        sample_dataset1 = self.dataset.set_task(MockTask())
-        sample_dataset2 = self.dataset.set_task(MockTask2())
+        task1 = MockTask()
+        task2 = MockTask2()
+        sample_dataset1 = self.dataset.set_task(task1)
+        sample_dataset2 = self.dataset.set_task(task2)
 
         self.assertNotEqual(sample_dataset1.path, sample_dataset2.path)
 
-        task_params1 = json.dumps(
-            {"input_schema": {"test_attribute": "raw"}, "output_schema": {"test_label": "binary"}, "param": 0},
-            sort_keys=True,
-            default=str
-        )
-
-        task_params2 = json.dumps(
-            {"input_schema": {"test_attribute": "raw"}, "output_schema": {"test_label": "multiclass"}, "param": 0},
-            sort_keys=True,
-            default=str
-        )
-
-        task_cache1 = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params1)}"
-        task_cache2 = self.dataset.cache_dir / "tasks" / f"{self.task.task_name}_{uuid.uuid5(uuid.NAMESPACE_DNS, task_params2)}"
+        task_cache1 = self._task_cache_dir(task1)
+        task_cache2 = self._task_cache_dir(task2)
 
         self.assertTrue(task_cache1.exists())
         self.assertTrue(task_cache2.exists())
@@ -267,6 +249,20 @@ class TestCachingFunctionality(BaseTestCase):
         self.assertTrue((self.dataset.cache_dir / "global_event_df.parquet").exists())
         self.assertEqual(len(sample_dataset1), 4)
         self.assertEqual(len(sample_dataset2), 4)
+
+        sample_dataset1.close()
+        sample_dataset2.close()
+
+    def test_tasks_with_same_name_and_state_but_diff_classes_get_diff_caches(self):
+        task1 = MockTask()
+        task2 = MockTaskAlias()
+
+        sample_dataset1 = self.dataset.set_task(task1)
+        sample_dataset2 = self.dataset.set_task(task2)
+
+        self.assertNotEqual(sample_dataset1.path, sample_dataset2.path)
+        self.assertTrue(self._task_cache_dir(task1).exists())
+        self.assertTrue(self._task_cache_dir(task2).exists())
 
         sample_dataset1.close()
         sample_dataset2.close()


### PR DESCRIPTION
## Summary
- include the task class, module, and stored task state in the task cache signature so tasks with the same name and schema but different implementations do not share a cache
- add a regression test covering same-name, same-schema tasks that come from different task classes
- document dataset cache derivation, task cache inputs, predefined split placement, and built-in dataset source/file compatibility expectations for the core datasets covered here

## Notes
- the task cache logging now makes the cache inputs explicit when set_task() runs
- the docs clarify that an explicit cache_dir is treated as a parent directory and still receives a configuration-derived UUID suffix
- the split guidance distinguishes generic helpers in pyhealth.datasets.splitter from dataset- or task-specific official split logic

## Validation
- git diff --check
- python -m py_compile pyhealth/datasets/base_dataset.py tests/core/test_caching.py
- python -m unittest tests.core.test_caching -v (blocked locally by a pre-existing NumPy 2.x vs compiled dependency mismatch in the machine environment)