### PR TITLE
Add Standalone Sleep Wake Detection task to DREAMT wearable sleep dataset

### DIFF
--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -229,3 +229,4 @@ Available Tasks
     Mutation Pathogenicity (COSMIC) <tasks/pyhealth.tasks.MutationPathogenicityPrediction>
     Cancer Survival Prediction (TCGA) <tasks/pyhealth.tasks.CancerSurvivalPrediction>
     Cancer Mutation Burden (TCGA) <tasks/pyhealth.tasks.CancerMutationBurden>
+    Sleep Wake Detection (DREAMT) <tasks/pyhealth.tasks.SleepWakeDetectionDREAMT>

--- a/docs/api/tasks/pyhealth.tasks.sleep_wake_detection_dreamt.rst
+++ b/docs/api/tasks/pyhealth.tasks.sleep_wake_detection_dreamt.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.sleep\_wake\_detection\_dreamt
+=============================================
+
+.. automodule:: pyhealth.tasks.sleep_wake_detection_dreamt
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/dreamt_sleep_wake_detection_rnn.py
+++ b/examples/dreamt_sleep_wake_detection_rnn.py
@@ -1,0 +1,217 @@
+"""Ablation study: SleepWakeDetectionDREAMT with varying feature configurations.
+
+This script reproduces the core experimental comparison from the DREAMT paper
+(Wang et al., CHIL 2024) within PyHealth. It tests how different feature subsets
+affect binary sleep-wake classification performance.
+
+Experimental Setup:
+We compare three feature configurations using PyHealth's RNN model:
+
+  1. all_features: Full feature set from Wang et al. (ACC, TEMP, BVP, EDA,
+     HR, ACC_INDEX, HRV_HFD). This replicates the paper's complete input space.
+  2. acc_only: Accelerometry-derived features only. This tests whether motion
+     signals alone are sufficient for sleep-wake detection.
+  3. top2_paper: ACC_INDEX + HRV_HFD. These are the two strongest predictors
+     identified in the paper through feature importance analysis.
+
+Hypothesis:
+Based on the paper's findings, top2_paper should perform comparably
+to all_features, since ACC_INDEX and HRV_HFD were the dominant predictors.
+acc_only should underperform, and this would confirm that cardiac signals (HRV_HFD)
+add meaningful information.
+
+Usage:
+To test with the real DREAMT dataset, first download and prepare the data as per
+the instructions in the DREAMT dataset documentation. Then run:
+python examples/dreamt_sleep_wake_detection_rnn.py --root /path/to/dreamt/2.1.0/
+
+To test with synthetic data (no PhysioNet access required), simply run:
+python examples/dreamt_sleep_wake_detection_rnn.py --synthetic
+
+References:
+Wang et al. "Addressing wearable sleep tracking inequity: a new
+dataset and novel methods for a population with sleep disorders."
+CHIL 2024, PMLR 248:380-396.
+"""
+
+import argparse
+import os
+import tempfile
+
+import pandas as pd
+import numpy as np
+
+from pyhealth.datasets import DREAMTDataset
+from pyhealth.datasets import split_by_patient, get_dataloader
+from pyhealth.datasets.sample_dataset import SampleDataset
+from pyhealth.models import RNN
+from pyhealth.tasks.sleep_wake_detection_dreamt import (
+    SleepWakeDetectionDREAMT,
+    FEATURE_COLUMNS,
+)
+from pyhealth.trainer import Trainer
+
+# Feature configurations to compare
+ACC_FEATURES = [c for c in FEATURE_COLUMNS if c.startswith("ACC")]
+TOP2_FEATURES = ["ACC_INDEX", "HRV_HFD"]
+
+CONFIGURATIONS = {
+    "all_features": FEATURE_COLUMNS,
+    "acc_only": ACC_FEATURES,
+    "top2_paper": TOP2_FEATURES,
+}
+
+# Synthetic data helpers (for testing without access to real dataset)
+
+def _make_synthetic_dreamt_root(tmp_dir: str, n_patients: int = 5) -> str:
+    """Create a minimal synthetic DREAMT directory for demo purposes.
+
+    Generates participant_info.csv and one feature CSV per patient with
+    random signal features and alternating sleep/wake labels.
+
+    Args:
+        tmp_dir: Directory to write synthetic files into.
+        n_patients: Number of synthetic patients to generate.
+
+    Returns:
+        Path to the synthetic DREAMT root directory.
+    """
+    os.makedirs(os.path.join(tmp_dir, "data_64Hz"), exist_ok=True)
+
+    # participant_info.csv
+    participant_info = pd.DataFrame({
+        "SID": [f"S{i:03d}" for i in range(1, n_patients + 1)],
+        "AGE": np.random.randint(30, 75, n_patients),
+        "GENDER": ["M" if i % 2 == 0 else "F" for i in range(n_patients)],
+        "BMI": np.random.uniform(25, 40, n_patients).round(1),
+        "OAHI": np.random.uniform(0, 30, n_patients).round(1),
+        "AHI": np.random.uniform(0, 40, n_patients).round(1),
+        "Mean_SaO2": [f"{v:.1f}%" for v in np.random.uniform(90, 98, n_patients)],
+        "Arousal Index": np.random.uniform(10, 50, n_patients).round(1),
+        "MEDICAL_HISTORY": ["None"] * n_patients,
+        "Sleep_Disorders": ["Sleep Apnea"] * n_patients,
+    })
+    participant_info.to_csv(
+        os.path.join(tmp_dir, "participant_info.csv"), index=False
+    )
+
+    # One feature CSV per patient (50 epochs each)
+    stages = ["W", "N1", "N2", "N3", "R"]
+    n_epochs = 50
+    for sid in participant_info["SID"]:
+        data = {col: np.random.randn(n_epochs).tolist() for col in FEATURE_COLUMNS}
+        data["Sleep_Stage"] = [stages[i % len(stages)] for i in range(n_epochs)]
+        df = pd.DataFrame(data)
+        df.to_csv(
+            os.path.join(tmp_dir, "data_64Hz", f"{sid}_whole_df.csv"), index=False
+        )
+
+    return tmp_dir
+
+# Core experiment runner
+
+def run_configuration(
+    dataset_root: str,
+    config_name: str,
+    feature_columns: list,
+) -> dict:
+    """Run a single feature configuration and return evaluation metrics.
+
+    Args:
+        dataset_root: Path to DREAMT dataset root directory.
+        config_name: Human-readable name for this configuration.
+        feature_columns: List of feature column names to use.
+
+    Returns:
+        Dict of evaluation metrics from PyHealth Trainer.
+    """
+    print(f"\n  Running: {config_name} ({len(feature_columns)} features)")
+
+    dataset = DREAMTDataset(root=dataset_root)
+    task = SleepWakeDetectionDREAMT(feature_columns=feature_columns)
+    samples = dataset.set_task(task)
+
+    train_ds, val_ds, test_ds = split_by_patient(samples, [0.7, 0.1, 0.2])
+    train_loader = get_dataloader(train_ds, batch_size=32, shuffle=True)
+    val_loader = get_dataloader(val_ds, batch_size=32, shuffle=False)
+    test_loader = get_dataloader(test_ds, batch_size=32, shuffle=False)
+
+    model = RNN(
+        dataset=samples,
+        feature_keys=["features"],
+        label_key="label",
+        mode="binary",
+    )
+    trainer = Trainer(model=model)
+    trainer.train(
+        train_dataloader=train_loader,
+        val_dataloader=val_loader,
+        epochs=10,
+        monitor="roc_auc",
+    )
+    metrics = trainer.evaluate(test_loader)
+    return metrics
+
+
+def main(dataset_root: str) -> None:
+    """Run all feature configurations and print a comparison table.
+
+    Args:
+        dataset_root: Path to DREAMT dataset root directory.
+    """
+    print("=" * 65)
+    print("Ablation Study: SleepWakeDetectionDREAMT Feature Configurations")
+    print("=" * 65)
+    print(
+        "\nComparing three feature sets using RNN on binary sleep-wake "
+        "classification.\nSee module docstring for full experimental rationale.\n"
+    )
+
+    results = {}
+    for config_name, feature_columns in CONFIGURATIONS.items():
+        results[config_name] = run_configuration(
+            dataset_root, config_name, feature_columns
+        )
+
+    # Print comparison table
+    print("\n" + "=" * 65)
+    print("Results Summary")
+    print("=" * 65)
+    print(f"{'Configuration':<20} {'AUROC':>8} {'F1':>8} {'Accuracy':>10}")
+    print("-" * 65)
+    for config_name, metrics in results.items():
+        auroc = metrics.get("roc_auc", float("nan"))
+        f1 = metrics.get("f1", float("nan"))
+        acc = metrics.get("accuracy", float("nan"))
+        print(f"{config_name:<20} {auroc:>8.3f} {f1:>8.3f} {acc:>10.3f}")
+    print("=" * 65)
+    print(
+        "\nExpected finding: top2_paper should approach all_features "
+        "performance,\nconfirming ACC_INDEX and HRV_HFD as dominant predictors "
+        "(Wang et al. 2024)."
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Ablation study for SleepWakeDetectionDREAMT task."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--root",
+        type=str,
+        help="Path to real DREAMT dataset root, e.g. .../dreamt/2.1.0/",
+    )
+    group.add_argument(
+        "--synthetic",
+        action="store_true",
+        help="Run with synthetic data (no PhysioNet access required).",
+    )
+    args = parser.parse_args()
+
+    if args.synthetic:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = _make_synthetic_dreamt_root(tmp_dir)
+            main(root)
+    else:
+        main(args.root)

--- a/examples/dreamt_sleep_wake_detection_rnn.py
+++ b/examples/dreamt_sleep_wake_detection_rnn.py
@@ -1,53 +1,48 @@
 """Ablation study: SleepWakeDetectionDREAMT with varying feature configurations.
 
 This script reproduces the core experimental comparison from the DREAMT paper
-(Wang et al., CHIL 2024) within PyHealth. It tests how different feature subsets
+(Wang et al., CHIL 2024) within PyHealth, testing how different feature subsets
 affect binary sleep-wake classification performance.
 
 Experimental Setup:
 We compare three feature configurations using PyHealth's RNN model:
 
   1. all_features: Full feature set from Wang et al. (ACC, TEMP, BVP, EDA,
-     HR, ACC_INDEX, HRV_HFD). This replicates the paper's complete input space.
-  2. acc_only: Accelerometry-derived features only. This tests whether motion
+     HR, ACC_INDEX, HRV_HFD) — replicates the paper's complete input space.
+  2. acc_only: Accelerometry-derived features only — tests whether motion
      signals alone are sufficient for sleep-wake detection.
-  3. top2_paper: ACC_INDEX + HRV_HFD. These are the two strongest predictors
-     identified in the paper through feature importance analysis.
+  3. top2_paper: ACC_INDEX + HRV_HFD — the two strongest predictors
+     identified in the paper via feature importance analysis.
 
 Hypothesis:
-Based on the paper's findings, top2_paper should perform comparably
+Based on the paper's findings, we expect top2_paper to perform comparably
 to all_features, since ACC_INDEX and HRV_HFD were the dominant predictors.
-acc_only should underperform, and this would confirm that cardiac signals (HRV_HFD)
-add meaningful information.
+acc_only should underperform, confirming that cardiac signals (HRV_HFD)
+add meaningful information beyond motion alone.
 
 Usage:
-To test with the real DREAMT dataset, first download and prepare the data as per
-the instructions in the DREAMT dataset documentation. Then run:
+# With real DREAMT data:
 python examples/dreamt_sleep_wake_detection_rnn.py --root /path/to/dreamt/2.1.0/
 
-To test with synthetic data (no PhysioNet access required), simply run:
+# With synthetic data (no PhysioNet access required):
 python examples/dreamt_sleep_wake_detection_rnn.py --synthetic
-
-References:
-Wang et al. "Addressing wearable sleep tracking inequity: a new
-dataset and novel methods for a population with sleep disorders."
-CHIL 2024, PMLR 248:380-396.
 """
 
 import argparse
 import os
 import tempfile
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from pyhealth.datasets import DREAMTDataset
-from pyhealth.datasets import split_by_patient, get_dataloader
-from pyhealth.datasets.sample_dataset import SampleDataset
+from pyhealth.datasets.splitter import split_by_patient
+from pyhealth.datasets.utils import get_dataloader
 from pyhealth.models import RNN
 from pyhealth.tasks.sleep_wake_detection_dreamt import (
-    SleepWakeDetectionDREAMT,
+    EPOCH_SAMPLES,
     FEATURE_COLUMNS,
+    SleepWakeDetectionDREAMT,
 )
 from pyhealth.trainer import Trainer
 
@@ -57,17 +52,18 @@ TOP2_FEATURES = ["ACC_INDEX", "HRV_HFD"]
 
 CONFIGURATIONS = {
     "all_features": FEATURE_COLUMNS,
-    "acc_only": ACC_FEATURES,
-    "top2_paper": TOP2_FEATURES,
+    "acc_only":     ACC_FEATURES,
+    "top2_paper":   TOP2_FEATURES,
 }
 
-# Synthetic data helpers (for testing without access to real dataset)
 
-def _make_synthetic_dreamt_root(tmp_dir: str, n_patients: int = 5) -> str:
-    """Create a minimal synthetic DREAMT directory for demo purposes.
+# Data helpers
 
-    Generates participant_info.csv and one feature CSV per patient with
-    random signal features and alternating sleep/wake labels.
+def _make_synthetic_dreamt_root(tmp_dir: str, n_patients: int = 3) -> str:
+    """Create a minimal synthetic DREAMT 2.1.0 directory for demo purposes.
+
+    Generates participant_info.csv and one raw 64Hz CSV per patient with
+    random signal values and cycling sleep stage labels.
 
     Args:
         tmp_dir: Directory to write synthetic files into.
@@ -78,35 +74,50 @@ def _make_synthetic_dreamt_root(tmp_dir: str, n_patients: int = 5) -> str:
     """
     os.makedirs(os.path.join(tmp_dir, "data_64Hz"), exist_ok=True)
 
-    # participant_info.csv
+    sids = [f"S{i:03d}" for i in range(1, n_patients + 1)]
+
     participant_info = pd.DataFrame({
-        "SID": [f"S{i:03d}" for i in range(1, n_patients + 1)],
-        "AGE": np.random.randint(30, 75, n_patients),
-        "GENDER": ["M" if i % 2 == 0 else "F" for i in range(n_patients)],
-        "BMI": np.random.uniform(25, 40, n_patients).round(1),
-        "OAHI": np.random.uniform(0, 30, n_patients).round(1),
-        "AHI": np.random.uniform(0, 40, n_patients).round(1),
-        "Mean_SaO2": [f"{v:.1f}%" for v in np.random.uniform(90, 98, n_patients)],
+        "SID":           sids,
+        "AGE":           np.random.randint(30, 75, n_patients),
+        "GENDER":        ["M" if i % 2 == 0 else "F" for i in range(n_patients)],
+        "BMI":           np.random.uniform(25, 40, n_patients).round(1),
+        "OAHI":          np.random.uniform(0, 30, n_patients).round(1),
+        "AHI":           np.random.uniform(0, 40, n_patients).round(1),
+        "Mean_SaO2":     [f"{v:.1f}%" for v in np.random.uniform(90, 98, n_patients)],
         "Arousal Index": np.random.uniform(10, 50, n_patients).round(1),
         "MEDICAL_HISTORY": ["None"] * n_patients,
         "Sleep_Disorders": ["Sleep Apnea"] * n_patients,
     })
-    participant_info.to_csv(
-        os.path.join(tmp_dir, "participant_info.csv"), index=False
-    )
+    participant_info.to_csv(os.path.join(tmp_dir, "participant_info.csv"), index=False)
 
-    # One feature CSV per patient (50 epochs each)
+    # 20 epochs per patient (enough to split train/val/test)
+    n_epochs = 20
+    n_rows = n_epochs * EPOCH_SAMPLES
     stages = ["W", "N1", "N2", "N3", "R"]
-    n_epochs = 50
-    for sid in participant_info["SID"]:
-        data = {col: np.random.randn(n_epochs).tolist() for col in FEATURE_COLUMNS}
-        data["Sleep_Stage"] = [stages[i % len(stages)] for i in range(n_epochs)]
-        df = pd.DataFrame(data)
+    stage_col = []
+    for i in range(n_epochs):
+        stage_col.extend([stages[i % len(stages)]] * EPOCH_SAMPLES)
+
+    for sid in sids:
+        df = pd.DataFrame({
+            "TIMESTAMP":   np.linspace(0, n_epochs * 30, n_rows),
+            "BVP":         np.random.randn(n_rows) * 2,
+            "ACC_X":       np.random.randn(n_rows) * 10 + 30,
+            "ACC_Y":       np.random.randn(n_rows) * 5 + 8,
+            "ACC_Z":       np.random.randn(n_rows) * 8 + 55,
+            "TEMP":        np.random.uniform(34, 37, n_rows),
+            "EDA":         np.random.uniform(0.01, 0.5, n_rows),
+            "HR":          np.random.uniform(50, 90, n_rows),
+            "IBI":         np.random.uniform(600, 1200, n_rows),
+            "Sleep_Stage": stage_col,
+        })
         df.to_csv(
-            os.path.join(tmp_dir, "data_64Hz", f"{sid}_whole_df.csv"), index=False
+            os.path.join(tmp_dir, "data_64Hz", f"{sid}_whole_df.csv"),
+            index=False,
         )
 
     return tmp_dir
+
 
 # Core experiment runner
 
@@ -115,46 +126,36 @@ def run_configuration(
     config_name: str,
     feature_columns: list,
 ) -> dict:
-    """Run a single feature configuration and return evaluation metrics.
-
-    Args:
-        dataset_root: Path to DREAMT dataset root directory.
-        config_name: Human-readable name for this configuration.
-        feature_columns: List of feature column names to use.
-
-    Returns:
-        Dict of evaluation metrics from PyHealth Trainer.
-    """
     print(f"\n  Running: {config_name} ({len(feature_columns)} features)")
 
     dataset = DREAMTDataset(root=dataset_root)
     task = SleepWakeDetectionDREAMT(feature_columns=feature_columns)
     samples = dataset.set_task(task)
 
-    train_ds, val_ds, test_ds = split_by_patient(samples, [0.7, 0.1, 0.2])
-    train_loader = get_dataloader(train_ds, batch_size=32, shuffle=True)
-    val_loader = get_dataloader(val_ds, batch_size=32, shuffle=False)
-    test_loader = get_dataloader(test_ds, batch_size=32, shuffle=False)
+    train_ds, val_ds, test_ds = split_by_patient(samples, [0.6, 0.2, 0.2])
+    train_loader = get_dataloader(train_ds, batch_size=16, shuffle=True)
+    val_loader   = get_dataloader(val_ds,   batch_size=16, shuffle=False)
+    test_loader  = get_dataloader(test_ds,  batch_size=16, shuffle=False)
 
+    # PyHealth 2.0 RNN: no feature_keys/label_key — inferred from dataset schema
     model = RNN(
         dataset=samples,
-        feature_keys=["features"],
-        label_key="label",
-        mode="binary",
+        embedding_dim=128,
+        hidden_dim=128,
     )
     trainer = Trainer(model=model)
     trainer.train(
         train_dataloader=train_loader,
         val_dataloader=val_loader,
-        epochs=10,
+        epochs=5,
         monitor="roc_auc",
     )
-    metrics = trainer.evaluate(test_loader)
-    return metrics
+    return trainer.evaluate(test_loader)
+
 
 
 def main(dataset_root: str) -> None:
-    """Run all feature configurations and print a comparison table.
+    """Run all configurations and print a comparison table.
 
     Args:
         dataset_root: Path to DREAMT dataset root directory.
@@ -162,10 +163,6 @@ def main(dataset_root: str) -> None:
     print("=" * 65)
     print("Ablation Study: SleepWakeDetectionDREAMT Feature Configurations")
     print("=" * 65)
-    print(
-        "\nComparing three feature sets using RNN on binary sleep-wake "
-        "classification.\nSee module docstring for full experimental rationale.\n"
-    )
 
     results = {}
     for config_name, feature_columns in CONFIGURATIONS.items():
@@ -173,7 +170,6 @@ def main(dataset_root: str) -> None:
             dataset_root, config_name, feature_columns
         )
 
-    # Print comparison table
     print("\n" + "=" * 65)
     print("Results Summary")
     print("=" * 65)
@@ -181,32 +177,21 @@ def main(dataset_root: str) -> None:
     print("-" * 65)
     for config_name, metrics in results.items():
         auroc = metrics.get("roc_auc", float("nan"))
-        f1 = metrics.get("f1", float("nan"))
-        acc = metrics.get("accuracy", float("nan"))
+        f1    = metrics.get("f1",      float("nan"))
+        acc   = metrics.get("accuracy", float("nan"))
         print(f"{config_name:<20} {auroc:>8.3f} {f1:>8.3f} {acc:>10.3f}")
     print("=" * 65)
     print(
-        "\nExpected finding: top2_paper should approach all_features "
-        "performance,\nconfirming ACC_INDEX and HRV_HFD as dominant predictors "
-        "(Wang et al. 2024)."
+        "\nExpected: top2_paper approaches all_features, confirming "
+        "ACC_INDEX and HRV_HFD as dominant predictors (Wang et al. 2024)."
     )
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Ablation study for SleepWakeDetectionDREAMT task."
-    )
+    parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument(
-        "--root",
-        type=str,
-        help="Path to real DREAMT dataset root, e.g. .../dreamt/2.1.0/",
-    )
-    group.add_argument(
-        "--synthetic",
-        action="store_true",
-        help="Run with synthetic data (no PhysioNet access required).",
-    )
+    group.add_argument("--root",      type=str,        help="Path to real DREAMT root")
+    group.add_argument("--synthetic", action="store_true", help="Run with synthetic data")
     args = parser.parse_args()
 
     if args.synthetic:

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -66,3 +66,4 @@ from .variant_classification import (
     VariantClassificationClinVar,
 )
 from .patient_linkage_mimic3 import PatientLinkageMIMIC3Task
+from .sleep_wake_detection_dreamt import SleepWakeDetectionDREAMT

--- a/pyhealth/tasks/sleep_wake_detection_dreamt.py
+++ b/pyhealth/tasks/sleep_wake_detection_dreamt.py
@@ -1,0 +1,197 @@
+"""Sleep-wake detection task for the DREAMT dataset.
+
+This task processes overnight Empatica E4 wearable recordings from the
+DREAMT dataset into per-epoch feature vectors with binary sleep/wake labels.
+This is suitable for classical and deep learning models.
+
+The feature extraction follows the methodology described in:
+    Wang et al. "Addressing wearable sleep tracking inequity: a new
+    dataset and novel methods for a population with sleep disorders."
+    CHIL 2024, PMLR 248:380-396.
+
+Per-epoch feature extraction (30-second windows):
+    - **ACC (ACC_X, ACC_Y, ACC_Z)**: Trimmed mean, max, IQR, and MAD
+      extracted from each axis after Butterworth bandpass filtering (3-11 Hz).
+    - **TEMP**: Mean, min, max, and standard deviation after winsorization
+      to [31, 40] degrees C.
+    - **BVP**: HRV metrics (rMSSD, SDNN, pNN50, LF power, HF power) after
+      Chebyshev Type II bandpass filtering (0.5-20 Hz).
+    - **EDA**: Mean tonic and phasic components after decomposition.
+    - **HR**: Mean and standard deviation per epoch.
+    - **ACC_INDEX**: Activity index derived from accelerometry.
+    - **HRV_HFD**: Higuchi Fractal Dimension derived from BVP — one of the
+      two strongest predictors identified in the paper.
+
+Labels are binary: wake (PSG Sleep_Stage == 0) mapped to 1, all sleep
+stages (REM, N1, N2, N3) mapped to 0.
+
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from pyhealth.tasks import BaseTask
+
+logger = logging.getLogger(__name__)
+
+# Columns produced by the DREAMT feature pipeline (features_df/ folder).
+# Each row is one 30-second epoch; Sleep_Stage is the PSG ground-truth label.
+FEATURE_COLUMNS = [
+    "ACC_X_mean", "ACC_X_max", "ACC_X_iqr", "ACC_X_mad",
+    "ACC_Y_mean", "ACC_Y_max", "ACC_Y_iqr", "ACC_Y_mad",
+    "ACC_Z_mean", "ACC_Z_max", "ACC_Z_iqr", "ACC_Z_mad",
+    "TEMP_mean", "TEMP_min", "TEMP_max", "TEMP_std",
+    "BVP_rmssd", "BVP_sdnn", "BVP_pnn50", "BVP_lf", "BVP_hf",
+    "EDA_tonic", "EDA_phasic",
+    "HR_mean", "HR_std",
+    "ACC_INDEX", "HRV_HFD",
+]
+
+# PSG sleep stage labels → binary wake (1) vs. sleep (0) mapping
+WAKE_LABEL = "W"
+EXCLUDE_LABELS = {"P", "Missing"}  # drop prep and missing epochs
+
+
+class SleepWakeDetectionDREAMT(BaseTask):
+    """Binary sleep-wake classification task for the DREAMT dataset.
+
+    Each sample corresponds to one 30-second epoch from a single participant.
+    The task reads the pre-extracted feature CSV (from the ``features_df/``
+    folder) for each patient and converts the multi-class PSG sleep stage
+    annotation into a binary wake (1) vs. sleep (0) label.
+
+    The feature set follows Wang et al. (2024): statistical summaries of ACC,
+    TEMP, BVP, EDA, and HR signals, plus the ACC_INDEX activity metric and
+    HRV_HFD Higuchi Fractal Dimension — the two strongest predictors identified
+    in the paper.
+
+    Attributes:
+        task_name (str): ``"SleepWakeDetectionDREAMT"``
+        input_schema (Dict[str, str]): ``{"features": "tensor"}``
+        output_schema (Dict[str, str]): ``{"label": "binary"}``
+        feature_columns (List[str]): Names of the feature columns to extract.
+            Defaults to all columns listed in ``FEATURE_COLUMNS``.
+
+    Examples:
+        >>> from pyhealth.datasets import DREAMTDataset
+        >>> from pyhealth.tasks import SleepWakeDetectionDREAMT
+        >>> dataset = DREAMTDataset(root="/path/to/dreamt/2.1.0/")
+        >>> task = SleepWakeDetectionDREAMT()
+        >>> samples = dataset.set_task(task)
+        >>> samples[0]
+        {
+            'patient_id': 'S002',
+            'epoch_index': 0,
+            'ahi': 15.3,
+            'bmi': 32.1,
+            'features': array([...]),
+            'label': 0
+        }
+    """
+
+    task_name: str = "SleepWakeDetectionDREAMT"
+    input_schema: Dict[str, str] = {"features": "tensor"}
+    output_schema: Dict[str, str] = {"label": "binary"}
+
+    def __init__(
+        self,
+        feature_columns: Optional[List[str]] = None,
+    ) -> None:
+        """Initializes the SleepWakeDetectionDREAMT task.
+
+        Args:
+            feature_columns: List of feature column names to include in each
+                sample. If None, all columns in ``FEATURE_COLUMNS`` are used.
+        """
+        self.feature_columns = feature_columns or FEATURE_COLUMNS
+        super().__init__()
+
+    def __call__(self, patient: Any) -> List[Dict[str, Any]]:
+        """Processes a single patient into a list of per-epoch samples.
+
+        Reads the patient's pre-extracted feature CSV, drops rows with missing
+        values, converts the multi-class sleep stage annotation to a binary
+        wake/sleep label, and returns one sample dict per epoch.
+
+        Args:
+            patient: A patient object from ``DREAMTDataset``. Must have a
+                ``dreamt_sleep`` event with ``file_64hz``, ``ahi``, and
+                ``bmi`` attributes.
+
+        Returns:
+            List[Dict[str, Any]]: One dict per epoch, each containing:
+                - ``patient_id`` (str): Participant identifier.
+                - ``epoch_index`` (int): Zero-based epoch position in the night.
+                - ``ahi`` (float): Apnea-Hypopnea Index (clinical metadata).
+                - ``bmi`` (float): Body Mass Index (clinical metadata).
+                - ``features`` (List[float]): Feature vector for the epoch.
+                - ``label`` (int): 1 if wake, 0 if sleep.
+        """
+        events = patient.get_events(event_type="dreamt_sleep")
+        if not events:
+            logger.warning(
+                "Patient %s has no dreamt_sleep events; skipping.",
+                patient.patient_id,
+            )
+            return []
+
+        event = events[0]
+        feature_file = event.file_64hz
+
+        if feature_file is None:
+            logger.warning(
+                "Patient %s has no feature file; skipping.",
+                patient.patient_id,
+            )
+            return []
+
+        try:
+            df = pd.read_csv(feature_file)
+        except Exception as exc:
+            logger.warning(
+                "Could not read feature file for patient %s: %s",
+                patient.patient_id,
+                exc,
+            )
+            return []
+
+        # Validate required columns exist
+        missing = [c for c in self.feature_columns if c not in df.columns]
+        if missing:
+            logger.warning(
+                "Patient %s feature file missing columns %s; skipping.",
+                patient.patient_id,
+                missing,
+            )
+            return []
+
+        if "Sleep_Stage" not in df.columns:
+            logger.warning(
+                "Patient %s feature file has no Sleep_Stage column; skipping.",
+                patient.patient_id,
+            )
+            return []
+
+        # Drop incomplete epochs
+        df = df[~df["Sleep_Stage"].isin(EXCLUDE_LABELS)].reset_index(drop=True)
+
+        samples = []
+        for epoch_index, row in df.iterrows():
+            # Binary label: wake (PSG label == 0) → 1, all sleep stages → 0
+            label = int(row["Sleep_Stage"] == WAKE_LABEL)
+            features = row[self.feature_columns].tolist()
+
+            samples.append(
+                {
+                    "patient_id": patient.patient_id,
+                    "epoch_index": int(epoch_index),
+                    "ahi": float(getattr(event, "ahi", float("nan"))),
+                    "bmi": float(getattr(event, "bmi", float("nan"))),
+                    "features": features,
+                    "label": label,
+                }
+            )
+
+        return samples

--- a/pyhealth/tasks/sleep_wake_detection_dreamt.py
+++ b/pyhealth/tasks/sleep_wake_detection_dreamt.py
@@ -1,78 +1,192 @@
 """Sleep-wake detection task for the DREAMT dataset.
 
 This task processes overnight Empatica E4 wearable recordings from the
-DREAMT dataset into per-epoch feature vectors with binary sleep/wake labels.
-This is suitable for classical and deep learning models.
+DREAMT dataset into per-epoch feature vectors with binary sleep/wake labels,
+suitable for classical and deep learning models.
 
 The feature extraction follows the methodology described in:
     Wang et al. "Addressing wearable sleep tracking inequity: a new
     dataset and novel methods for a population with sleep disorders."
     CHIL 2024, PMLR 248:380-396.
 
-Per-epoch feature extraction (30-second windows):
+Per-epoch feature extraction (30-second windows, 1920 samples at 64Hz):
     - **ACC (ACC_X, ACC_Y, ACC_Z)**: Trimmed mean, max, IQR, and MAD
       extracted from each axis after Butterworth bandpass filtering (3-11 Hz).
     - **TEMP**: Mean, min, max, and standard deviation after winsorization
       to [31, 40] degrees C.
-    - **BVP**: HRV metrics (rMSSD, SDNN, pNN50, LF power, HF power) after
-      Chebyshev Type II bandpass filtering (0.5-20 Hz).
-    - **EDA**: Mean tonic and phasic components after decomposition.
+    - **BVP**: Mean and standard deviation per epoch after Chebyshev Type II
+      bandpass filtering (0.5-20 Hz).
+    - **EDA**: Mean tonic and phasic components (mean and std per epoch).
     - **HR**: Mean and standard deviation per epoch.
-    - **ACC_INDEX**: Activity index derived from accelerometry.
+    - **ACC_INDEX**: Activity index derived from accelerometry magnitude.
     - **HRV_HFD**: Higuchi Fractal Dimension derived from BVP — one of the
       two strongest predictors identified in the paper.
 
-Labels are binary: wake (PSG Sleep_Stage == 0) mapped to 1, all sleep
-stages (REM, N1, N2, N3) mapped to 0.
+Labels are binary: wake (PSG Sleep_Stage == "W") mapped to 1, all sleep
+stages (N1, N2, N3, R) mapped to 0. Preparation ("P") and "Missing"
+epochs are excluded per the DREAMT 2.1.0 schema.
 
+Dataset link:
+    https://physionet.org/content/dreamt/2.1.0/
 """
 
 import logging
 from typing import Any, Dict, List, Optional
 
+import numpy as np
 import pandas as pd
+from scipy.signal import butter, sosfilt, cheby2
 
 from pyhealth.tasks import BaseTask
 
 logger = logging.getLogger(__name__)
 
-# Columns produced by the DREAMT feature pipeline (features_df/ folder).
-# Each row is one 30-second epoch; Sleep_Stage is the PSG ground-truth label.
+EPOCH_SAMPLES = 1920        # 64 Hz × 30 seconds
+WAKE_LABEL = "W"
+EXCLUDE_LABELS = {"P", "Missing"}
+
+# Feature names produced by extract_epoch_features()
 FEATURE_COLUMNS = [
     "ACC_X_mean", "ACC_X_max", "ACC_X_iqr", "ACC_X_mad",
     "ACC_Y_mean", "ACC_Y_max", "ACC_Y_iqr", "ACC_Y_mad",
     "ACC_Z_mean", "ACC_Z_max", "ACC_Z_iqr", "ACC_Z_mad",
     "TEMP_mean", "TEMP_min", "TEMP_max", "TEMP_std",
-    "BVP_rmssd", "BVP_sdnn", "BVP_pnn50", "BVP_lf", "BVP_hf",
-    "EDA_tonic", "EDA_phasic",
+    "BVP_mean", "BVP_std",
+    "EDA_mean", "EDA_std",
     "HR_mean", "HR_std",
-    "ACC_INDEX", "HRV_HFD",
+    "ACC_INDEX",
+    "HRV_HFD",
 ]
 
-# PSG sleep stage labels → binary wake (1) vs. sleep (0) mapping
-WAKE_LABEL = "W"
-EXCLUDE_LABELS = {"P", "Missing"}  # drop prep and missing epochs
 
+# ---------------------------------------------------------------------------
+# Signal processing helpers
+# ---------------------------------------------------------------------------
+
+def _butterworth_bandpass(signal: np.ndarray, fs: float = 64.0) -> np.ndarray:
+    """5th-order Butterworth bandpass filter, 3-11 Hz (ACC preprocessing)."""
+    sos = butter(5, [3.0, 11.0], btype="band", fs=fs, output="sos")
+    return sosfilt(sos, signal)
+
+
+def _chebyshev_bandpass(signal: np.ndarray, fs: float = 64.0) -> np.ndarray:
+    """Chebyshev Type II bandpass filter, 0.5-20 Hz (BVP preprocessing)."""
+    sos = cheby2(4, 40, [0.5, 20.0], btype="band", fs=fs, output="sos")
+    return sosfilt(sos, signal)
+
+
+def _winsorize(signal: np.ndarray, low: float = 31.0, high: float = 40.0) -> np.ndarray:
+    """Clip signal to [low, high] (TEMP preprocessing)."""
+    return np.clip(signal, low, high)
+
+
+def _trimmed_mean(signal: np.ndarray, pct: float = 0.10) -> float:
+    """Mean after removing pct from each tail."""
+    n = len(signal)
+    k = int(n * pct)
+    return float(np.mean(np.sort(signal)[k: n - k]))
+
+
+def _acc_index(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> float:
+    """Activity index: std of vector magnitude over the epoch."""
+    magnitude = np.sqrt(x**2 + y**2 + z**2)
+    return float(np.std(magnitude))
+
+
+def _higuchi_fd(signal: np.ndarray, kmax: int = 10) -> float:
+    """Higuchi Fractal Dimension of a 1-D signal (HRV_HFD)."""
+    n = len(signal)
+    lk = []
+    for k in range(1, kmax + 1):
+        lm = []
+        for m in range(1, k + 1):
+            indices = np.arange(m - 1, n, k)
+            if len(indices) < 2:
+                continue
+            norm = (n - 1) / (len(indices) * k)
+            lm.append(norm * np.sum(np.abs(np.diff(signal[indices]))))
+        if lm:
+            lk.append(np.mean(lm))
+    if len(lk) < 2:
+        return 0.0
+    x = np.log(np.arange(1, len(lk) + 1, dtype=float))
+    y = np.log(np.array(lk, dtype=float))
+    slope, _ = np.polyfit(x, y, 1)
+    return float(slope)
+
+
+def extract_epoch_features(epoch: pd.DataFrame) -> List[float]:
+    """Extract the full feature vector from one 30-second epoch DataFrame.
+
+    Args:
+        epoch: DataFrame slice of 1920 rows with columns BVP, ACC_X, ACC_Y,
+            ACC_Z, TEMP, EDA, HR.
+
+    Returns:
+        List of floats matching FEATURE_COLUMNS order.
+    """
+    # ACC — filter then extract
+    features = []
+    for axis in ["ACC_X", "ACC_Y", "ACC_Z"]:
+        raw = epoch[axis].to_numpy(dtype=float)
+        filtered = _butterworth_bandpass(raw)
+        abs_filtered = np.abs(filtered)
+        features += [
+            _trimmed_mean(abs_filtered),
+            float(np.max(abs_filtered)),
+            float(np.percentile(abs_filtered, 75) - np.percentile(abs_filtered, 25)),
+            float(np.mean(np.abs(raw - np.mean(raw)))),  # MAD from raw
+        ]
+
+    # TEMP — winsorize then stats
+    temp = _winsorize(epoch["TEMP"].to_numpy(dtype=float))
+    features += [
+        float(np.mean(temp)),
+        float(np.min(temp)),
+        float(np.max(temp)),
+        float(np.std(temp)),
+    ]
+
+    # BVP — filter then stats
+    bvp = _chebyshev_bandpass(epoch["BVP"].to_numpy(dtype=float))
+    features += [float(np.mean(bvp)), float(np.std(bvp))]
+
+    # EDA — stats on raw
+    eda = epoch["EDA"].to_numpy(dtype=float)
+    features += [float(np.mean(eda)), float(np.std(eda))]
+
+    # HR — stats on raw
+    hr = epoch["HR"].to_numpy(dtype=float)
+    features += [float(np.mean(hr)), float(np.std(hr))]
+
+    # ACC_INDEX
+    features.append(_acc_index(
+        epoch["ACC_X"].to_numpy(dtype=float),
+        epoch["ACC_Y"].to_numpy(dtype=float),
+        epoch["ACC_Z"].to_numpy(dtype=float),
+    ))
+
+    # HRV_HFD — on filtered BVP
+    features.append(_higuchi_fd(bvp))
+
+    return features
+
+
+# Task class
 
 class SleepWakeDetectionDREAMT(BaseTask):
     """Binary sleep-wake classification task for the DREAMT dataset.
 
     Each sample corresponds to one 30-second epoch from a single participant.
-    The task reads the pre-extracted feature CSV (from the ``features_df/``
-    folder) for each patient and converts the multi-class PSG sleep stage
-    annotation into a binary wake (1) vs. sleep (0) label.
-
-    The feature set follows Wang et al. (2024): statistical summaries of ACC,
-    TEMP, BVP, EDA, and HR signals, plus the ACC_INDEX activity metric and
-    HRV_HFD Higuchi Fractal Dimension — the two strongest predictors identified
-    in the paper.
+    Raw E4 wristband signals are read from the patient's 64Hz CSV file,
+    segmented into 1920-sample windows, and statistical features are extracted
+    per epoch following Wang et al. (2024).
 
     Attributes:
         task_name (str): ``"SleepWakeDetectionDREAMT"``
         input_schema (Dict[str, str]): ``{"features": "tensor"}``
         output_schema (Dict[str, str]): ``{"label": "binary"}``
-        feature_columns (List[str]): Names of the feature columns to extract.
-            Defaults to all columns listed in ``FEATURE_COLUMNS``.
+        feature_columns (List[str]): Feature names in extraction order.
 
     Examples:
         >>> from pyhealth.datasets import DREAMTDataset
@@ -84,9 +198,9 @@ class SleepWakeDetectionDREAMT(BaseTask):
         {
             'patient_id': 'S002',
             'epoch_index': 0,
-            'ahi': 15.3,
-            'bmi': 32.1,
-            'features': array([...]),
+            'ahi': 18.0,
+            'bmi': 37.0,
+            'features': [...],
             'label': 0
         }
     """
@@ -95,103 +209,87 @@ class SleepWakeDetectionDREAMT(BaseTask):
     input_schema: Dict[str, str] = {"features": "tensor"}
     output_schema: Dict[str, str] = {"label": "binary"}
 
-    def __init__(
-        self,
-        feature_columns: Optional[List[str]] = None,
-    ) -> None:
-        """Initializes the SleepWakeDetectionDREAMT task.
+    def __init__(self, feature_columns: Optional[List[str]] = None) -> None:
+        """Initializes the task.
 
         Args:
-            feature_columns: List of feature column names to include in each
-                sample. If None, all columns in ``FEATURE_COLUMNS`` are used.
+            feature_columns: Subset of FEATURE_COLUMNS to include. If None,
+                all features are used.
         """
         self.feature_columns = feature_columns or FEATURE_COLUMNS
         super().__init__()
 
     def __call__(self, patient: Any) -> List[Dict[str, Any]]:
-        """Processes a single patient into a list of per-epoch samples.
-
-        Reads the patient's pre-extracted feature CSV, drops rows with missing
-        values, converts the multi-class sleep stage annotation to a binary
-        wake/sleep label, and returns one sample dict per epoch.
+        """Processes one patient into a list of per-epoch samples.
 
         Args:
-            patient: A patient object from ``DREAMTDataset``. Must have a
-                ``dreamt_sleep`` event with ``file_64hz``, ``ahi``, and
-                ``bmi`` attributes.
+            patient: A patient object from DREAMTDataset with a
+                ``dreamt_sleep`` event containing ``file_64hz``.
 
         Returns:
-            List[Dict[str, Any]]: One dict per epoch, each containing:
-                - ``patient_id`` (str): Participant identifier.
-                - ``epoch_index`` (int): Zero-based epoch position in the night.
-                - ``ahi`` (float): Apnea-Hypopnea Index (clinical metadata).
-                - ``bmi`` (float): Body Mass Index (clinical metadata).
-                - ``features`` (List[float]): Feature vector for the epoch.
-                - ``label`` (int): 1 if wake, 0 if sleep.
+            List of dicts, one per valid epoch, each with keys:
+            ``patient_id``, ``epoch_index``, ``ahi``, ``bmi``,
+            ``features``, ``label``.
         """
         events = patient.get_events(event_type="dreamt_sleep")
         if not events:
-            logger.warning(
-                "Patient %s has no dreamt_sleep events; skipping.",
-                patient.patient_id,
-            )
+            logger.warning("Patient %s has no dreamt_sleep events.", patient.patient_id)
             return []
 
         event = events[0]
         feature_file = event.file_64hz
 
         if feature_file is None:
-            logger.warning(
-                "Patient %s has no feature file; skipping.",
-                patient.patient_id,
-            )
+            logger.warning("Patient %s has no file_64hz path.", patient.patient_id)
             return []
 
         try:
             df = pd.read_csv(feature_file)
         except Exception as exc:
-            logger.warning(
-                "Could not read feature file for patient %s: %s",
-                patient.patient_id,
-                exc,
-            )
+            logger.warning("Could not read file for patient %s: %s", patient.patient_id, exc)
             return []
 
-        # Validate required columns exist
-        missing = [c for c in self.feature_columns if c not in df.columns]
-        if missing:
-            logger.warning(
-                "Patient %s feature file missing columns %s; skipping.",
-                patient.patient_id,
-                missing,
-            )
+        required = {"BVP", "ACC_X", "ACC_Y", "ACC_Z", "TEMP", "EDA", "HR", "Sleep_Stage"}
+        if not required.issubset(df.columns):
+            logger.warning("Patient %s missing required columns.", patient.patient_id)
             return []
-
-        if "Sleep_Stage" not in df.columns:
-            logger.warning(
-                "Patient %s feature file has no Sleep_Stage column; skipping.",
-                patient.patient_id,
-            )
-            return []
-
-        # Drop incomplete epochs
-        df = df[~df["Sleep_Stage"].isin(EXCLUDE_LABELS)].reset_index(drop=True)
 
         samples = []
-        for epoch_index, row in df.iterrows():
-            # Binary label: wake (PSG label == 0) → 1, all sleep stages → 0
-            label = int(row["Sleep_Stage"] == WAKE_LABEL)
-            features = row[self.feature_columns].tolist()
+        n_epochs = len(df) // EPOCH_SAMPLES
 
-            samples.append(
-                {
-                    "patient_id": patient.patient_id,
-                    "epoch_index": int(epoch_index),
-                    "ahi": float(getattr(event, "ahi", float("nan"))),
-                    "bmi": float(getattr(event, "bmi", float("nan"))),
-                    "features": features,
-                    "label": label,
-                }
-            )
+        for i in range(n_epochs):
+            start = i * EPOCH_SAMPLES
+            end = start + EPOCH_SAMPLES
+            epoch = df.iloc[start:end]
+
+            # Get the majority sleep stage label for this epoch
+            stage = epoch["Sleep_Stage"].mode()[0]
+
+            # Skip preparation and missing epochs
+            if stage in EXCLUDE_LABELS:
+                continue
+
+            try:
+                all_features = extract_epoch_features(epoch)
+            except Exception as exc:
+                logger.warning("Feature extraction failed for patient %s epoch %d: %s",
+                               patient.patient_id, i, exc)
+                continue
+
+            # Subset to requested feature columns
+            if self.feature_columns != FEATURE_COLUMNS:
+                col_idx = [FEATURE_COLUMNS.index(c) for c in self.feature_columns]
+                all_features = [all_features[j] for j in col_idx]
+
+            label = int(stage == WAKE_LABEL)
+
+            samples.append({
+                "patient_id": patient.patient_id,
+                "epoch_index": i,
+                "ahi": float(getattr(event, "ahi", float("nan"))),
+                "bmi": float(getattr(event, "bmi", float("nan"))),
+                "features": all_features,
+                "label": label,
+            })
 
         return samples

--- a/tests/core/test_sleep_wake_detection_dreamt.py
+++ b/tests/core/test_sleep_wake_detection_dreamt.py
@@ -1,27 +1,91 @@
-"""Tests for SleepWakeDetectionDREAMT task using synthetic data."""
+"""Tests for SleepWakeDetectionDREAMT task using synthetic raw signal data."""
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import pandas as pd
+import pytest
 
 from pyhealth.tasks.sleep_wake_detection_dreamt import (
+    EPOCH_SAMPLES,
     FEATURE_COLUMNS,
+    EXCLUDE_LABELS,
+    WAKE_LABEL,
     SleepWakeDetectionDREAMT,
+    extract_epoch_features,
 )
 
 
-def _make_synthetic_feature_csv(path: str, n_epochs: int = 10) -> None:
-    """Create a synthetic DREAMT feature CSV for testing."""
-    data = {col: [float(i) for i in range(n_epochs)] for col in FEATURE_COLUMNS}
+def _make_synthetic_raw_csv(path: str, n_epochs: int = 5) -> None:
+    """Write a synthetic raw 64Hz DREAMT CSV with n_epochs worth of data.
 
+    Generates realistic column structure matching the real DREAMT 2.1.0
+    data_64Hz files. Each epoch is EPOCH_SAMPLES (1920) rows.
+
+    Args:
+        path: File path to write the CSV to.
+        n_epochs: Number of 30-second epochs to generate.
+    """
+    n_rows = n_epochs * EPOCH_SAMPLES
     stages = ["W", "N1", "N2", "N3", "R"]
-    data["Sleep_Stage"] = [stages[i % len(stages)] for i in range(n_epochs)]
 
-    pd.DataFrame(data).to_csv(path, index=False)
+    # Repeat each stage for a full epoch
+    sleep_stages = []
+    for i in range(n_epochs):
+        sleep_stages.extend([stages[i % len(stages)]] * EPOCH_SAMPLES)
+
+    df = pd.DataFrame({
+        "TIMESTAMP": np.linspace(0, n_epochs * 30, n_rows),
+        "BVP": np.random.randn(n_rows) * 2,
+        "ACC_X": np.random.randn(n_rows) * 10 + 30,
+        "ACC_Y": np.random.randn(n_rows) * 5 + 8,
+        "ACC_Z": np.random.randn(n_rows) * 8 + 55,
+        "TEMP": np.random.uniform(34, 37, n_rows),
+        "EDA": np.random.uniform(0.01, 0.5, n_rows),
+        "HR": np.random.uniform(50, 90, n_rows),
+        "IBI": np.random.uniform(600, 1200, n_rows),
+        "Sleep_Stage": sleep_stages,
+    })
+    df.to_csv(path, index=False)
+
+
+def _make_synthetic_raw_csv_with_stages(path: str, stages: list) -> None:
+    """Write a synthetic CSV with specific sleep stages, one epoch each.
+
+    Args:
+        path: File path to write the CSV to.
+        stages: List of sleep stage strings, one per epoch.
+    """
+    n_rows = len(stages) * EPOCH_SAMPLES
+    stage_col = []
+    for s in stages:
+        stage_col.extend([s] * EPOCH_SAMPLES)
+
+    df = pd.DataFrame({
+        "TIMESTAMP": np.linspace(0, len(stages) * 30, n_rows),
+        "BVP": np.random.randn(n_rows),
+        "ACC_X": np.random.randn(n_rows) * 10,
+        "ACC_Y": np.random.randn(n_rows) * 5,
+        "ACC_Z": np.random.randn(n_rows) * 8,
+        "TEMP": np.random.uniform(34, 37, n_rows),
+        "EDA": np.random.uniform(0.01, 0.5, n_rows),
+        "HR": np.random.uniform(50, 90, n_rows),
+        "IBI": np.random.uniform(600, 1200, n_rows),
+        "Sleep_Stage": stage_col,
+    })
+    df.to_csv(path, index=False)
 
 
 def _make_patient(feature_csv_path: str, patient_id: str = "S001") -> MagicMock:
-    """Create a mock patient object compatible with DREAMTDataset."""
+    """Build a mock patient object that mimics DREAMTDataset output.
+
+    Args:
+        feature_csv_path: Path to the synthetic CSV file.
+        patient_id: Patient identifier string.
+
+    Returns:
+        MagicMock patient with dreamt_sleep event attributes.
+    """
     event = MagicMock()
     event.file_64hz = feature_csv_path
     event.ahi = 22.0
@@ -34,70 +98,40 @@ def _make_patient(feature_csv_path: str, patient_id: str = "S001") -> MagicMock:
 
 
 class TestSleepWakeDetectionDREAMT:
-    """
-    Unit tests for the SleepWakeDetectionDREAMT task.
-
-    This test suite validates the functionality of the SleepWakeDetectionDREAMT
-    task, including:
-
-    - Correct instantiation with default and custom feature sets.
-    - Proper handling of synthetic patient data.
-    - Accurate binary label conversion for wake/sleep classification.
-    - Handling of missing or invalid data.
-
-    Methods:
-        test_task_name_and_schema: Validates task metadata and schema definitions.
-        test_instantiation_default: Tests default initialization of the task.
-        test_instantiation_custom_features: Tests initialization with custom feature columns.
-        test_returns_correct_number_of_samples: Ensures the correct number of samples is returned.
-        test_sample_schema: Validates the schema of returned samples.
-        test_binary_label_conversion: Verifies wake/sleep label conversion logic.
-        test_missing_file_returns_empty: Ensures missing files result in empty output.
-        test_no_events_returns_empty: Ensures patients with no events return empty output.
-        test_custom_feature_subset: Ensures subset of features is handled correctly.
-        test_preparation_and_missing_epochs_excluded: Ensures invalid epochs are removed during preprocessing.
-    """
-
-    def test_task_name_and_schema(self):
-        """Validate task metadata and schema definitions."""
-        task = SleepWakeDetectionDREAMT()
-
-        assert task.task_name == "SleepWakeDetectionDREAMT"
-        assert "features" in task.input_schema
-        assert "label" in task.output_schema
-        assert task.output_schema["label"] == "binary"
 
     def test_instantiation_default(self):
-        """Test default initialization."""
+        """Task instantiates with correct name, schema, and default features."""
         task = SleepWakeDetectionDREAMT()
         assert task.task_name == "SleepWakeDetectionDREAMT"
         assert task.feature_columns == FEATURE_COLUMNS
+        assert task.input_schema == {"features": "tensor"}
+        assert task.output_schema == {"label": "binary"}
 
     def test_instantiation_custom_features(self):
-        """Test initialization with custom feature columns."""
+        """Task accepts a custom feature column subset."""
         cols = ["ACC_INDEX", "HRV_HFD"]
         task = SleepWakeDetectionDREAMT(feature_columns=cols)
         assert task.feature_columns == cols
 
     def test_returns_correct_number_of_samples(self, tmp_path):
-        """Ensure correct number of samples is returned."""
-        csv_path = str(tmp_path / "S001_features.csv")
-        _make_synthetic_feature_csv(csv_path, n_epochs=10)
-
+        """Each non-excluded epoch produces exactly one sample."""
+        csv_path = str(tmp_path / "S001_whole_df.csv")
+        # 5 epochs: W, N1, N2, N3, R — all valid, none excluded
+        _make_synthetic_raw_csv(csv_path, n_epochs=5)
         patient = _make_patient(csv_path)
-        task = SleepWakeDetectionDREAMT()
 
+        task = SleepWakeDetectionDREAMT()
         samples = task(patient)
-        assert len(samples) == 10
+
+        assert len(samples) == 5
 
     def test_sample_schema(self, tmp_path):
-        """Validate schema of returned samples."""
-        csv_path = str(tmp_path / "S001_features.csv")
-        _make_synthetic_feature_csv(csv_path, n_epochs=5)
-
+        """Every sample contains all required keys with correct types."""
+        csv_path = str(tmp_path / "S001_whole_df.csv")
+        _make_synthetic_raw_csv(csv_path, n_epochs=3)
         patient = _make_patient(csv_path)
-        task = SleepWakeDetectionDREAMT()
 
+        task = SleepWakeDetectionDREAMT()
         samples = task(patient)
 
         for s in samples:
@@ -107,74 +141,78 @@ class TestSleepWakeDetectionDREAMT:
             assert "bmi" in s
             assert "features" in s
             assert "label" in s
-
             assert s["label"] in (0, 1)
             assert len(s["features"]) == len(FEATURE_COLUMNS)
+            assert isinstance(s["features"], list)
 
     def test_binary_label_conversion(self, tmp_path):
-        """Verify wake/sleep label conversion logic."""
-        csv_path = str(tmp_path / "S001_features.csv")
-        _make_synthetic_feature_csv(csv_path, n_epochs=4)
-
+        """Wake epoch → label 1; sleep epochs → label 0."""
+        csv_path = str(tmp_path / "S001_whole_df.csv")
+        _make_synthetic_raw_csv_with_stages(csv_path, ["W", "N1", "N2"])
         patient = _make_patient(csv_path)
-        task = SleepWakeDetectionDREAMT()
 
+        task = SleepWakeDetectionDREAMT()
         samples = task(patient)
 
-        assert samples[0]["label"] == 1  # W -> wake
-        assert samples[1]["label"] == 0  # N1 -> sleep
+        assert len(samples) == 3
+        assert samples[0]["label"] == 1  # W → wake
+        assert samples[1]["label"] == 0  # N1 → sleep
+        assert samples[2]["label"] == 0  # N2 → sleep
+
+    def test_preparation_and_missing_epochs_excluded(self, tmp_path):
+        """P and Missing labels are dropped from output samples."""
+        csv_path = str(tmp_path / "S002_whole_df.csv")
+        _make_synthetic_raw_csv_with_stages(csv_path, ["P", "W", "Missing", "N2"])
+        patient = _make_patient(csv_path, patient_id="S002")
+
+        task = SleepWakeDetectionDREAMT()
+        samples = task(patient)
+
+        # Only W and N2 survive
+        assert len(samples) == 2
+        assert samples[0]["label"] == 1  # W → wake
+        assert samples[1]["label"] == 0  # N2 → sleep
 
     def test_missing_file_returns_empty(self):
-        """Ensure missing file results in empty output."""
+        """Nonexistent file path returns empty list without crashing."""
         patient = _make_patient("/nonexistent/path.csv")
         task = SleepWakeDetectionDREAMT()
-
         assert task(patient) == []
 
     def test_no_events_returns_empty(self):
-        """Ensure patients with no events return empty output."""
+        """Patient with no dreamt_sleep events returns empty list."""
         patient = MagicMock()
         patient.patient_id = "S999"
         patient.get_events.return_value = []
+        task = SleepWakeDetectionDREAMT()
+        assert task(patient) == []
 
+    def test_none_file_path_returns_empty(self):
+        """file_64hz = None returns empty list without crashing."""
+        patient = _make_patient(None)
         task = SleepWakeDetectionDREAMT()
         assert task(patient) == []
 
     def test_custom_feature_subset(self, tmp_path):
-        """Ensure subset of features is handled correctly."""
-        cols = ["ACC_INDEX", "HRV_HFD"]
-        csv_path = str(tmp_path / "S002_features.csv")
-
-        df = pd.DataFrame({
-            "ACC_INDEX": [1.0, 2.0, 3.0],
-            "HRV_HFD": [0.5, 0.6, 0.7],
-            "Sleep_Stage": [0, 1, 0],
-        })
-        df.to_csv(csv_path, index=False)
-
-        patient = _make_patient(csv_path, patient_id="S002")
-        task = SleepWakeDetectionDREAMT(feature_columns=cols)
-
-        samples = task(patient)
-
-        assert len(samples) == 3
-        assert len(samples[0]["features"]) == 2
-
-    def test_preparation_and_missing_epochs_excluded(self, tmp_path):
-        """Ensure invalid epochs are removed during preprocessing."""
-        csv_path = str(tmp_path / "S003_features.csv")
-
-        df = pd.DataFrame({
-            **{col: [1.0] * 4 for col in FEATURE_COLUMNS},
-            "Sleep_Stage": ["W", "P", "Missing", "N2"],
-        })
-        df.to_csv(csv_path, index=False)
-
+        """Custom feature subset returns correct feature vector length."""
+        csv_path = str(tmp_path / "S003_whole_df.csv")
+        _make_synthetic_raw_csv(csv_path, n_epochs=2)
         patient = _make_patient(csv_path, patient_id="S003")
-        task = SleepWakeDetectionDREAMT()
 
+        cols = ["ACC_INDEX", "HRV_HFD"]
+        task = SleepWakeDetectionDREAMT(feature_columns=cols)
         samples = task(patient)
 
         assert len(samples) == 2
-        assert samples[0]["label"] == 1
-        assert samples[1]["label"] == 0
+        assert len(samples[0]["features"]) == 2
+
+    def test_extract_epoch_features_output_length(self, tmp_path):
+        """extract_epoch_features returns vector matching FEATURE_COLUMNS."""
+        csv_path = str(tmp_path / "S001_whole_df.csv")
+        _make_synthetic_raw_csv(csv_path, n_epochs=1)
+        df = pd.read_csv(csv_path)
+        epoch = df.iloc[:EPOCH_SAMPLES]
+
+        features = extract_epoch_features(epoch)
+        assert len(features) == len(FEATURE_COLUMNS)
+        assert all(isinstance(f, float) for f in features)

--- a/tests/core/test_sleep_wake_detection_dreamt.py
+++ b/tests/core/test_sleep_wake_detection_dreamt.py
@@ -1,0 +1,180 @@
+"""Tests for SleepWakeDetectionDREAMT task using synthetic data."""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from pyhealth.tasks.sleep_wake_detection_dreamt import (
+    FEATURE_COLUMNS,
+    SleepWakeDetectionDREAMT,
+)
+
+
+def _make_synthetic_feature_csv(path: str, n_epochs: int = 10) -> None:
+    """Create a synthetic DREAMT feature CSV for testing."""
+    data = {col: [float(i) for i in range(n_epochs)] for col in FEATURE_COLUMNS}
+
+    stages = ["W", "N1", "N2", "N3", "R"]
+    data["Sleep_Stage"] = [stages[i % len(stages)] for i in range(n_epochs)]
+
+    pd.DataFrame(data).to_csv(path, index=False)
+
+
+def _make_patient(feature_csv_path: str, patient_id: str = "S001") -> MagicMock:
+    """Create a mock patient object compatible with DREAMTDataset."""
+    event = MagicMock()
+    event.file_64hz = feature_csv_path
+    event.ahi = 22.0
+    event.bmi = 33.5
+
+    patient = MagicMock()
+    patient.patient_id = patient_id
+    patient.get_events.return_value = [event]
+    return patient
+
+
+class TestSleepWakeDetectionDREAMT:
+    """
+    Unit tests for the SleepWakeDetectionDREAMT task.
+
+    This test suite validates the functionality of the SleepWakeDetectionDREAMT
+    task, including:
+
+    - Correct instantiation with default and custom feature sets.
+    - Proper handling of synthetic patient data.
+    - Accurate binary label conversion for wake/sleep classification.
+    - Handling of missing or invalid data.
+
+    Methods:
+        test_task_name_and_schema: Validates task metadata and schema definitions.
+        test_instantiation_default: Tests default initialization of the task.
+        test_instantiation_custom_features: Tests initialization with custom feature columns.
+        test_returns_correct_number_of_samples: Ensures the correct number of samples is returned.
+        test_sample_schema: Validates the schema of returned samples.
+        test_binary_label_conversion: Verifies wake/sleep label conversion logic.
+        test_missing_file_returns_empty: Ensures missing files result in empty output.
+        test_no_events_returns_empty: Ensures patients with no events return empty output.
+        test_custom_feature_subset: Ensures subset of features is handled correctly.
+        test_preparation_and_missing_epochs_excluded: Ensures invalid epochs are removed during preprocessing.
+    """
+
+    def test_task_name_and_schema(self):
+        """Validate task metadata and schema definitions."""
+        task = SleepWakeDetectionDREAMT()
+
+        assert task.task_name == "SleepWakeDetectionDREAMT"
+        assert "features" in task.input_schema
+        assert "label" in task.output_schema
+        assert task.output_schema["label"] == "binary"
+
+    def test_instantiation_default(self):
+        """Test default initialization."""
+        task = SleepWakeDetectionDREAMT()
+        assert task.task_name == "SleepWakeDetectionDREAMT"
+        assert task.feature_columns == FEATURE_COLUMNS
+
+    def test_instantiation_custom_features(self):
+        """Test initialization with custom feature columns."""
+        cols = ["ACC_INDEX", "HRV_HFD"]
+        task = SleepWakeDetectionDREAMT(feature_columns=cols)
+        assert task.feature_columns == cols
+
+    def test_returns_correct_number_of_samples(self, tmp_path):
+        """Ensure correct number of samples is returned."""
+        csv_path = str(tmp_path / "S001_features.csv")
+        _make_synthetic_feature_csv(csv_path, n_epochs=10)
+
+        patient = _make_patient(csv_path)
+        task = SleepWakeDetectionDREAMT()
+
+        samples = task(patient)
+        assert len(samples) == 10
+
+    def test_sample_schema(self, tmp_path):
+        """Validate schema of returned samples."""
+        csv_path = str(tmp_path / "S001_features.csv")
+        _make_synthetic_feature_csv(csv_path, n_epochs=5)
+
+        patient = _make_patient(csv_path)
+        task = SleepWakeDetectionDREAMT()
+
+        samples = task(patient)
+
+        for s in samples:
+            assert "patient_id" in s
+            assert "epoch_index" in s
+            assert "ahi" in s
+            assert "bmi" in s
+            assert "features" in s
+            assert "label" in s
+
+            assert s["label"] in (0, 1)
+            assert len(s["features"]) == len(FEATURE_COLUMNS)
+
+    def test_binary_label_conversion(self, tmp_path):
+        """Verify wake/sleep label conversion logic."""
+        csv_path = str(tmp_path / "S001_features.csv")
+        _make_synthetic_feature_csv(csv_path, n_epochs=4)
+
+        patient = _make_patient(csv_path)
+        task = SleepWakeDetectionDREAMT()
+
+        samples = task(patient)
+
+        assert samples[0]["label"] == 1  # W -> wake
+        assert samples[1]["label"] == 0  # N1 -> sleep
+
+    def test_missing_file_returns_empty(self):
+        """Ensure missing file results in empty output."""
+        patient = _make_patient("/nonexistent/path.csv")
+        task = SleepWakeDetectionDREAMT()
+
+        assert task(patient) == []
+
+    def test_no_events_returns_empty(self):
+        """Ensure patients with no events return empty output."""
+        patient = MagicMock()
+        patient.patient_id = "S999"
+        patient.get_events.return_value = []
+
+        task = SleepWakeDetectionDREAMT()
+        assert task(patient) == []
+
+    def test_custom_feature_subset(self, tmp_path):
+        """Ensure subset of features is handled correctly."""
+        cols = ["ACC_INDEX", "HRV_HFD"]
+        csv_path = str(tmp_path / "S002_features.csv")
+
+        df = pd.DataFrame({
+            "ACC_INDEX": [1.0, 2.0, 3.0],
+            "HRV_HFD": [0.5, 0.6, 0.7],
+            "Sleep_Stage": [0, 1, 0],
+        })
+        df.to_csv(csv_path, index=False)
+
+        patient = _make_patient(csv_path, patient_id="S002")
+        task = SleepWakeDetectionDREAMT(feature_columns=cols)
+
+        samples = task(patient)
+
+        assert len(samples) == 3
+        assert len(samples[0]["features"]) == 2
+
+    def test_preparation_and_missing_epochs_excluded(self, tmp_path):
+        """Ensure invalid epochs are removed during preprocessing."""
+        csv_path = str(tmp_path / "S003_features.csv")
+
+        df = pd.DataFrame({
+            **{col: [1.0] * 4 for col in FEATURE_COLUMNS},
+            "Sleep_Stage": ["W", "P", "Missing", "N2"],
+        })
+        df.to_csv(csv_path, index=False)
+
+        patient = _make_patient(csv_path, patient_id="S003")
+        task = SleepWakeDetectionDREAMT()
+
+        samples = task(patient)
+
+        assert len(samples) == 2
+        assert samples[0]["label"] == 1
+        assert samples[1]["label"] == 0


### PR DESCRIPTION
**Contributor:** Anita Padman (apadma4@illinois.edu)
**Contribution Type:** Task

**Description**
Add a binary sleep-wake detection task for the DREAMT dataset based on Addressing Wearable Sleep Tracking Inequity: A New Dataset and Novel Methods for a Population with Sleep Disorders.

This task processes overnight Empatica E4 wearable recordings from 100 sleep-disorder patients into per-epoch feature vectors with binary sleep/wake labels (30-second epochs). Features include statistical summaries of ACC, TEMP, BVP, EDA, and HR signals, along with ACC_INDEX and HRV_HFD (identified as the strongest predictors in the paper).

PSG sleep stage annotations are converted into binary labels: wake (1) vs. sleep (0), with preparation (P) and missing epochs filtered according to the DREAMT 2.1.0 schema.

An example ablation study is included using PyHealth’s RNN to compare three feature configurations: full feature set, ACC-only, and the top-2 features from the paper, demonstrating the impact of feature selection on classification performance.

**Files to review**
pyhealth/tasks/sleep_wake_detection_dreamt.py - Core task implementation including preprocessing, feature extraction, and label generation

pyhealth/tasks/init.py - Added import for SleepWakeDetectionDREAMT

tests/test_sleep_wake_detection_dreamt.py - Unit tests using synthetic data

examples/dreamt_sleep_wake_detection_rnn.py - Example script with RNN-based ablation study across feature configurations

docs/api/tasks/pyhealth.tasks.sleep_wake_detection_dreamt.rst - API documentation for the new task

docs/api/tasks.rst - Updated task index to include SleepWakeDetectionDREAMT