### PR TITLE
Add HOC (Hallmarks of Cancer) dataset + classification task for PyHealth

### DIFF
--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -225,6 +225,7 @@ Available Datasets
     datasets/pyhealth.datasets.MIMIC3Dataset
     datasets/pyhealth.datasets.MIMIC4Dataset
     datasets/pyhealth.datasets.MedicalTranscriptionsDataset
+    datasets/pyhealth.datasets.HallmarksOfCancerDataset
     datasets/pyhealth.datasets.CardiologyDataset
     datasets/pyhealth.datasets.eICUDataset
     datasets/pyhealth.datasets.ISRUCDataset

--- a/docs/api/datasets/pyhealth.datasets.HallmarksOfCancerDataset.rst
+++ b/docs/api/datasets/pyhealth.datasets.HallmarksOfCancerDataset.rst
@@ -1,0 +1,11 @@
+pyhealth.datasets.HallmarksOfCancerDataset
+==========================================
+
+Hallmarks of Cancer (HOC) sentence-level multi-label text classification.
+Source corpus: Baker et al., *Bioinformatics* 2016; BigBio/Hugging Face:
+https://huggingface.co/datasets/bigbio/hallmarks_of_cancer (GPL-3.0).
+
+.. autoclass:: pyhealth.datasets.HallmarksOfCancerDataset
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -214,6 +214,7 @@ Available Tasks
     Drug Recommendation <tasks/pyhealth.tasks.drug_recommendation>
     Length of Stay Prediction <tasks/pyhealth.tasks.length_of_stay_prediction>
     Medical Transcriptions Classification <tasks/pyhealth.tasks.MedicalTranscriptionsClassification>
+    Hallmarks of Cancer (sentence, multilabel) <tasks/pyhealth.tasks.HallmarksOfCancerSentenceClassification>
     Mortality Prediction (Next Visit) <tasks/pyhealth.tasks.mortality_prediction>
     Mortality Prediction (StageNet MIMIC-IV) <tasks/pyhealth.tasks.mortality_prediction_stagenet_mimic4>
     Patient Linkage (MIMIC-III) <tasks/pyhealth.tasks.patient_linkage_mimic3_fn>

--- a/docs/api/tasks/pyhealth.tasks.HallmarksOfCancerSentenceClassification.rst
+++ b/docs/api/tasks/pyhealth.tasks.HallmarksOfCancerSentenceClassification.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.HallmarksOfCancerSentenceClassification
+=====================================================
+
+.. autoclass:: pyhealth.tasks.hallmarks_of_cancer_classification.HallmarksOfCancerSentenceClassification
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/data_prep/export_hallmarks_of_cancer_bigbio.py
+++ b/examples/data_prep/export_hallmarks_of_cancer_bigbio.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Export BigBio Hallmarks of Cancer to a CSV for :class:`HallmarksOfCancerDataset`.
+
+This script is **not** run by PyHealth tests. Use it once to materialize data
+under a directory you pass to ``HallmarksOfCancerDataset(root=...)``.
+
+Requires::
+
+    pip install datasets pandas
+
+Data source (GPL-3.0): https://huggingface.co/datasets/bigbio/hallmarks_of_cancer
+Use config ``hallmarks_of_cancer_bigbio_text`` for sentence-level ``text`` and
+``labels`` fields.
+
+Example::
+
+    python examples/data_prep/export_hallmarks_of_cancer_bigbio.py \\
+        --output-dir ~/data/hallmarks_of_cancer
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory to write hallmarks_of_cancer.csv into",
+    )
+    args = parser.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    from datasets import load_dataset  # noqa: WPS433 (runtime optional dep)
+
+    ds = load_dataset(
+        "bigbio/hallmarks_of_cancer",
+        "hallmarks_of_cancer_bigbio_text",
+    )
+    split_map = {
+        "train": "train",
+        "validation": "validation",
+        "test": "test",
+    }
+
+    rows: list[dict[str, str]] = []
+    for split_name, hf_split in split_map.items():
+        for i, rec in enumerate(ds[hf_split]):
+            sid = str(rec.get("id", f"{split_name}_{i}"))
+            doc = str(rec.get("document_id", ""))
+            text = rec.get("text", "")
+            if not isinstance(text, str):
+                text = str(text)
+            labels = rec.get("labels", [])
+            if not isinstance(labels, list):
+                labels = [str(labels)]
+            labels_str = "##".join(str(x) for x in labels)
+            rows.append(
+                {
+                    "sentence_id": sid,
+                    "document_id": doc,
+                    "text": text.replace("\r\n", "\n").replace("\r", "\n"),
+                    "labels": labels_str,
+                    "split": split_name,
+                }
+            )
+
+    out_path = args.output_dir / "hallmarks_of_cancer.csv"
+    import pandas as pd  # noqa: WPS433
+
+    pd.DataFrame(rows).to_csv(out_path, index=False)
+    print(f"Wrote {len(rows)} rows to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -54,6 +54,7 @@ from .cosmic import COSMICDataset
 from .covid19_cxr import COVID19CXRDataset
 from .dreamt import DREAMTDataset
 from .ehrshot import EHRShotDataset
+from .hallmarks_of_cancer import HallmarksOfCancerDataset
 from .eicu import eICUDataset
 from .isruc import ISRUCDataset
 from .medical_transcriptions import MedicalTranscriptionsDataset

--- a/pyhealth/datasets/configs/hallmarks_of_cancer.yaml
+++ b/pyhealth/datasets/configs/hallmarks_of_cancer.yaml
@@ -1,0 +1,11 @@
+version: "1.0"
+tables:
+  hoc:
+    file_path: "hallmarks_of_cancer.csv"
+    patient_id: "sentence_id"
+    timestamp: null
+    attributes:
+      - "document_id"
+      - "text"
+      - "labels"
+      - "split"

--- a/pyhealth/datasets/hallmarks_of_cancer.py
+++ b/pyhealth/datasets/hallmarks_of_cancer.py
@@ -1,0 +1,77 @@
+import logging
+from pathlib import Path
+from typing import Optional
+
+from .base_dataset import BaseDataset
+
+logger = logging.getLogger(__name__)
+
+
+class HallmarksOfCancerDataset(BaseDataset):
+    """Hallmarks of Cancer (HOC) sentence corpus for multi-label text classification.
+
+    This dataset expects a **single** CSV file under ``root`` (default filename
+    ``hallmarks_of_cancer.csv``) with one row per sentence. Prepare the file by
+    exporting from the BigBio Hugging Face dataset (see
+    ``examples/data_prep/export_hallmarks_of_cancer_bigbio.py``) or any tool that
+    produces the same columns.
+
+    Original corpus (PubMed abstracts, sentence-level hallmark labels):
+    Baker et al., *Bioinformatics* 2016. Hugging Face:
+    https://huggingface.co/datasets/bigbio/hallmarks_of_cancer
+
+    The upstream data is distributed under **GPL-3.0**; cite the original paper
+    and comply with the license when redistributing derived files.
+
+    **CSV columns**
+
+    - ``sentence_id``: unique ID per sentence (used as ``patient_id`` in PyHealth).
+    - ``document_id``: document-level identifier (e.g. PMID-based id from BigBio).
+    - ``text``: sentence text.
+    - ``labels``: multi-label column. Use ``##`` between labels, e.g. ``none`` or
+      ``activating invasion and metastasis##sustaining proliferative signaling``.
+    - ``split``: one of ``train``, ``validation``, ``test`` (Hugging Face naming).
+
+    Args:
+        root: Directory containing ``hallmarks_of_cancer.csv`` (or path given in YAML).
+        dataset_name: Logical name for caching. Defaults to ``hallmarks_of_cancer``.
+        config_path: Optional YAML config; defaults to the package config file.
+
+    Examples:
+        >>> from pyhealth.datasets import HallmarksOfCancerDataset
+        >>> from pyhealth.tasks import HallmarksOfCancerSentenceClassification
+        >>> ds = HallmarksOfCancerDataset(root="/path/to/hoc_root")
+        >>> task = HallmarksOfCancerSentenceClassification(split="train")
+        >>> samples = ds.set_task(task)
+    """
+
+    def __init__(
+        self,
+        root: str,
+        dataset_name: Optional[str] = None,
+        config_path: Optional[str] = None,
+        cache_dir=None,
+        num_workers: int = 1,
+        dev: bool = False,
+    ) -> None:
+        if config_path is None:
+            logger.info("No config path provided, using default Hallmarks of Cancer config")
+            config_path = (
+                Path(__file__).parent / "configs" / "hallmarks_of_cancer.yaml"
+            )
+        super().__init__(
+            root=root,
+            tables=["hoc"],
+            dataset_name=dataset_name or "hallmarks_of_cancer",
+            config_path=str(config_path),
+            cache_dir=cache_dir,
+            num_workers=num_workers,
+            dev=dev,
+        )
+
+    @property
+    def default_task(self):
+        """Default task: training split, multi-label sentence classification."""
+        from pyhealth.tasks import HallmarksOfCancerSentenceClassification
+
+        return HallmarksOfCancerSentenceClassification(split="train")

--- a/pyhealth/models/t5classifier.py
+++ b/pyhealth/models/t5classifier.py
@@ -1,0 +1,129 @@
+import torch
+import torch.nn as nn
+from transformers import T5EncoderModel, AutoTokenizer
+from pyhealth.models import BaseModel
+
+
+class T5Classifier(BaseModel):
+    def __init__(
+        self,
+        dataset,
+        pretrained_model_name="t5-base",
+        max_length=256,
+        dropout=0.1,
+        pooling="mean",   # "mean" or "first"
+    ):
+        super().__init__(dataset=dataset)
+
+        # label setup from BaseModel
+        self.label_key = self.label_keys[0]
+
+        # hyperparameters
+        self.max_length = max_length
+        self.pooling = pooling
+
+        # backbone
+        self.tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name)
+        self.encoder = T5EncoderModel.from_pretrained(pretrained_model_name)
+
+        # head
+        hidden_size = self.encoder.config.d_model
+        self.dropout = nn.Dropout(dropout)
+        self.classifier = nn.Linear(hidden_size, self.get_output_size())
+
+    def forward(self, **samples):
+        """
+        samples = batch from PyHealth (MIMIC-style)
+
+        Example:
+        {
+            "conditions": [...],
+            "procedures": [...],
+            "note": [...],
+            "label": tensor([...])
+        }
+        """
+
+        # -----------------------------
+        # 1. Build text input (simple)
+        # -----------------------------
+        texts = []
+        batch_size = len(next(iter(samples.values())))
+
+        for i in range(batch_size):
+            parts = []
+
+            for key in self.feature_keys:
+                if key not in samples:
+                    continue
+
+                val = samples[key][i]
+
+                # basic flattening
+                if isinstance(val, list):
+                    val = " ".join(map(str, val))
+                else:
+                    val = str(val)
+
+                parts.append(f"{key}: {val}")
+
+            texts.append(" ".join(parts))
+
+        # -----------------------------
+        # 2. Tokenize
+        # -----------------------------
+        enc = self.tokenizer(
+            texts,
+            padding=True,
+            truncation=True,
+            max_length=self.max_length,
+            return_tensors="pt",
+        )
+
+        input_ids = enc["input_ids"].to(self.device)
+        attention_mask = enc["attention_mask"].to(self.device)
+
+        # -----------------------------
+        # 3. Encoder
+        # -----------------------------
+        outputs = self.encoder(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            return_dict=True,
+        )
+
+        hidden = outputs.last_hidden_state  # [B, L, H]
+
+        # -----------------------------
+        # 4. Pooling
+        # -----------------------------
+        if self.pooling == "first":
+            pooled = hidden[:, 0, :]
+        else:
+            pooled = hidden.mean(dim=1)
+
+        # -----------------------------
+        # 5. Head
+        # -----------------------------
+        pooled = self.dropout(pooled)
+        logits = self.classifier(pooled)
+
+        # -----------------------------
+        # 6. Output
+        # -----------------------------
+        result = {
+            "logit": logits,
+            "y_prob": self.prepare_y_prob(logits),
+        }
+
+        # -----------------------------
+        # 7. Loss
+        # -----------------------------
+        if self.label_key in samples:
+            y_true = samples[self.label_key].to(self.device)
+            loss = self.get_loss_function()(logits, y_true)
+
+            result["loss"] = loss
+            result["y_true"] = y_true
+
+        return result

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -31,6 +31,7 @@ from .length_of_stay_prediction import (
 from .length_of_stay_stagenet_mimic4 import LengthOfStayStageNetMIMIC4
 from .medical_coding import MIMIC3ICD9Coding
 from .medical_transcriptions_classification import MedicalTranscriptionsClassification
+from .hallmarks_of_cancer_classification import HallmarksOfCancerSentenceClassification
 from .mortality_prediction import (
     MortalityPredictionEICU,
     MortalityPredictionEICU2,

--- a/pyhealth/tasks/hallmarks_of_cancer_classification.py
+++ b/pyhealth/tasks/hallmarks_of_cancer_classification.py
@@ -1,0 +1,92 @@
+"""Hallmarks of Cancer (HOC) sentence-level multi-label classification task."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List
+
+import polars as pl
+
+from pyhealth.data import Patient
+
+from .base_task import BaseTask
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_labels_raw(raw: str) -> List[str]:
+    """Parse label field from CSV: ``##``-separated list or JSON list string."""
+    raw = (raw or "").strip()
+    if not raw:
+        return []
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return [str(x) for x in parsed]
+        except json.JSONDecodeError:
+            logger.debug("labels JSON parse failed, falling back to split: %r", raw)
+    return [p for p in raw.split("##") if p.strip()]
+
+
+class HallmarksOfCancerSentenceClassification(BaseTask):
+    """Multi-label sentence classification on the Hallmarks of Cancer corpus.
+
+    Each PyHealth "patient" is one sentence row. Inputs are sentence strings;
+    outputs are lists of hallmark class names (including ``none`` when no
+    hallmark applies), matching the BigBio ``hallmarks_of_cancer_bigbio_text``
+    schema.
+
+    Args:
+        split: Which split to keep: ``train``, ``validation``, or ``test``.
+            Rows are filtered via :meth:`pre_filter` on the ``hoc/split`` column.
+
+    Attributes:
+        task_name: Fixed task name string.
+        input_schema: ``{"text": "text"}``.
+        output_schema: ``{"labels": "multilabel"}``.
+
+    Examples:
+        >>> from pyhealth.datasets import HallmarksOfCancerDataset
+        >>> from pyhealth.tasks import HallmarksOfCancerSentenceClassification
+        >>> ds = HallmarksOfCancerDataset(root="/path/to/data")
+        >>> task = HallmarksOfCancerSentenceClassification(split="train")
+        >>> samples = ds.set_task(task)
+    """
+
+    task_name: str = "HallmarksOfCancerSentenceClassification"
+
+    def __init__(self, split: str = "train") -> None:
+        if split not in ("train", "validation", "test"):
+            raise ValueError(
+                f"split must be 'train', 'validation', or 'test', got {split!r}"
+            )
+        self.split = split
+        self.input_schema: Dict[str, str] = {"text": "text"}
+        self.output_schema: Dict[str, str] = {"labels": "multilabel"}
+
+    def pre_filter(self, df: pl.LazyFrame) -> pl.LazyFrame:
+        """Keep only rows for the requested train/validation/test split."""
+        return df.filter(pl.col("hoc/split") == self.split)
+
+    def __call__(self, patient: Patient) -> List[Dict[str, Any]]:
+        events = patient.get_events(event_type="hoc")
+        samples: List[Dict[str, Any]] = []
+        for event in events:
+            text = event["text"]
+            if not isinstance(text, str) or not text.strip():
+                continue
+            raw_labels = event["labels"]
+            if not isinstance(raw_labels, str):
+                raw_labels = str(raw_labels)
+            labels = _parse_labels_raw(raw_labels)
+            samples.append(
+                {
+                    "patient_id": patient.patient_id,
+                    "record_id": patient.patient_id,
+                    "text": text,
+                    "labels": labels,
+                }
+            )
+        return samples

--- a/tests/datasets/test_hallmarks_of_cancer.py
+++ b/tests/datasets/test_hallmarks_of_cancer.py
@@ -1,0 +1,87 @@
+"""Tests for Hallmarks of Cancer dataset and task (synthetic CSV only)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import polars as pl
+
+from pyhealth.datasets import HallmarksOfCancerDataset
+from pyhealth.tasks.hallmarks_of_cancer_classification import (
+    HallmarksOfCancerSentenceClassification,
+    _parse_labels_raw,
+)
+
+
+class TestParseLabels(unittest.TestCase):
+    def test_pipe_style(self):
+        self.assertEqual(_parse_labels_raw("none"), ["none"])
+        self.assertEqual(
+            _parse_labels_raw("a##b"),
+            ["a", "b"],
+        )
+
+    def test_json_style(self):
+        self.assertEqual(_parse_labels_raw('["none"]'), ["none"])
+        self.assertEqual(
+            _parse_labels_raw('["activating invasion and metastasis"]'),
+            ["activating invasion and metastasis"],
+        )
+
+
+class TestHallmarksOfCancerTask(unittest.TestCase):
+    def test_pre_filter_column(self):
+        task = HallmarksOfCancerSentenceClassification(split="train")
+        lf = pl.DataFrame(
+            {
+                "patient_id": ["1", "2"],
+                "event_type": ["hoc", "hoc"],
+                "timestamp": [None, None],
+                "hoc/split": ["train", "validation"],
+                "hoc/text": ["hello", "world"],
+                "hoc/labels": ["none", "none"],
+                "hoc/document_id": ["d1", "d2"],
+            }
+        ).lazy()
+        out = task.pre_filter(lf).collect()
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out["patient_id"].to_list()[0], "1")
+
+
+class TestHallmarksOfCancerDataset(unittest.TestCase):
+    def _write_minimal_csv(self, directory: Path) -> None:
+        lines = [
+            "sentence_id,document_id,text,labels,split",
+            's1,d1,"hello",none,train',
+            's2,d2,"world","a##b",train',
+            's3,d3,"val row",none,validation',
+        ]
+        (directory / "hallmarks_of_cancer.csv").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+
+    def test_load_and_task_produces_samples(self):
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "pyhealth.datasets.base_dataset.platformdirs.user_cache_dir",
+            return_value=tmp,
+        ):
+            root = Path(tmp) / "hoc_root"
+            root.mkdir()
+            self._write_minimal_csv(root)
+            ds = HallmarksOfCancerDataset(
+                root=str(root),
+                cache_dir=Path(tmp) / "hoc_cache",
+                num_workers=1,
+                dev=True,
+            )
+            task = HallmarksOfCancerSentenceClassification(split="train")
+            samples = ds.set_task(task)
+            self.assertGreaterEqual(len(samples), 1)
+            row0 = samples[0]
+            self.assertIn("text", row0)
+            self.assertIn("labels", row0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds the Hallmarks of Cancer (HOC) corpus as a PyHealth `BaseDataset` + `BaseTask` for sentence-level **multi-label** classification, with docs and synthetic tests.

## What’s included
- `HallmarksOfCancerDataset` + `configs/hallmarks_of_cancer.yaml` (CSV under `root/`)
- `HallmarksOfCancerSentenceClassification` with `train` / `validation` / `test` split filtering
- `examples/data_prep/export_hallmarks_of_cancer_bigbio.py` — optional one-off export from `bigbio/hallmarks_of_cancer` (`hallmarks_of_cancer_bigbio_text`)
- API RST + index entries; unit tests (no network)

## How to test
python -m unittest tests.datasets.test_hallmarks_of_cancer -v