### PR TITLE
fix: remove deprecated code_mapping, dev, refresh_cache from examples and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,8 +189,6 @@ Module 1: <pyhealth.datasets>
         root="https://storage.googleapis.com/pyhealth/Synthetic_MIMIC-III/",
         # raw CSV table name
         tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-        # map all NDC codes to CCS codes in these tables
-        code_mapping={"NDC": "CCSCM"},
     )
 
 .. image:: figure/structured-dataset.png

--- a/examples/drug_recommendation/drug_recommendation_mimic4_gamenet.py
+++ b/examples/drug_recommendation/drug_recommendation_mimic4_gamenet.py
@@ -25,9 +25,6 @@ def prepare_drug_task_data():
     mimicvi = MIMIC4Dataset(
         root="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
         tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
-        code_mapping={"NDC": ("ATC", {"target_kwargs": {"level": 3}})},
-        dev=_DEV,
-        refresh_cache=False,
     )
 
     print("stat")

--- a/examples/mortality_prediction/mortality_mimic3_grasp.py
+++ b/examples/mortality_prediction/mortality_mimic3_grasp.py
@@ -9,9 +9,6 @@ if __name__ == "__main__":
     base_dataset = MIMIC3Dataset(
         root="/srv/local/data/physionet.org/files/mimiciii/1.4",
         tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-        code_mapping={"ICD9CM": "CCSCM", "ICD9PROC": "CCSPROC", "NDC": "ATC"},
-        dev=False,
-        refresh_cache=False,
     )
     base_dataset.stat()
 

--- a/examples/patient_linkage_mimic3_medlink.py
+++ b/examples/patient_linkage_mimic3_medlink.py
@@ -29,9 +29,6 @@ USE_BM25_HARDNEGS = False
 base_dataset = MIMIC3Dataset(
     root="/srv/local/data/physionet.org/files/mimiciii/1.4",
     tables=["DIAGNOSES_ICD"],
-    code_mapping={"ICD9CM": ("CCSCM", {})},
-    dev=False,
-    refresh_cache=False,
 )
 base_dataset.stat()
 

--- a/leaderboard/utils.py
+++ b/leaderboard/utils.py
@@ -64,9 +64,6 @@ def get_dataset(dataset_name):
         mimic3dataset = MIMIC3Dataset(
             root="/srv/local/data/physionet.org/files/mimiciii/1.4",
             tables=["DIAGNOSES_ICD", "PROCEDURES_ICD", "PRESCRIPTIONS"],
-            dev=False,
-            code_mapping={"NDC": "ATC"},
-            refresh_cache=False,
         )
         dataset = mimic3dataset
 
@@ -83,9 +80,6 @@ def get_dataset(dataset_name):
         mimic4dataset = MIMIC4Dataset(
             root="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
             tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
-            dev=False,
-            code_mapping={"NDC": "ATC"},
-            refresh_cache=False,
         )
         dataset = mimic4dataset
 


### PR DESCRIPTION
## Summary

Remove references to deprecated `code_mapping`, `dev`, and `refresh_cache` parameters from example scripts and README. These parameters belonged to the legacy `BaseEHRDataset` API and are no longer accepted by the v2.0 `MIMIC3Dataset`/`MIMIC4Dataset` (based on `BaseDataset`).

### Files updated

| File | Change |
|------|--------|
| `README.rst` | Remove `code_mapping={"NDC": "CCSCM"}` from quickstart example |
| `examples/mortality_prediction/mortality_mimic3_grasp.py` | Remove `code_mapping`, `dev`, `refresh_cache` |
| `examples/drug_recommendation/drug_recommendation_mimic4_gamenet.py` | Remove `code_mapping`, `dev`, `refresh_cache` |
| `examples/patient_linkage_mimic3_medlink.py` | Remove `code_mapping`, `dev`, `refresh_cache` |
| `leaderboard/utils.py` | Remove `code_mapping`, `dev`, `refresh_cache` from MIMIC3/MIMIC4 loaders |

### Out of scope (for follow-up PRs)

- Task file docstrings (`pyhealth/tasks/*.py`) — these contain `code_mapping` in `>>>` doctest examples that also need updating
- `pyhealth/datasets/mimicextract.py` — still uses the legacy API (not yet migrated to v2.0)
- `chat-assistant/corpus/` — auto-generated text corpus, will update when source docs are fixed

Fixes #535