### PR TITLE
Add cache behavior documentation to _init_cache_dir

### DIFF
--- a/pyhealth/datasets/base_dataset.py
+++ b/pyhealth/datasets/base_dataset.py
@@ -382,7 +382,21 @@ class BaseDataset(ABC):
                     {task_name}_{task_uuid}/        # Cached data for specific task based on task name, schema, and args
                         task_df.ld/                 # Intermediate task dataframe based on schema
                         samples_{proc_uuid}.ld/     # Final processed samples after applying processors
+        Important: when to clear the cache manually
+          The cache ID only tracks root, tables, dataset_name, and dev.
+          If you change your raw data files, column mappings, or any 
+          processing logic without changing these four values, PyHealth
+          will load old cached data without warning. Delete the cache
+          folder manually if you suspect this has happened.
 
+        Default cache location (when cache_dir is None):
+              Linux/Mac: ~/.cache/pyhealth/
+              Windows: C:\\Users\\<you>\\AppData\\Local\\pyhealth\\
+
+        Concurrency warning:
+              Running multiple processes that cache the same dataset at
+              the same time may cause crashes if the cache does not
+              exist yet. Run a single process first to create the cache.
         Returns:
             Path: The resolved cache directory path.
         """


### PR DESCRIPTION
Closes #763

Added documentation to the `_init_cache_dir` docstring covering:

- When to manually clear the cache (the cache ID only tracks root, tables, dataset_name, and dev — other changes can cause stale data)
- Default cache locations on Linux/Mac and Windows
- Concurrency warning about multiple processes writing cache at the same time