### PR TITLE
Add PTB-XL dataset and MI classification task

### DIFF
--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -245,3 +245,4 @@ Available Datasets
     datasets/pyhealth.datasets.TCGAPRADDataset
     datasets/pyhealth.datasets.splitter
     datasets/pyhealth.datasets.utils
+    pyhealth.datasets.ptbxl

--- a/docs/api/datasets/pyhealth.datasets.ptbxl.rst
+++ b/docs/api/datasets/pyhealth.datasets.ptbxl.rst
@@ -1,0 +1,7 @@
+pyhealth.datasets.ptbxl
+=======================
+
+.. autoclass:: pyhealth.datasets.PTBXLDataset
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -229,3 +229,4 @@ Available Tasks
     Mutation Pathogenicity (COSMIC) <tasks/pyhealth.tasks.MutationPathogenicityPrediction>
     Cancer Survival Prediction (TCGA) <tasks/pyhealth.tasks.CancerSurvivalPrediction>
     Cancer Mutation Burden (TCGA) <tasks/pyhealth.tasks.CancerMutationBurden>
+    PTB-XL MI Classification <tasks/pyhealth.tasks.ptbxl_mi_classification>

--- a/docs/api/tasks/pyhealth.tasks.ptbxl_mi_classification.rst
+++ b/docs/api/tasks/pyhealth.tasks.ptbxl_mi_classification.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.ptbxl_mi_classification
+======================================
+
+.. autoclass:: pyhealth.tasks.PTBXLMIClassificationTask
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/ptbxl_mi_classification_cnn.py
+++ b/examples/ptbxl_mi_classification_cnn.py
@@ -1,0 +1,19 @@
+from pyhealth.datasets import PTBXLDataset
+from pyhealth.tasks import PTBXLMIClassificationTask
+
+
+def main():
+    dataset = PTBXLDataset(
+        root="/Users/zaidalkhatib/Downloads/ptb-xl-a-large-publicly-available-electrocardiography-dataset-1.0.3",
+        dev=True,
+    )
+
+    task = PTBXLMIClassificationTask()
+    task_dataset = dataset.set_task(task)
+
+    print(task_dataset[0])
+    print(f"Number of samples: {len(task_dataset)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ptbxl_mi_classification_cnn.py
+++ b/examples/ptbxl_mi_classification_cnn.py
@@ -3,12 +3,14 @@ from pyhealth.tasks import PTBXLMIClassificationTask
 
 
 def main():
+    root = "/Users/zaidalkhatib/Downloads/ptb-xl-a-large-publicly-available-electrocardiography-dataset-1.0.3"
+
     dataset = PTBXLDataset(
-        root="/Users/zaidalkhatib/Downloads/ptb-xl-a-large-publicly-available-electrocardiography-dataset-1.0.3",
+        root=root,
         dev=True,
     )
 
-    task = PTBXLMIClassificationTask()
+    task = PTBXLMIClassificationTask(root=root)
     task_dataset = dataset.set_task(task)
 
     print(task_dataset[0])

--- a/examples/ptbxl_mi_classification_cnn.py
+++ b/examples/ptbxl_mi_classification_cnn.py
@@ -8,9 +8,14 @@ def main():
     dataset = PTBXLDataset(
         root=root,
         dev=True,
+        use_high_resolution=False,  # False -> records100, True -> records500
     )
 
-    task = PTBXLMIClassificationTask(root=root)
+    task = PTBXLMIClassificationTask(
+        root=root,
+        signal_length=1000,   # 10 seconds at 100 Hz
+        normalize=True,
+    )
     task_dataset = dataset.set_task(task)
 
     print(task_dataset[0])

--- a/examples/ptbxl_mi_classification_cnn.py
+++ b/examples/ptbxl_mi_classification_cnn.py
@@ -1,10 +1,11 @@
 from pyhealth.datasets import PTBXLDataset
 from pyhealth.tasks import PTBXLMIClassificationTask
-
+import os
 
 def main():
-    root = "/Users/zaidalkhatib/Downloads/ptb-xl-a-large-publicly-available-electrocardiography-dataset-1.0.3"
-
+    root = os.path.expanduser(
+        "~/Downloads/ptb-xl-a-large-publicly-available-electrocardiography-dataset-1.0.3"
+    )
     dataset = PTBXLDataset(
         root=root,
         dev=True,

--- a/examples/ptbxl_mi_classification_cnn.py
+++ b/examples/ptbxl_mi_classification_cnn.py
@@ -5,6 +5,32 @@ import argparse
 
 
 def run_once(root: str, normalize: bool):
+    metadata_file = os.path.join(root, "ptbxl_database.csv")
+
+    if not os.path.exists(metadata_file):
+        print("=" * 60)
+        print("PTB-XL dataset not found. Running synthetic demo mode.")
+        print(f"Expected file: {metadata_file}")
+
+        import torch
+        from torch.utils.data import DataLoader, TensorDataset
+
+        X = torch.randn(10, 12, 1000)
+        y = torch.randint(0, 2, (10,)).float()
+
+        demo_dataset = TensorDataset(X, y)
+        demo_loader = DataLoader(demo_dataset, batch_size=2, shuffle=False)
+
+        first_batch = next(iter(demo_loader))
+        demo_signal, demo_label = first_batch
+
+        print(f"normalize={normalize}")
+        print(f"demo batch signal shape: {demo_signal.shape}")
+        print(f"demo batch labels: {demo_label}")
+        print(f"demo signal mean/std: {demo_signal.mean():.4f} / {demo_signal.std():.4f}")
+        print(f"Number of demo samples: {len(demo_dataset)}")
+        return
+
     dataset = PTBXLDataset(
         root=root,
         dev=True,
@@ -22,7 +48,6 @@ def run_once(root: str, normalize: bool):
     sample = task_dataset[0]
     signal = sample["signal"]
 
-    # Convert signal to numbers for printing mean/std
     try:
         signal_np = signal.detach().cpu().numpy()
     except Exception:
@@ -44,13 +69,17 @@ def main():
         type=str,
         default=os.getenv(
             "PTBXL_ROOT",
-            os.path.expanduser("~/Downloads/ptb-xl-a-large-publicly-available-electrocardiography-dataset-1.0.1"),
+            os.path.expanduser(
+                "~/Downloads/ptb-xl-a-large-publicly-available-electrocardiography-dataset-1.0.3"
+            ),
         ),
-        help="Path to PTB-XL root folder (contains ptbxl_database.csv, scp_statements.csv, records100/records500/). "
-             "You can also set PTBXL_ROOT environment variable instead of passing --root.",
+        help=(
+            "Path to PTB-XL root folder (contains ptbxl_database.csv, "
+            "scp_statements.csv, records100/records500/). "
+            "You can also set PTBXL_ROOT environment variable instead of passing --root."
+        ),
     )
 
-    # Ablation flags
     parser.add_argument(
         "--normalize",
         dest="normalize",
@@ -67,7 +96,7 @@ def main():
     parser.add_argument(
         "--ablation-normalize",
         action="store_true",
-        help="Running a tiny ablation: compare normalize=True vs normalize=False.",
+        help="Run a tiny ablation: compare normalize=True vs normalize=False.",
     )
 
     args = parser.parse_args()

--- a/examples/ptbxl_mi_classification_cnn.py
+++ b/examples/ptbxl_mi_classification_cnn.py
@@ -1,11 +1,10 @@
 from pyhealth.datasets import PTBXLDataset
 from pyhealth.tasks import PTBXLMIClassificationTask
 import os
+import argparse
 
-def main():
-    root = os.path.expanduser(
-        "~/Downloads/ptb-xl-a-large-publicly-available-electrocardiography-dataset-1.0.3"
-    )
+
+def run_once(root: str, normalize: bool):
     dataset = PTBXLDataset(
         root=root,
         dev=True,
@@ -15,12 +14,70 @@ def main():
     task = PTBXLMIClassificationTask(
         root=root,
         signal_length=1000,   # 10 seconds at 100 Hz
-        normalize=True,
+        normalize=normalize,
     )
+
     task_dataset = dataset.set_task(task)
 
-    print(task_dataset[0])
+    sample = task_dataset[0]
+    signal = sample["signal"]
+
+    # Convert signal to numbers for printing mean/std
+    try:
+        signal_np = signal.detach().cpu().numpy()
+    except Exception:
+        signal_np = signal
+
+    print("=" * 60)
+    print(f"normalize={normalize}")
+    print(f"sample label: {sample['label']}")
+    print(f"signal shape: {signal_np.shape}")
+    print(f"signal mean/std: {signal_np.mean():.4f} / {signal_np.std():.4f}")
     print(f"Number of samples: {len(task_dataset)}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--root",
+        type=str,
+        default=os.getenv(
+            "PTBXL_ROOT",
+            os.path.expanduser("~/Downloads/ptb-xl-a-large-publicly-available-electrocardiography-dataset-1.0.1"),
+        ),
+        help="Path to PTB-XL root folder (contains ptbxl_database.csv, scp_statements.csv, records100/records500/). "
+             "You can also set PTBXL_ROOT environment variable instead of passing --root.",
+    )
+
+    # Ablation flags
+    parser.add_argument(
+        "--normalize",
+        dest="normalize",
+        action="store_true",
+        default=True,
+        help="Enable per-channel z-score normalization (default: True).",
+    )
+    parser.add_argument(
+        "--no-normalize",
+        dest="normalize",
+        action="store_false",
+        help="Disable normalization.",
+    )
+    parser.add_argument(
+        "--ablation-normalize",
+        action="store_true",
+        help="Running a tiny ablation: compare normalize=True vs normalize=False.",
+    )
+
+    args = parser.parse_args()
+    root = args.root
+
+    if args.ablation_normalize:
+        run_once(root, normalize=True)
+        run_once(root, normalize=False)
+    else:
+        run_once(root, normalize=args.normalize)
 
 
 if __name__ == "__main__":

--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -90,3 +90,4 @@ from .utils import (
     save_processors,
 )
 from .collate import collate_temporal
+from .ptbxl import PTBXLDataset

--- a/pyhealth/datasets/configs/ptbxl.yaml
+++ b/pyhealth/datasets/configs/ptbxl.yaml
@@ -1,0 +1,4 @@
+dataset_name: PTBXL
+tables:
+  - ptbxl
+root: data/ptb-xl

--- a/pyhealth/datasets/ptbxl.py
+++ b/pyhealth/datasets/ptbxl.py
@@ -1,4 +1,3 @@
-import ast
 import os
 from typing import Optional
 
@@ -32,10 +31,6 @@ class PTBXLDataset(BaseDataset):
         metadata_path = os.path.join(self.root, "ptbxl_database.csv")
         df = pd.read_csv(metadata_path)
 
-        if self.dev:
-            df = df.head(10)
-
-        # Keep only the fields we need for the task
         event_df = pd.DataFrame(
             {
                 "patient_id": df["patient_id"].astype(str),

--- a/pyhealth/datasets/ptbxl.py
+++ b/pyhealth/datasets/ptbxl.py
@@ -1,0 +1,51 @@
+import ast
+import os
+from typing import Optional
+
+import dask.dataframe as dd
+import pandas as pd
+
+from pyhealth.datasets import BaseDataset
+
+
+class PTBXLDataset(BaseDataset):
+    """PTB-XL ECG dataset represented as an event table."""
+
+    def __init__(
+        self,
+        root: str,
+        dataset_name: Optional[str] = "PTBXL",
+        dev: bool = False,
+        cache_dir: Optional[str] = None,
+        num_workers: int = 1,
+    ):
+        super().__init__(
+            root=root,
+            tables=["ptbxl"],
+            dataset_name=dataset_name,
+            cache_dir=cache_dir,
+            num_workers=num_workers,
+            dev=dev,
+        )
+
+    def load_data(self) -> dd.DataFrame:
+        metadata_path = os.path.join(self.root, "ptbxl_database.csv")
+        df = pd.read_csv(metadata_path)
+
+        if self.dev:
+            df = df.head(10)
+
+        # Keep only the fields we need for the task
+        event_df = pd.DataFrame(
+            {
+                "patient_id": df["patient_id"].astype(str),
+                "event_type": "ptbxl",
+                "timestamp": pd.NaT,
+                "ptbxl/ecg_id": df["ecg_id"],
+                "ptbxl/filename_lr": df["filename_lr"],
+                "ptbxl/filename_hr": df["filename_hr"],
+                "ptbxl/scp_codes": df["scp_codes"],
+            }
+        )
+
+        return dd.from_pandas(event_df, npartitions=1)

--- a/pyhealth/datasets/ptbxl.py
+++ b/pyhealth/datasets/ptbxl.py
@@ -17,7 +17,9 @@ class PTBXLDataset(BaseDataset):
         dev: bool = False,
         cache_dir: Optional[str] = None,
         num_workers: int = 1,
+        use_high_resolution: bool = False,
     ):
+        self.use_high_resolution = use_high_resolution
         super().__init__(
             root=root,
             tables=["ptbxl"],
@@ -31,14 +33,15 @@ class PTBXLDataset(BaseDataset):
         metadata_path = os.path.join(self.root, "ptbxl_database.csv")
         df = pd.read_csv(metadata_path)
 
+        record_path_col = "filename_hr" if self.use_high_resolution else "filename_lr"
+
         event_df = pd.DataFrame(
             {
                 "patient_id": df["patient_id"].astype(str),
                 "event_type": "ptbxl",
                 "timestamp": pd.NaT,
                 "ptbxl/ecg_id": df["ecg_id"],
-                "ptbxl/filename_lr": df["filename_lr"],
-                "ptbxl/filename_hr": df["filename_hr"],
+                "ptbxl/record_path": df[record_path_col],
                 "ptbxl/scp_codes": df["scp_codes"],
             }
         )

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -66,3 +66,4 @@ from .variant_classification import (
     VariantClassificationClinVar,
 )
 from .patient_linkage_mimic3 import PatientLinkageMIMIC3Task
+from .ptbxl_mi_classification import PTBXLMIClassificationTask

--- a/pyhealth/tasks/ptbxl_mi_classification.py
+++ b/pyhealth/tasks/ptbxl_mi_classification.py
@@ -4,6 +4,7 @@ import pickle
 from typing import Dict, List
 
 import numpy as np
+import pandas as pd
 
 from pyhealth.tasks import BaseTask
 
@@ -11,17 +12,25 @@ from pyhealth.tasks import BaseTask
 class PTBXLMIClassificationTask(BaseTask):
     task_name = "ptbxl_mi_classification"
     input_schema = {
-        "signal": "timeseries",
+        "signal": "tensor",
     }
     output_schema = {
         "label": "binary",
     }
 
+    def __init__(self, root: str):
+        self.root = root
+
+        scp_path = os.path.join(self.root, "scp_statements.csv")
+        scp_df = pd.read_csv(scp_path, index_col=0)
+        self.mi_codes = set(
+            scp_df[scp_df["diagnostic_class"] == "MI"].index.astype(str).tolist()
+        )
+
     def __call__(self, patient) -> List[Dict]:
         samples = []
 
-        patient_df = patient.data_source
-        rows = patient_df.to_dicts()
+        rows = patient.data_source.to_dicts()
 
         for idx, row in enumerate(rows):
             raw_label = row["ptbxl/scp_codes"]
@@ -35,7 +44,7 @@ class PTBXLMIClassificationTask(BaseTask):
             except (ValueError, SyntaxError):
                 scp_codes = {}
 
-            label = 1 if "MI" in scp_codes else 0
+            label = 1 if any(code in self.mi_codes for code in scp_codes.keys()) else 0
 
             signal = np.zeros((12, 1000), dtype=np.float32)
 
@@ -47,13 +56,7 @@ class PTBXLMIClassificationTask(BaseTask):
             )
 
             with open(save_file_path, "wb") as f:
-                pickle.dump(
-                    {
-                        "signal": signal,
-                        "label": label,
-                    },
-                    f,
-                )
+                pickle.dump({"signal": signal, "label": label}, f)
 
             samples.append(
                 {

--- a/pyhealth/tasks/ptbxl_mi_classification.py
+++ b/pyhealth/tasks/ptbxl_mi_classification.py
@@ -1,0 +1,69 @@
+import ast
+import os
+import pickle
+from typing import Dict, List
+
+import numpy as np
+
+from pyhealth.tasks import BaseTask
+
+
+class PTBXLMIClassificationTask(BaseTask):
+    task_name = "ptbxl_mi_classification"
+    input_schema = {
+        "signal": "timeseries",
+    }
+    output_schema = {
+        "label": "binary",
+    }
+
+    def __call__(self, patient) -> List[Dict]:
+        samples = []
+
+        patient_df = patient.data_source
+        rows = patient_df.to_dicts()
+
+        for idx, row in enumerate(rows):
+            raw_label = row["ptbxl/scp_codes"]
+
+            try:
+                scp_codes = (
+                    ast.literal_eval(raw_label)
+                    if isinstance(raw_label, str)
+                    else raw_label
+                )
+            except (ValueError, SyntaxError):
+                scp_codes = {}
+
+            label = 1 if "MI" in scp_codes else 0
+
+            signal = np.zeros((12, 1000), dtype=np.float32)
+
+            visit_id = str(row["ptbxl/ecg_id"])
+            cache_dir = os.path.join("/tmp", "ptbxl_task_cache")
+            os.makedirs(cache_dir, exist_ok=True)
+            save_file_path = os.path.join(
+                cache_dir, f"{patient.patient_id}-MI-{visit_id}.pkl"
+            )
+
+            with open(save_file_path, "wb") as f:
+                pickle.dump(
+                    {
+                        "signal": signal,
+                        "label": label,
+                    },
+                    f,
+                )
+
+            samples.append(
+                {
+                    "patient_id": patient.patient_id,
+                    "visit_id": visit_id,
+                    "record_id": idx + 1,
+                    "signal": signal.tolist(),
+                    "label": label,
+                    "epoch_path": save_file_path,
+                }
+            )
+
+        return samples

--- a/pyhealth/tasks/ptbxl_mi_classification.py
+++ b/pyhealth/tasks/ptbxl_mi_classification.py
@@ -1,3 +1,10 @@
+"""PTBXL MI classification task for PyHealth.
+
+This module defines a task that loads PTB-XL ECG records, maps SCP
+diagnostic codes to myocardial infarction (MI) labels, and returns one
+binary-labeled sample per record.
+"""
+
 import ast
 import os
 from typing import Dict, List
@@ -10,6 +17,17 @@ from pyhealth.tasks import BaseTask
 
 
 class PTBXLMIClassificationTask(BaseTask):
+    """Task for classifying myocardial infarction (MI) in PTB-XL ECG records.
+
+    This task converts the PTB-XL SCP diagnostic codes into a binary MI label
+    and loads the corresponding ECG signal for each record.
+
+    Attributes:
+        task_name (str): The name of the task.
+        input_schema (Dict[str, str]): Input schema mapping signal to tensor.
+        output_schema (Dict[str, str]): Output schema mapping label to binary.
+    """
+
     task_name = "ptbxl_mi_classification"
     input_schema = {
         "signal": "tensor",
@@ -24,6 +42,14 @@ class PTBXLMIClassificationTask(BaseTask):
         signal_length: int = 1000,
         normalize: bool = True,
     ):
+        """Initialize the PTBXL MI classification task.
+
+        Args:
+            root: PTB-XL dataset root directory containing `scp_statements.csv`.
+            signal_length: Number of samples to use for each ECG signal.
+            normalize: Whether to z-score normalize each ECG channel.
+        """
+
         self.root = root
         self.signal_length = signal_length
         self.normalize = normalize
@@ -60,6 +86,20 @@ class PTBXLMIClassificationTask(BaseTask):
         return signal
 
     def __call__(self, patient) -> List[Dict]:
+        """Generate PTB-XL MI samples from a patient record.
+
+        Args:
+            patient: Patient object containing PTB-XL event data.
+
+        Returns:
+            A list of sample dictionaries with keys:
+                - patient_id
+                - visit_id
+                - record_id
+                - signal
+                - label
+        """
+
         samples = []
 
         rows = patient.data_source.to_dicts()

--- a/pyhealth/tasks/ptbxl_mi_classification.py
+++ b/pyhealth/tasks/ptbxl_mi_classification.py
@@ -1,10 +1,10 @@
 import ast
 import os
-import pickle
 from typing import Dict, List
 
 import numpy as np
 import pandas as pd
+import wfdb
 
 from pyhealth.tasks import BaseTask
 
@@ -18,14 +18,46 @@ class PTBXLMIClassificationTask(BaseTask):
         "label": "binary",
     }
 
-    def __init__(self, root: str):
+    def __init__(
+        self,
+        root: str,
+        signal_length: int = 1000,
+        normalize: bool = True,
+    ):
         self.root = root
+        self.signal_length = signal_length
+        self.normalize = normalize
 
         scp_path = os.path.join(self.root, "scp_statements.csv")
         scp_df = pd.read_csv(scp_path, index_col=0)
         self.mi_codes = set(
             scp_df[scp_df["diagnostic_class"] == "MI"].index.astype(str).tolist()
         )
+
+    def _load_ecg_signal(self, record_rel_path: str) -> np.ndarray:
+        """Loads a PTB-XL WFDB record and returns shape (12, signal_length)."""
+        record_path = os.path.join(self.root, record_rel_path)
+
+        # WFDB expects the record path without file extension.
+        signal, _ = wfdb.rdsamp(record_path)
+
+        # rdsamp returns shape (num_samples, num_channels)
+        signal = signal.T.astype(np.float32)  # -> (channels, time)
+
+        if self.normalize:
+            mean = signal.mean(axis=1, keepdims=True)
+            std = signal.std(axis=1, keepdims=True)
+            std = np.where(std < 1e-6, 1.0, std)
+            signal = (signal - mean) / std
+
+        current_len = signal.shape[1]
+        if current_len >= self.signal_length:
+            signal = signal[:, : self.signal_length]
+        else:
+            pad_width = self.signal_length - current_len
+            signal = np.pad(signal, ((0, 0), (0, pad_width)), mode="constant")
+
+        return signal
 
     def __call__(self, patient) -> List[Dict]:
         samples = []
@@ -34,6 +66,7 @@ class PTBXLMIClassificationTask(BaseTask):
 
         for idx, row in enumerate(rows):
             raw_label = row["ptbxl/scp_codes"]
+            record_rel_path = row["ptbxl/record_path"]
 
             try:
                 scp_codes = (
@@ -45,18 +78,9 @@ class PTBXLMIClassificationTask(BaseTask):
                 scp_codes = {}
 
             label = 1 if any(code in self.mi_codes for code in scp_codes.keys()) else 0
-
-            signal = np.zeros((12, 1000), dtype=np.float32)
+            signal = self._load_ecg_signal(record_rel_path)
 
             visit_id = str(row["ptbxl/ecg_id"])
-            cache_dir = os.path.join("/tmp", "ptbxl_task_cache")
-            os.makedirs(cache_dir, exist_ok=True)
-            save_file_path = os.path.join(
-                cache_dir, f"{patient.patient_id}-MI-{visit_id}.pkl"
-            )
-
-            with open(save_file_path, "wb") as f:
-                pickle.dump({"signal": signal, "label": label}, f)
 
             samples.append(
                 {
@@ -65,7 +89,6 @@ class PTBXLMIClassificationTask(BaseTask):
                     "record_id": idx + 1,
                     "signal": signal.tolist(),
                     "label": label,
-                    "epoch_path": save_file_path,
                 }
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "more-itertools~=10.8.0",
   "einops>=0.8.0",
   "linear-attention-transformer>=0.19.1",
+  "wfdb>=4.0.0"
 ]
 license = "BSD-3-Clause"
 license-files = ["LICENSE.md"]

--- a/tests/core/test_ptbxl_dataset.py
+++ b/tests/core/test_ptbxl_dataset.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+import unittest
+
+from pyhealth.datasets import PTBXLDataset
+
+
+class TestPTBXLDataset(unittest.TestCase):
+    def test_load_data_dev_mode(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "ptbxl_database.csv")
+
+            with open(csv_path, "w") as f:
+                f.write("ecg_id,patient_id,filename_lr,filename_hr,scp_codes\n")
+                f.write('1,100,records100/00000/00001_lr,records500/00000/00001_hr,"{\'MI\': 1}"\n')
+                f.write('2,101,records100/00000/00002_lr,records500/00000/00002_hr,"{\'NORM\': 1}"\n')
+
+            dataset = PTBXLDataset(
+                root=tmpdir,
+                dev=True,
+            )
+
+            df = dataset.load_data().compute()
+
+            self.assertEqual(len(df), 2)
+            self.assertIn("patient_id", df.columns)
+            self.assertIn("event_type", df.columns)
+            self.assertIn("ptbxl/ecg_id", df.columns)
+            self.assertIn("ptbxl/filename_lr", df.columns)
+            self.assertIn("ptbxl/scp_codes", df.columns)
+            self.assertEqual(str(df.iloc[0]["patient_id"]), "100")
+            self.assertEqual(df.iloc[0]["event_type"], "ptbxl")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_ptbxl_dataset.py
+++ b/tests/core/test_ptbxl_dataset.py
@@ -26,7 +26,7 @@ class TestPTBXLDataset(unittest.TestCase):
             self.assertIn("patient_id", df.columns)
             self.assertIn("event_type", df.columns)
             self.assertIn("ptbxl/ecg_id", df.columns)
-            self.assertIn("ptbxl/filename_lr", df.columns)
+            self.assertIn("ptbxl/record_path", df.columns)
             self.assertIn("ptbxl/scp_codes", df.columns)
             self.assertEqual(str(df.iloc[0]["patient_id"]), "100")
             self.assertEqual(df.iloc[0]["event_type"], "ptbxl")

--- a/tests/core/test_ptbxl_mi_classification.py
+++ b/tests/core/test_ptbxl_mi_classification.py
@@ -1,0 +1,42 @@
+import unittest
+import pandas as pd
+import polars as pl
+
+from pyhealth.tasks.ptbxl_mi_classification import PTBXLMIClassificationTask
+from pyhealth.data import Patient
+
+
+class TestPTBXLTask(unittest.TestCase):
+
+    def test_mi_label_extraction(self):
+        # synthetic patient data
+        df = pd.DataFrame({
+            "patient_id": ["1", "1"],
+            "event_type": ["ptbxl", "ptbxl"],
+            "timestamp": [None, None],
+            "ptbxl/ecg_id": [100, 101],
+            "ptbxl/filename_lr": ["a", "b"],
+            "ptbxl/filename_hr": ["a", "b"],
+            "ptbxl/scp_codes": [
+                "{'MI': 1}",     # should be label = 1
+                "{'NORM': 1}"    # should be label = 0
+            ],
+        })
+
+        pl_df = pl.from_pandas(df)
+
+        patient = Patient(
+            patient_id="1",
+            data_source=pl_df
+        )
+
+        task = PTBXLMIClassificationTask()
+        samples = task(patient)
+
+        self.assertEqual(len(samples), 2)
+        self.assertEqual(samples[0]["label"], 1)
+        self.assertEqual(samples[1]["label"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_ptbxl_mi_classification.py
+++ b/tests/core/test_ptbxl_mi_classification.py
@@ -1,4 +1,9 @@
+import os
+import tempfile
 import unittest
+from unittest.mock import patch
+
+import numpy as np
 import pandas as pd
 import polars as pl
 
@@ -7,35 +12,51 @@ from pyhealth.data import Patient
 
 
 class TestPTBXLTask(unittest.TestCase):
+    @patch.object(PTBXLMIClassificationTask, "_load_ecg_signal")
+    def test_mi_label_extraction(self, mock_load_signal):
+        mock_load_signal.return_value = np.zeros((12, 1000), dtype=np.float32)
 
-    def test_mi_label_extraction(self):
-        # synthetic patient data
-        df = pd.DataFrame({
-            "patient_id": ["1", "1"],
-            "event_type": ["ptbxl", "ptbxl"],
-            "timestamp": [None, None],
-            "ptbxl/ecg_id": [100, 101],
-            "ptbxl/filename_lr": ["a", "b"],
-            "ptbxl/filename_hr": ["a", "b"],
-            "ptbxl/scp_codes": [
-                "{'MI': 1}",     # should be label = 1
-                "{'NORM': 1}"    # should be label = 0
-            ],
-        })
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scp_path = os.path.join(tmpdir, "scp_statements.csv")
 
-        pl_df = pl.from_pandas(df)
+            # minimal synthetic SCP mapping
+            scp_df = pd.DataFrame(
+                {
+                    "diagnostic_class": ["MI", "NORM"],
+                },
+                index=["IMI", "NORM"],
+            )
+            scp_df.to_csv(scp_path)
 
-        patient = Patient(
-            patient_id="1",
-            data_source=pl_df
-        )
+            df = pd.DataFrame(
+                {
+                    "patient_id": ["1", "1"],
+                    "event_type": ["ptbxl", "ptbxl"],
+                    "timestamp": [None, None],
+                    "ptbxl/ecg_id": [100, 101],
+                    "ptbxl/record_path": [
+                        "records100/00000/00001_lr",
+                        "records100/00000/00002_lr",
+                    ],
+                    "ptbxl/scp_codes": [
+                        "{'IMI': 1}",
+                        "{'NORM': 1}",
+                    ],
+                }
+            )
 
-        task = PTBXLMIClassificationTask()
-        samples = task(patient)
+            patient = Patient(
+                patient_id="1",
+                data_source=pl.from_pandas(df),
+            )
 
-        self.assertEqual(len(samples), 2)
-        self.assertEqual(samples[0]["label"], 1)
-        self.assertEqual(samples[1]["label"], 0)
+            task = PTBXLMIClassificationTask(root=tmpdir)
+            samples = task(patient)
+
+            self.assertEqual(len(samples), 2)
+            self.assertEqual(samples[0]["label"], 1)
+            self.assertEqual(samples[1]["label"], 0)
+            self.assertEqual(np.array(samples[0]["signal"]).shape, (12, 1000))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Contributors:** Zaid Alkhatib (zaida3@illinois.edu), Anila Narapusetty (anilan2@illinois.edu)

**Contribution Type:** Dataset + Task

**Paper:** Data Augmentation for Electrocardiograms  
**Paper Link:** https://arxiv.org/abs/2204.04360

---

## Overview

This PR adds support for the PTB-XL ECG dataset and implements a binary myocardial infarction (MI) classification task as a partial reproduction of the paper *Data Augmentation for Electrocardiograms*.

The contribution focuses on the dataset and task components of the pipeline within PyHealth, rather than reproducing the full model and training procedure.

---

## What was implemented

### Dataset

- Added `PTBXLDataset` in `pyhealth/datasets/ptbxl.py`
- Inherits from `BaseDataset`
- Loads PTB-XL metadata from `ptbxl_database.csv`
- Supports both:
  - `records100/` (100 Hz, default)
  - `records500/` (500 Hz, optional)
- Converts ECG records into PyHealth-compatible event format
- Includes `record_path` for downstream waveform loading
- Supports `dev=True` for fast iteration

---

### Task

- Added `PTBXLMIClassificationTask` in `pyhealth/tasks/ptbxl_mi_classification.py`
- Binary classification:
  - `1` → Myocardial Infarction (MI)
  - `0` → Non-MI
- Labels derived using `scp_statements.csv` to map SCP codes to the MI diagnostic class
- Loads **real ECG waveforms** using WFDB from PTB-XL records
- Signal processing:
  - Transposes signals to `(channels, time)`
  - Normalizes per channel
  - Pads/truncates to fixed length for model compatibility
- Uses PyHealth schema:
  - `signal`: `"tensor"`
  - `label`: `"binary"`

---

### Tests

- Added synthetic unit tests:
  - `tests/core/test_ptbxl_dataset.py`
  - `tests/core/test_ptbxl_mi_classification.py`
- Tests:
  - Use small synthetic data (no external dependency)
  - Run quickly
  - Validate:
    - dataset loading
    - label generation logic
    - sample structure
- Waveform loading is mocked in tests to keep them lightweight

---

### Docs

- Added dataset documentation:
  - `docs/api/datasets/pyhealth.datasets.ptbxl.rst`
- Added task documentation:
  - `docs/api/tasks/pyhealth.tasks.ptbxl_mi_classification.rst`
- Updated:
  - `docs/api/datasets.rst`
  - `docs/api/tasks.rst`

---

### Example

- Added:
  - `examples/ptbxl_mi_classification_cnn.py`
  - Supports synthetic demo mode if PTB-XL dataset is not available
  - Includes a small ablation comparing normalization enabled vs disabled
 
Demonstrates:
- loading PTB-XL dataset
- applying MI classification task
- generating processed samples
- using real ECG waveform data

#### Ablation / Variation (Normalize On vs Off)

The example script supports a small ablation by toggling `normalize=True/False`.

Run:
```bash
python examples/ptbxl_mi_classification_cnn.py --ablation-normalize
```



## Files to Review

### Core implementation
- `pyhealth/datasets/ptbxl.py`
- `pyhealth/tasks/ptbxl_mi_classification.py`

### Registration
- `pyhealth/datasets/__init__.py`
- `pyhealth/tasks/__init__.py`

### Tests
- `tests/core/test_ptbxl_dataset.py`
- `tests/core/test_ptbxl_mi_classification.py`

### Documentation
- `docs/api/datasets/pyhealth.datasets.ptbxl.rst`
- `docs/api/tasks/pyhealth.tasks.ptbxl_mi_classification.rst`
- `docs/api/datasets.rst`
- `docs/api/tasks.rst`

### Example
- `examples/ptbxl_mi_classification_cnn.py`


## Notes

- Tests use synthetic data only (per PyHealth guidelines)
- Example supports both real PTB-XL data and a synthetic demo fallback when the dataset is not available locally
- This implementation reproduces the dataset and task setup from the paper
- Model training and augmentation pipeline are not included in this PR