### PR TITLE
Add download source and required files documentation to datasets

### DIFF
--- a/pyhealth/datasets/cardiology.py
+++ b/pyhealth/datasets/cardiology.py
@@ -10,7 +10,20 @@ from pyhealth.datasets import BaseSignalDataset
 
 class CardiologyDataset(BaseSignalDataset):
     """Base ECG dataset for Cardiology
+    
+    Download: https://physionet.org/content/challenge-2020/1.0.2/
+    Access: Requires PhysioNet account.
 
+    Required files:
+        - cpsc_2018/ (directory)
+        - cpsc_2018_extra/ (directory)
+        - georgia/ (directory)
+        - ptb/ (directory)
+        - ptb-xl/ (directory)
+        - st_petersburg_incart/ (directory)
+
+    Compatible formats: .mat, .hea
+    Note: All dataset directories must be placed in the root directory.
     Dataset is available at https://physionet.org/content/challenge-2020/1.0.2/
 
     Args:

--- a/pyhealth/datasets/ehrshot.py
+++ b/pyhealth/datasets/ehrshot.py
@@ -10,7 +10,14 @@ logger = logging.getLogger(__name__)
 class EHRShotDataset(BaseDataset):
     """
     A dataset class for handling EHRShot data.
+    Download: https://huggingface.co/datasets/StanfordShahLab/ehrshot
+    Access: Requires HuggingFace account and dataset agreement.
 
+    Required files:
+        - ehrshot.csv
+
+    Compatible formats: .csv
+    Note: All files must be placed in the root directory.
     This class is responsible for loading and managing the EHRShot dataset.
 
     Website: https://som-shahlab.github.io/ehrshot-website/

--- a/pyhealth/datasets/eicu.py
+++ b/pyhealth/datasets/eicu.py
@@ -8,7 +8,23 @@ logger = logging.getLogger(__name__)
 
 
 class eICUDataset(BaseDataset):
-    """
+     """
+    Download: https://eicu-crd.mit.edu/
+    Access: Requires PhysioNet credentialed access and DUA agreement.
+    
+    Required files:
+        - patient.csv
+        - hospital.csv
+        - diagnosis.csv
+        - treatment.csv
+        - medication.csv
+        - lab.csv
+        - physicalExam.csv
+        - admissionDx.csv
+    
+    Compatible formats: .csv
+    Note: All files must be placed in the root directory.
+   
     A dataset class for handling eICU data.
 
     The eICU dataset is a large dataset of de-identified health records of ICU

--- a/pyhealth/datasets/mimic3.py
+++ b/pyhealth/datasets/mimic3.py
@@ -13,7 +13,20 @@ logger = logging.getLogger(__name__)
 class MIMIC3Dataset(BaseDataset):
     """
     A dataset class for handling MIMIC-III data.
+    Download: https://physionet.org/content/mimiciii/1.4/
+    Access: Requires PhysioNet credentialed access and DUA agreement.
 
+    Required files:
+        - ADMISSIONS.csv
+        - PATIENTS.csv
+        - DIAGNOSES_ICD.csv
+        - PROCEDURES_ICD.csv
+        - PRESCRIPTIONS.csv
+        - LABEVENTS.csv
+        - ICUSTAYS.csv
+
+    Compatible formats: .csv
+    Note: All files must be placed in the root directory.
     This class is responsible for loading and managing the MIMIC-III dataset,
     which includes tables such as patients, admissions, and icustays.
 

--- a/pyhealth/datasets/mimic4.py
+++ b/pyhealth/datasets/mimic4.py
@@ -31,6 +31,20 @@ def log_memory_usage(tag=""):
 class MIMIC4EHRDataset(BaseDataset):
     """
     MIMIC-IV EHR dataset.
+    Download: https://physionet.org/content/mimiciv/2.2/
+    Access: Requires PhysioNet credentialed access and DUA agreement.
+
+    Required files:
+        - admissions.csv
+        - patients.csv
+        - diagnoses_icd.csv
+        - procedures_icd.csv
+        - prescriptions.csv
+        - labevents.csv
+        - icustays.csv
+
+    Compatible formats: .csv
+    Note: All files must be placed in the root directory.
 
     This class is responsible for loading and managing the MIMIC-IV EHR dataset,
     which includes tables such as patients, admissions, and icustays.


### PR DESCRIPTION
Hi! I'm a new contributor and wanted to help with issue #883.

I added download links and required file lists to the docstrings of these datasets:
- eICUDataset
- MIMIC3Dataset
- MIMIC4EHRDataset
- EHRShotDataset
- CardiologyDataset

This way users don't have to guess where to find the data or which files they need. Let me know if anything needs to be changed!

Closes #883