### PR TITLE
feat(models): Add L1 regularization support to LogisticRegression

### DIFF
--- a/pyhealth/models/logistic_regression.py
+++ b/pyhealth/models/logistic_regression.py
@@ -10,22 +10,33 @@ from .embedding import EmbeddingModel
 
 
 class LogisticRegression(BaseModel):
-    """Logistic/Linear regression baseline model.
+    """Logistic/Linear regression baseline model with optional L1 regularization.
 
     This model uses embeddings from different input features and applies a single
     linear transformation (no hidden layers or non-linearity) to produce predictions.
-    
+
     - For classification tasks: acts as logistic regression
     - For regression tasks: acts as linear regression
-    
+
     The model automatically handles different input types through the EmbeddingModel,
     pools sequence dimensions, concatenates all feature embeddings, and applies a
     final linear layer.
+
+    L1 regularization (``l1_lambda > 0``) adds a sparsity-inducing penalty to the
+    weight vector during training, equivalent to scikit-learn's
+    ``LogisticRegression(penalty='l1', C=C)`` with ``l1_lambda = 1 / (C * n_train)``.
+    This is the formulation used in Boag et al. (2018) "Racial Disparities and
+    Mistrust in End-of-Life Care" (MLHC 2018) to train interpersonal-feature
+    mistrust classifiers on MIMIC-III.
 
     Args:
         dataset: the dataset to train the model. It is used to query certain
             information such as the set of all tokens.
         embedding_dim: the embedding dimension. Default is 128.
+        l1_lambda: coefficient for the L1 weight penalty added to the loss.
+            ``loss = BCE + l1_lambda * ||W||_1``. Set to 0.0 (default) to
+            disable regularization (backward-compatible). Equivalent to
+            ``1 / (C * n_train)`` for sklearn's C-parameterised formulation.
         **kwargs: other parameters (for compatibility).
 
     Examples:
@@ -55,7 +66,7 @@ class LogisticRegression(BaseModel):
         ...                        dataset_name="test")
         >>>
         >>> from pyhealth.models import LogisticRegression
-        >>> model = LogisticRegression(dataset=dataset)
+        >>> model = LogisticRegression(dataset=dataset, l1_lambda=1e-4)
         >>>
         >>> from pyhealth.datasets import get_dataloader
         >>> train_loader = get_dataloader(dataset, batch_size=2, shuffle=True)
@@ -64,7 +75,7 @@ class LogisticRegression(BaseModel):
         >>> ret = model(**data_batch)
         >>> print(ret)
         {
-            'loss': tensor(0.6931, grad_fn=<BinaryCrossEntropyWithLogitsBackward0>),
+            'loss': tensor(0.6931, grad_fn=<AddBackward0>),
             'y_prob': tensor([[0.5123],
                             [0.4987]], grad_fn=<SigmoidBackward0>),
             'y_true': tensor([[1.],
@@ -80,10 +91,12 @@ class LogisticRegression(BaseModel):
         self,
         dataset: SampleDataset,
         embedding_dim: int = 128,
+        l1_lambda: float = 0.0,
         **kwargs,
     ):
         super(LogisticRegression, self).__init__(dataset)
         self.embedding_dim = embedding_dim
+        self.l1_lambda = l1_lambda
 
         assert len(self.label_keys) == 1, "Only one label key is supported"
         self.label_key = self.label_keys[0]
@@ -197,6 +210,10 @@ class LogisticRegression(BaseModel):
         # Obtain y_true, loss, y_prob
         y_true = kwargs[self.label_key].to(self.device)
         loss = self.get_loss_function()(logits, y_true)
+        # L1 regularization on the final linear layer's weights (bias excluded),
+        # equivalent to sklearn's penalty='l1' with C = 1 / (l1_lambda * n_train).
+        if self.l1_lambda > 0.0:
+            loss = loss + self.l1_lambda * self.fc.weight.abs().sum()
         y_prob = self.prepare_y_prob(logits)
         
         results = {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  Adds an optional `l1_lambda` parameter to `LogisticRegression` that appends                                                                                                                                      
  a sparsity-inducing L1 penalty on the final linear layer's weights to the                                                                                                                                        
  training loss:                                                                                                                                                                                                   
                                                                                                                                                                                                                   
  loss = BCE(logits, y_true) + l1_lambda * ‖fc.weight‖₁                                                                                                                                                            
                                                                                                                                                                                                                   
  The default is `l1_lambda=0.0`, making this **fully backward-compatible** —                                                                                                                                      
  existing code that instantiates `LogisticRegression` without the parameter                                                                                                                                       
  is unaffected.                                                                                                                                                                                                   
                                                                                                                                                                                                                   
  ## Motivation                                                                                                                                                                                                    
                                                                                                                                                                                                                   
  The current `LogisticRegression` model supports unregularised logistic                                                                                                                                           
  regression only. Many clinical prediction tasks — particularly those with                                                                                                                                        
  high-dimensional, sparse binary feature spaces — benefit from L1                                                                                                                                                 
  regularisation to produce interpretable, sparse weight vectors. This is the                                                                                                                                      
  standard approach in clinical ML literature (e.g. LASSO logistic regression)                                                                                                                                     
  and was specifically used in:                                                                                                                                                                                    
                                                                                                                                                                                                                   
  > Boag et al. "Racial Disparities and Mistrust in End-of-Life Care."                                                                                                                                             
  > MLHC 2018. [arXiv:1808.03827](https://arxiv.org/abs/1808.03827)                                                                                                                                                
                                                                                                                                                                                                                   
  ## Parameter equivalence to scikit-learn                                                                                                                                                                         
                                                                                                                                                                                                                   
  For users migrating from scikit-learn's `LogisticRegression(penalty='l1', C=C)`:                                                                                                                                 

  l1_lambda = 1 / (C × n_train)

  Example: `C=0.1` on a dataset of 38,000 training samples → `l1_lambda ≈ 2.6e-4`

  ## Changes

  - `pyhealth/models/logistic_regression.py`
    - Add `l1_lambda: float = 0.0` to `__init__`
    - In `forward()`: add `l1_lambda * self.fc.weight.abs().sum()` to loss
      when `l1_lambda > 0`
    - Updated docstring with usage example and sklearn equivalence

## Usage

  ```python
  from pyhealth.models import LogisticRegression

  model = LogisticRegression(
      dataset=sample_dataset,
      embedding_dim=128,
      l1_lambda=2.6e-4,   # equivalent to sklearn C=0.1 with n_train=38,000
  )

  Testing

  - Existing LogisticRegression tests pass unchanged (l1_lambda defaults to 0)
  - With l1_lambda > 0, loss increases by the penalty term and gradients
  flow correctly through fc.weight — verified via loss.backward()

  Related PRs

  This is PR 1 of 3 in a series implementing the Boag et al. 2018 mistrust
  pipeline in PyHealth.
PRs #2 and #3 depend on this change.
