### PR TITLE
[DL4H Sp26] Add MedFuse model for multi-modal EHR + chest X-ray fusion

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -194,6 +194,7 @@ API Reference
     models/pyhealth.models.ConCare
     models/pyhealth.models.Agent
     models/pyhealth.models.GRASP
+    models/pyhealth.models.MedFuse
     models/pyhealth.models.MedLink
     models/pyhealth.models.TCN
     models/pyhealth.models.TFMTokenizer

--- a/docs/api/models/pyhealth.models.MedFuse.rst
+++ b/docs/api/models/pyhealth.models.MedFuse.rst
@@ -1,0 +1,24 @@
+pyhealth.models.MedFuse
+=======================
+
+Overview
+--------
+
+MedFuse is an LSTM-based multi-modal fusion model for combining clinical
+time-series (EHR) and chest X-ray (CXR) representations.
+
+Reference: Hayat et al., "MedFuse: Multi-modal fusion with clinical
+time-series data and chest X-ray images." MLHC 2022.
+
+API Reference
+-------------
+
+.. autoclass:: pyhealth.models.MedFuseLayer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: pyhealth.models.MedFuse
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/mimic4_mortality_medfuse.py
+++ b/examples/mimic4_mortality_medfuse.py
@@ -1,0 +1,381 @@
+"""MedFuse Ablation Study for In-Hospital Mortality Prediction.
+
+This script demonstrates MedFuse with varying hyperparameters on synthetic
+mortality-like data to validate model behavior quickly.
+
+Paper:
+    Hayat et al. "MedFuse: Multi-modal fusion with clinical time-series data
+    and chest X-ray images." MLHC 2022.
+
+Ablations:
+    1. EHR hidden dim: 64, 128, 256, 512
+    2. Fusion hidden dim: 128, 256, 512
+    3. Dropout: 0.0, 0.3, 0.5, 0.7
+    4. Learning rate: 1e-5, 1e-4, 1e-3
+    5. Modality: EHR-only vs EHR+CXR
+
+The script is intentionally lightweight by default:
+    - Synthetic data only
+    - Small dataset
+    - Few epochs
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+from sklearn.metrics import average_precision_score, roc_auc_score
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models import MedFuse
+
+
+def set_seed(seed: int) -> None:
+    """Sets all random seeds for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+def make_synthetic_samples(
+    num_samples: int,
+    seq_len: int,
+    ehr_dim: int,
+    image_size: int,
+    seed: int,
+) -> List[Dict[str, object]]:
+    """Builds synthetic samples with weakly learnable mortality signal."""
+    generator = torch.Generator().manual_seed(seed)
+    samples: List[Dict[str, object]] = []
+
+    for index in range(num_samples):
+        ehr = torch.randn(seq_len, ehr_dim, generator=generator)
+        cxr = torch.randn(3, image_size, image_size, generator=generator)
+
+        score = 0.7 * float(ehr[:, 0].mean())
+        score += 0.3 * float(cxr.mean())
+        score += float(torch.randn(1, generator=generator)) * 0.1
+        label = 1 if score > 0 else 0
+
+        samples.append(
+            {
+                "patient_id": f"patient-{index}",
+                "visit_id": f"visit-{index}",
+                "ehr": ehr.tolist(),
+                "cxr": cxr.tolist(),
+                "label": label,
+            }
+        )
+
+    return samples
+
+
+def build_datasets(
+    train_size: int,
+    val_size: int,
+    seq_len: int,
+    ehr_dim: int,
+    image_size: int,
+    seed: int,
+):
+    """Creates synthetic train/validation datasets."""
+    train_samples = make_synthetic_samples(
+        num_samples=train_size,
+        seq_len=seq_len,
+        ehr_dim=ehr_dim,
+        image_size=image_size,
+        seed=seed,
+    )
+    val_samples = make_synthetic_samples(
+        num_samples=val_size,
+        seq_len=seq_len,
+        ehr_dim=ehr_dim,
+        image_size=image_size,
+        seed=seed + 1,
+    )
+
+    input_schema = {"ehr": "tensor", "cxr": "tensor"}
+    output_schema = {"label": "binary"}
+
+    train_dataset = create_sample_dataset(
+        samples=train_samples,
+        input_schema=input_schema,
+        output_schema=output_schema,
+        dataset_name="medfuse_ablation_train",
+    )
+    val_dataset = create_sample_dataset(
+        samples=val_samples,
+        input_schema=input_schema,
+        output_schema=output_schema,
+        dataset_name="medfuse_ablation_val",
+    )
+    return train_dataset, val_dataset
+
+
+def compute_binary_metrics(
+    y_true: List[float],
+    y_prob: List[float],
+) -> Dict[str, float]:
+    """Computes AUROC and AUPRC with robust fallbacks."""
+    metrics = {
+        "auroc": math.nan,
+        "auprc": math.nan,
+    }
+
+    if len(set(y_true)) > 1:
+        metrics["auroc"] = float(roc_auc_score(y_true, y_prob))
+    if any(y_true):
+        metrics["auprc"] = float(average_precision_score(y_true, y_prob))
+
+    return metrics
+
+
+def train_and_evaluate(
+    train_dataset,
+    val_dataset,
+    use_cxr: bool,
+    ehr_hidden_dim: int,
+    fusion_hidden_dim: int,
+    dropout: float,
+    learning_rate: float,
+    epochs: int,
+    batch_size: int,
+    cxr_backbone: str,
+) -> Dict[str, float]:
+    """Trains one MedFuse configuration and reports validation metrics."""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = MedFuse(
+        dataset=train_dataset,
+        ehr_feature_key="ehr",
+        cxr_feature_key="cxr",
+        cxr_mask_key="cxr_mask",
+        ehr_hidden_dim=ehr_hidden_dim,
+        ehr_num_layers=2,
+        cxr_backbone=cxr_backbone,
+        cxr_pretrained=False,
+        fusion_hidden_dim=fusion_hidden_dim,
+        projection_dim=ehr_hidden_dim,
+        dropout=dropout,
+    )
+    model.to(device)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+    train_loader = get_dataloader(train_dataset, batch_size=batch_size, shuffle=True)
+    val_loader = get_dataloader(val_dataset, batch_size=batch_size, shuffle=False)
+
+    for _ in range(epochs):
+        model.train()
+        for batch in train_loader:
+            optimizer.zero_grad()
+            model_inputs = {
+                "ehr": batch["ehr"].to(device),
+                "label": batch["label"].to(device),
+            }
+            if use_cxr:
+                model_inputs["cxr"] = batch["cxr"].to(device)
+
+            outputs = model(**model_inputs)
+            outputs["loss"].backward()
+            optimizer.step()
+
+    model.eval()
+    all_probs: List[float] = []
+    all_true: List[float] = []
+
+    with torch.no_grad():
+        for batch in val_loader:
+            model_inputs = {"ehr": batch["ehr"].to(device)}
+            if use_cxr:
+                model_inputs["cxr"] = batch["cxr"].to(device)
+
+            outputs = model(**model_inputs)
+            all_probs.extend(outputs["y_prob"].view(-1).cpu().tolist())
+            all_true.extend(batch["label"].view(-1).cpu().tolist())
+
+    return compute_binary_metrics(all_true, all_probs)
+
+
+def best_config(rows: List[Tuple[str, Dict[str, float]]]) -> Tuple[str, float]:
+    """Returns the setting name and AUROC of the best configuration."""
+    best_name = rows[0][0]
+    best_auroc = -1.0
+    for name, metrics in rows:
+        auroc = metrics["auroc"]
+        if not math.isnan(auroc) and auroc > best_auroc:
+            best_auroc = auroc
+            best_name = name
+    return best_name, best_auroc
+
+
+def format_metric(value: float) -> str:
+    """Formats metric values for table output."""
+    if math.isnan(value):
+        return "nan"
+    return f"{value:.4f}"
+
+
+def print_table(title: str, rows: List[Tuple[str, Dict[str, float]]]) -> None:
+    """Prints a compact ablation result table."""
+    print(f"\n{title}")
+    print("| setting | AUROC | AUPRC |")
+    print("|---------|-------|-------|")
+    for setting, metrics in rows:
+        auroc = format_metric(metrics["auroc"])
+        auprc = format_metric(metrics["auprc"])
+        print(f"| {setting} | {auroc} | {auprc} |")
+
+
+def run_ablation_study(args: argparse.Namespace) -> None:
+    """Runs all required MedFuse ablations."""
+    set_seed(args.seed)
+    train_dataset, val_dataset = build_datasets(
+        train_size=args.train_size,
+        val_size=args.val_size,
+        seq_len=args.seq_len,
+        ehr_dim=args.ehr_dim,
+        image_size=args.image_size,
+        seed=args.seed,
+    )
+
+    base_config = {
+        "use_cxr": True,
+        "ehr_hidden_dim": 128,
+        "fusion_hidden_dim": 256,
+        "dropout": 0.3,
+        "learning_rate": 1e-4,
+        "epochs": args.epochs,
+        "batch_size": args.batch_size,
+        "cxr_backbone": args.cxr_backbone,
+    }
+
+    hidden_results: List[Tuple[str, Dict[str, float]]] = []
+    for hidden_dim in [64, 128, 256, 512]:
+        metrics = train_and_evaluate(
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            use_cxr=True,
+            ehr_hidden_dim=hidden_dim,
+            fusion_hidden_dim=base_config["fusion_hidden_dim"],
+            dropout=base_config["dropout"],
+            learning_rate=base_config["learning_rate"],
+            epochs=base_config["epochs"],
+            batch_size=base_config["batch_size"],
+            cxr_backbone=base_config["cxr_backbone"],
+        )
+        hidden_results.append((f"ehr_hidden_dim={hidden_dim}", metrics))
+
+    fusion_results: List[Tuple[str, Dict[str, float]]] = []
+    for fusion_dim in [128, 256, 512]:
+        metrics = train_and_evaluate(
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            use_cxr=True,
+            ehr_hidden_dim=base_config["ehr_hidden_dim"],
+            fusion_hidden_dim=fusion_dim,
+            dropout=base_config["dropout"],
+            learning_rate=base_config["learning_rate"],
+            epochs=base_config["epochs"],
+            batch_size=base_config["batch_size"],
+            cxr_backbone=base_config["cxr_backbone"],
+        )
+        fusion_results.append((f"fusion_hidden_dim={fusion_dim}", metrics))
+
+    dropout_results: List[Tuple[str, Dict[str, float]]] = []
+    for dropout_value in [0.0, 0.3, 0.5, 0.7]:
+        metrics = train_and_evaluate(
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            use_cxr=True,
+            ehr_hidden_dim=base_config["ehr_hidden_dim"],
+            fusion_hidden_dim=base_config["fusion_hidden_dim"],
+            dropout=dropout_value,
+            learning_rate=base_config["learning_rate"],
+            epochs=base_config["epochs"],
+            batch_size=base_config["batch_size"],
+            cxr_backbone=base_config["cxr_backbone"],
+        )
+        dropout_results.append((f"dropout={dropout_value}", metrics))
+
+    lr_results: List[Tuple[str, Dict[str, float]]] = []
+    for lr in [1e-5, 1e-4, 1e-3]:
+        metrics = train_and_evaluate(
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            use_cxr=True,
+            ehr_hidden_dim=base_config["ehr_hidden_dim"],
+            fusion_hidden_dim=base_config["fusion_hidden_dim"],
+            dropout=base_config["dropout"],
+            learning_rate=lr,
+            epochs=base_config["epochs"],
+            batch_size=base_config["batch_size"],
+            cxr_backbone=base_config["cxr_backbone"],
+        )
+        lr_results.append((f"learning_rate={lr:.0e}", metrics))
+
+    modality_results: List[Tuple[str, Dict[str, float]]] = []
+    for use_cxr in [False, True]:
+        metrics = train_and_evaluate(
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            use_cxr=use_cxr,
+            ehr_hidden_dim=base_config["ehr_hidden_dim"],
+            fusion_hidden_dim=base_config["fusion_hidden_dim"],
+            dropout=base_config["dropout"],
+            learning_rate=base_config["learning_rate"],
+            epochs=base_config["epochs"],
+            batch_size=base_config["batch_size"],
+            cxr_backbone=base_config["cxr_backbone"],
+        )
+        name = "EHR+CXR" if use_cxr else "EHR-only"
+        modality_results.append((name, metrics))
+
+    all_ablations = [
+        ("EHR Hidden Dim Ablation", hidden_results),
+        ("Fusion Hidden Dim Ablation", fusion_results),
+        ("Dropout Ablation", dropout_results),
+        ("Learning Rate Ablation", lr_results),
+        ("Modality Ablation", modality_results),
+    ]
+
+    for title, rows in all_ablations:
+        print_table(title, rows)
+
+    print("\nFindings (auto-generated from results above):")
+    for title, rows in all_ablations:
+        name, auroc = best_config(rows)
+        print(f"- {title}: best config = {name} (AUROC={format_metric(auroc)})")
+
+    print(
+        "\nNote: These results are on small synthetic data with minimal training "
+        "(default 32 train samples, 1 epoch). They validate that the model is "
+        "sensitive to hyperparameter choices but should not be interpreted as "
+        "representative of real-world performance. On clinical data (e.g., "
+        "MIMIC-IV), the paper reports that multi-modal EHR+CXR fusion improves "
+        "over unimodal baselines."
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parses CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run MedFuse synthetic mortality ablation study."
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--train-size", type=int, default=32)
+    parser.add_argument("--val-size", type=int, default=16)
+    parser.add_argument("--seq-len", type=int, default=5)
+    parser.add_argument("--ehr-dim", type=int, default=10)
+    parser.add_argument("--image-size", type=int, default=32)
+    parser.add_argument("--cxr-backbone", type=str, default="resnet18")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    run_ablation_study(parse_args())

--- a/examples/mimic4_mortality_medfuse.py
+++ b/examples/mimic4_mortality_medfuse.py
@@ -354,9 +354,13 @@ def run_ablation_study(args: argparse.Namespace) -> None:
         "\nNote: These results are on small synthetic data with minimal training "
         "(default 32 train samples, 1 epoch). They validate that the model is "
         "sensitive to hyperparameter choices but should not be interpreted as "
-        "representative of real-world performance. On clinical data (e.g., "
-        "MIMIC-IV), the paper reports that multi-modal EHR+CXR fusion improves "
-        "over unimodal baselines."
+        "representative of real-world performance. For reference, Hayat et al. "
+        "(2022) report the following for in-hospital mortality on MIMIC-IV + "
+        "MIMIC-CXR:\n"
+        "  - Table 2 (paired EHR+CXR test set): MedFuse (OPTIMAL) 0.865 AUROC "
+        "/ 0.594 AUPRC, vs. Unified (Hayat et al., 2021a) 0.835 / 0.495.\n"
+        "  - Table 3 (partial test set): MedFuse (OPTIMAL) 0.874 AUROC / 0.567 "
+        "AUPRC."
     )
 
 

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -15,6 +15,7 @@ from .gnn import GAT, GCN
 from .graph_torchvision_model import Graph_TorchvisionModel
 from .graphcare import GraphCare
 from .grasp import GRASP, GRASPLayer
+from .medfuse import MedFuse, MedFuseLayer
 from .medlink import MedLink
 from .micron import MICRON, MICRONLayer
 from .mlp import MLP

--- a/pyhealth/models/medfuse.py
+++ b/pyhealth/models/medfuse.py
@@ -1,0 +1,450 @@
+# Author: Sean Nian
+# Description: MedFuse model implementation for PyHealth.
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple, cast
+
+import torch
+import torch.nn as nn
+import torch.nn.utils.rnn as rnn_utils
+
+from pyhealth.datasets import SampleDataset
+from pyhealth.models.base_model import BaseModel
+
+
+class MedFuseLayer(nn.Module):
+    """MedFuse fusion layer.
+
+    Fuses EHR time-series and chest X-ray (CXR) representations using an
+    LSTM-based sequential fusion strategy that supports missing CXR modality.
+
+    Paper:
+        Hayat, N., Geras, K. J., & Shamout, F. E. (2022).
+        MedFuse: Multi-modal fusion with clinical time-series data and chest
+        X-ray images. MLHC 2022.
+
+    Args:
+        ehr_input_dim: Dimension of EHR features at each timestep.
+        ehr_hidden_dim: Hidden dimension of the EHR LSTM encoder.
+            Default is 256.
+        ehr_num_layers: Number of stacked LSTM layers for EHR.
+            Default is 2.
+        cxr_backbone: ResNet variant for CXR encoder.
+            Default is ``"resnet34"``.
+        cxr_pretrained: Whether to use pretrained CXR encoder weights.
+            Default is True.
+        fusion_hidden_dim: Hidden dimension of fusion LSTM.
+            Default is 512.
+        projection_dim: Dimension to project CXR features to.
+            Must match ``ehr_hidden_dim``.
+        dropout: Dropout rate.
+        num_labels: Number of output labels.
+    """
+
+    SUPPORTED_CXR_BACKBONES = ("resnet18", "resnet34", "resnet50")
+
+    def __init__(
+        self,
+        ehr_input_dim: int,
+        ehr_hidden_dim: int = 256,
+        ehr_num_layers: int = 2,
+        cxr_backbone: str = "resnet34",
+        cxr_pretrained: bool = True,
+        fusion_hidden_dim: int = 512,
+        projection_dim: int = 256,
+        dropout: float = 0.5,
+        num_labels: int = 1,
+    ) -> None:
+        super().__init__()
+        if projection_dim != ehr_hidden_dim:
+            raise ValueError(
+                "projection_dim must match ehr_hidden_dim for fusion sequencing."
+            )
+        if cxr_backbone not in self.SUPPORTED_CXR_BACKBONES:
+            raise ValueError(
+                f"Unsupported cxr_backbone: {cxr_backbone}. "
+                f"Supported values: {self.SUPPORTED_CXR_BACKBONES}."
+            )
+
+        self.ehr_encoder = nn.LSTM(
+            input_size=ehr_input_dim,
+            hidden_size=ehr_hidden_dim,
+            num_layers=ehr_num_layers,
+            batch_first=True,
+            dropout=dropout if ehr_num_layers > 1 else 0.0,
+        )
+
+        self.cxr_encoder, cxr_feature_dim = self._build_cxr_encoder(
+            cxr_backbone=cxr_backbone,
+            cxr_pretrained=cxr_pretrained,
+        )
+        self.projection = nn.Linear(cxr_feature_dim, projection_dim)
+
+        self.fusion_lstm = nn.LSTM(
+            input_size=projection_dim,
+            hidden_size=fusion_hidden_dim,
+            num_layers=1,
+            batch_first=True,
+        )
+        self.dropout_layer = nn.Dropout(dropout)
+        self.classifier = nn.Linear(fusion_hidden_dim, num_labels)
+
+    def _build_cxr_encoder(
+        self,
+        cxr_backbone: str,
+        cxr_pretrained: bool,
+    ) -> Tuple[nn.Module, int]:
+        """Builds the CXR backbone and returns encoder + feature dimension."""
+        try:
+            import torchvision.models as tv_models
+        except ImportError as exc:
+            raise ImportError(
+                "torchvision is required to use MedFuse CXR backbones."
+            ) from exc
+
+        constructor = getattr(tv_models, cxr_backbone)
+
+        if cxr_pretrained:
+            try:
+                weights = tv_models.get_model_weights(cxr_backbone).DEFAULT
+                backbone = constructor(weights=weights)
+            except Exception:
+                backbone = constructor(pretrained=True)
+        else:
+            try:
+                backbone = constructor(weights=None)
+            except TypeError:
+                backbone = constructor(pretrained=False)
+
+        if not hasattr(backbone, "fc") or not isinstance(backbone.fc, nn.Linear):
+            raise ValueError(
+                f"Backbone {cxr_backbone} must expose a linear `fc` layer."
+            )
+
+        feature_dim = backbone.fc.in_features
+        backbone.fc = nn.Identity()
+        return backbone, feature_dim
+
+    def _encode_cxr(self, cxr_input: torch.Tensor) -> torch.Tensor:
+        """Encodes CXR images and projects them to the fusion dimension."""
+        if cxr_input.dim() != 4:
+            raise ValueError(
+                "cxr_input must have shape [batch, channels, height, width]."
+            )
+
+        if cxr_input.size(1) == 1:
+            cxr_input = cxr_input.repeat(1, 3, 1, 1)
+        elif cxr_input.size(1) != 3:
+            raise ValueError("cxr_input must have 1 or 3 channels.")
+
+        cxr_features = self.cxr_encoder(cxr_input)
+        if cxr_features.dim() > 2:
+            cxr_features = torch.flatten(cxr_features, start_dim=1)
+
+        projected = self.projection(cxr_features)
+        return projected
+
+    def forward(
+        self,
+        ehr_input: torch.Tensor,
+        cxr_input: Optional[torch.Tensor] = None,
+        cxr_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Runs MedFuse fusion.
+
+        Args:
+            ehr_input: EHR tensor of shape ``[batch, seq_len, ehr_input_dim]``.
+            cxr_input: Optional CXR tensor of shape
+                ``[batch, channels, height, width]``.
+            cxr_mask: Optional tensor of shape ``[batch]`` indicating CXR
+                availability (1 = present, 0 = missing).
+
+        Returns:
+            Logits tensor of shape ``[batch, num_labels]``.
+        """
+        if ehr_input.dim() != 3:
+            raise ValueError(
+                "ehr_input must have shape [batch, seq_len, ehr_input_dim]."
+            )
+
+        _, (ehr_hidden, _) = self.ehr_encoder(ehr_input)
+        ehr_repr = self.dropout_layer(ehr_hidden[-1])
+
+        batch_size = ehr_repr.size(0)
+        sequence_lengths = torch.ones(
+            batch_size,
+            dtype=torch.long,
+            device=ehr_input.device,
+        )
+        fusion_tokens = [ehr_repr.unsqueeze(1)]
+
+        if cxr_input is not None:
+            if cxr_input.size(0) != batch_size:
+                raise ValueError(
+                    "cxr_input batch size must match ehr_input batch size."
+                )
+
+            if cxr_mask is None:
+                cxr_present_mask = torch.ones(
+                    batch_size,
+                    dtype=torch.bool,
+                    device=ehr_input.device,
+                )
+            else:
+                cxr_present_mask = cxr_mask.to(ehr_input.device).view(-1).bool()
+                if cxr_present_mask.numel() != batch_size:
+                    raise ValueError("cxr_mask must have shape [batch].")
+
+            cxr_projected = torch.zeros(
+                batch_size,
+                self.projection.out_features,
+                dtype=ehr_repr.dtype,
+                device=ehr_input.device,
+            )
+
+            if cxr_present_mask.any():
+                present_cxr = cxr_input[cxr_present_mask]
+                present_projected = self._encode_cxr(present_cxr)
+                cxr_projected[cxr_present_mask] = present_projected
+                sequence_lengths[cxr_present_mask] = 2
+
+            fusion_tokens.append(cxr_projected.unsqueeze(1))
+
+        fusion_sequence = torch.cat(fusion_tokens, dim=1)
+        packed_sequence = rnn_utils.pack_padded_sequence(
+            fusion_sequence,
+            lengths=sequence_lengths.cpu(),
+            batch_first=True,
+            enforce_sorted=False,
+        )
+        _, (fusion_hidden, _) = self.fusion_lstm(packed_sequence)
+        fused_repr = self.dropout_layer(fusion_hidden[-1])
+        logits = self.classifier(fused_repr)
+        return logits
+
+
+class MedFuse(BaseModel):
+    """MedFuse model for multi-modal clinical prediction.
+
+    This model fuses clinical time-series (EHR) and chest X-ray (CXR)
+    representations using an LSTM-based fusion module. It handles missing CXR
+    via variable sequence lengths, where each sample contributes either:
+
+    - ``[v_ehr]`` (EHR only), or
+    - ``[v_ehr, v_cxr]`` (EHR + CXR).
+
+    Paper:
+        Hayat, N., Geras, K. J., & Shamout, F. E. (2022).
+        MedFuse: Multi-modal fusion with clinical time-series data and chest
+        X-ray images. MLHC 2022.
+
+    Args:
+        dataset: Sample dataset used for model configuration.
+        ehr_feature_key: Input key for EHR tensor. Default is ``"ehr"``.
+        cxr_feature_key: Input key for CXR tensor. Default is ``"cxr"``.
+        cxr_mask_key: Optional input key for per-sample CXR availability mask.
+            Default is ``"cxr_mask"``.
+        ehr_hidden_dim: Hidden dimension for EHR encoder.
+        ehr_num_layers: Number of EHR LSTM layers.
+        cxr_backbone: CXR ResNet backbone. Default is ``"resnet34"``.
+        cxr_pretrained: Whether to use pretrained CXR backbone.
+        fusion_hidden_dim: Hidden dimension for fusion LSTM.
+        projection_dim: CXR projection output dimension.
+        dropout: Dropout rate.
+
+    Examples:
+        >>> from pyhealth.datasets import create_sample_dataset, get_dataloader
+        >>> from pyhealth.models import MedFuse
+        >>> samples = [
+        ...     {
+        ...         "patient_id": "p0",
+        ...         "visit_id": "v0",
+        ...         "ehr": torch.randn(5, 10).tolist(),
+        ...         "cxr": torch.randn(3, 32, 32).tolist(),
+        ...         "label": 1,
+        ...     },
+        ...     {
+        ...         "patient_id": "p1",
+        ...         "visit_id": "v1",
+        ...         "ehr": torch.randn(5, 10).tolist(),
+        ...         "cxr": torch.randn(3, 32, 32).tolist(),
+        ...         "label": 0,
+        ...     },
+        ... ]
+        >>> dataset = create_sample_dataset(
+        ...     samples=samples,
+        ...     input_schema={"ehr": "tensor", "cxr": "tensor"},
+        ...     output_schema={"label": "binary"},
+        ... )
+        >>> loader = get_dataloader(dataset, batch_size=2)
+        >>> model = MedFuse(dataset=dataset, cxr_pretrained=False)
+        >>> batch = next(iter(loader))
+        >>> output = model(**batch)
+        >>> output["y_prob"].shape
+        torch.Size([2, 1])
+    """
+
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        ehr_feature_key: str = "ehr",
+        cxr_feature_key: str = "cxr",
+        cxr_mask_key: Optional[str] = "cxr_mask",
+        ehr_hidden_dim: int = 256,
+        ehr_num_layers: int = 2,
+        cxr_backbone: str = "resnet34",
+        cxr_pretrained: bool = True,
+        fusion_hidden_dim: int = 512,
+        projection_dim: int = 256,
+        dropout: float = 0.5,
+    ) -> None:
+        super().__init__(dataset=dataset)
+
+        if len(self.label_keys) != 1:
+            raise ValueError("MedFuse supports exactly one label key.")
+
+        if ehr_feature_key not in self.feature_keys:
+            raise ValueError(
+                f"ehr_feature_key '{ehr_feature_key}' not found in dataset "
+                f"features: {self.feature_keys}."
+            )
+
+        self.ehr_feature_key = ehr_feature_key
+        self.cxr_feature_key = cxr_feature_key
+        self.cxr_mask_key = cxr_mask_key
+        self.label_key = self.label_keys[0]
+        self.mode = self._resolve_mode(self.dataset.output_schema[self.label_key])
+
+        self.has_cxr_feature = cxr_feature_key in self.feature_keys
+        self.ehr_input_dim = self._infer_ehr_input_dim(ehr_feature_key)
+
+        output_size = self.get_output_size()
+        self.layer = MedFuseLayer(
+            ehr_input_dim=self.ehr_input_dim,
+            ehr_hidden_dim=ehr_hidden_dim,
+            ehr_num_layers=ehr_num_layers,
+            cxr_backbone=cxr_backbone,
+            cxr_pretrained=cxr_pretrained,
+            fusion_hidden_dim=fusion_hidden_dim,
+            projection_dim=projection_dim,
+            dropout=dropout,
+            num_labels=output_size,
+        )
+
+    def _extract_feature_value(
+        self,
+        feature_key: str,
+        feature: torch.Tensor | tuple[torch.Tensor, ...],
+    ) -> torch.Tensor:
+        """Extracts the semantic ``value`` tensor from a feature payload."""
+        if isinstance(feature, torch.Tensor):
+            return feature
+
+        if feature_key not in self.dataset.input_processors:
+            raise ValueError(
+                f"Feature '{feature_key}' is not defined in dataset processors."
+            )
+
+        schema = self.dataset.input_processors[feature_key].schema()
+        if "value" in schema:
+            value = feature[schema.index("value")]
+            if isinstance(value, torch.Tensor):
+                return value
+
+        raise ValueError(
+            f"Feature '{feature_key}' must provide a tensor value in its schema."
+        )
+
+    def _infer_ehr_input_dim(self, ehr_feature_key: str) -> int:
+        """Infers EHR input feature dimension from processed dataset samples."""
+        for sample in self.dataset:
+            if ehr_feature_key not in sample:
+                continue
+            feature = sample[ehr_feature_key]
+            if isinstance(feature, tuple):
+                value = self._extract_feature_value(ehr_feature_key, feature)
+            elif isinstance(feature, torch.Tensor):
+                value = feature
+            else:
+                value = torch.as_tensor(feature)
+
+            if value.dim() >= 2:
+                return int(value.shape[-1])
+
+        raise ValueError(
+            "Unable to infer EHR input dimension. Ensure EHR feature tensors "
+            "have shape [seq_len, feature_dim]."
+        )
+
+    def forward(
+        self,
+        **kwargs: torch.Tensor | tuple[torch.Tensor, ...],
+    ) -> Dict[str, torch.Tensor]:
+        """Forward propagation.
+
+        Args:
+            **kwargs: Model inputs. Expected keys include:
+                - ``ehr_feature_key`` (required): EHR tensor.
+                - ``cxr_feature_key`` (optional): CXR tensor.
+                - ``cxr_mask_key`` (optional): CXR availability mask.
+                - ``label_key`` (optional): Label tensor for loss computation.
+
+        Returns:
+            A dictionary containing:
+                - ``logit``: Raw logits.
+                - ``y_prob``: Predicted probabilities.
+                - ``loss``: Loss tensor when labels are provided.
+                - ``y_true``: Ground-truth labels when provided.
+        """
+        if self.ehr_feature_key not in kwargs:
+            raise ValueError(
+                f"Missing required EHR feature key: '{self.ehr_feature_key}'."
+            )
+
+        ehr_input = self._extract_feature_value(
+            self.ehr_feature_key,
+            cast(torch.Tensor | tuple[torch.Tensor, ...], kwargs[self.ehr_feature_key]),
+        )
+        ehr_input = ehr_input.to(self.device).float()
+
+        cxr_input: Optional[torch.Tensor] = None
+        if self.cxr_feature_key in kwargs:
+            cxr_input = self._extract_feature_value(
+                self.cxr_feature_key,
+                cast(
+                    torch.Tensor | tuple[torch.Tensor, ...],
+                    kwargs[self.cxr_feature_key],
+                ),
+            )
+            cxr_input = cxr_input.to(self.device).float()
+
+        cxr_mask: Optional[torch.Tensor] = None
+        if self.cxr_mask_key is not None and self.cxr_mask_key in kwargs:
+            raw_mask = kwargs[self.cxr_mask_key]
+            if isinstance(raw_mask, tuple):
+                raise ValueError("cxr_mask must be provided as a tensor.")
+            if isinstance(raw_mask, torch.Tensor):
+                cxr_mask = raw_mask.to(self.device)
+            else:
+                cxr_mask = torch.as_tensor(raw_mask, device=self.device)
+
+        logits = self.layer(
+            ehr_input=ehr_input,
+            cxr_input=cxr_input,
+            cxr_mask=cxr_mask,
+        )
+        y_prob = self.prepare_y_prob(logits)
+
+        results: Dict[str, torch.Tensor] = {
+            "logit": logits,
+            "y_prob": y_prob,
+        }
+
+        if self.label_key in kwargs:
+            y_true = cast(torch.Tensor, kwargs[self.label_key]).to(self.device)
+            loss = self.get_loss_function()(logits, y_true)
+            results["loss"] = loss
+            results["y_true"] = y_true
+
+        return results

--- a/pyhealth/models/medfuse.py
+++ b/pyhealth/models/medfuse.py
@@ -1,4 +1,4 @@
-# Author: Sean Nian
+# Authors: Sean Nian, Tony Hong, Yaqi Qiao
 # Description: MedFuse model implementation for PyHealth.
 
 from __future__ import annotations
@@ -18,6 +18,9 @@ class MedFuseLayer(nn.Module):
 
     Fuses EHR time-series and chest X-ray (CXR) representations using an
     LSTM-based sequential fusion strategy that supports missing CXR modality.
+    Follows Paper §3.2, Eq. 4: the fusion LSTM consumes the token sequence
+    ``v_fusion = [v_ehr, v*_cxr]`` (length 1 when CXR is missing). The EHR
+    representation is the first input token, not an initial hidden state.
 
     Paper:
         Hayat, N., Geras, K. J., & Shamout, F. E. (2022).
@@ -244,7 +247,10 @@ class MedFuse(BaseModel):
         ehr_feature_key: Input key for EHR tensor. Default is ``"ehr"``.
         cxr_feature_key: Input key for CXR tensor. Default is ``"cxr"``.
         cxr_mask_key: Optional input key for per-sample CXR availability mask.
-            Default is ``"cxr_mask"``.
+            Default is ``"cxr_mask"``. To surface the mask through the
+            standard dataloader, include ``"cxr_mask": "tensor"`` in your
+            dataset's ``input_schema`` with per-sample availability values
+            (1 = CXR present, 0 = missing).
         ehr_hidden_dim: Hidden dimension for EHR encoder.
         ehr_num_layers: Number of EHR LSTM layers.
         cxr_backbone: CXR ResNet backbone. Default is ``"resnet34"``.

--- a/tests/core/test_medfuse.py
+++ b/tests/core/test_medfuse.py
@@ -1,0 +1,202 @@
+import unittest
+
+import torch
+import torch.nn as nn
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models import MedFuse, MedFuseLayer
+
+try:
+    import torchvision  # noqa: F401
+
+    HAS_TORCHVISION = True
+except ImportError:
+    HAS_TORCHVISION = False
+
+
+@unittest.skipUnless(HAS_TORCHVISION, "torchvision is required for MedFuse tests")
+class TestMedFuse(unittest.TestCase):
+    """Test cases for the MedFuse model."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.binary_dataset = cls._create_binary_dataset()
+        cls.multilabel_dataset = cls._create_multilabel_dataset()
+
+    @staticmethod
+    def _create_binary_dataset():
+        generator = torch.Generator().manual_seed(7)
+        samples = []
+        for index in range(4):
+            samples.append(
+                {
+                    "patient_id": f"patient-{index}",
+                    "visit_id": f"visit-{index}",
+                    "ehr": torch.randn(5, 10, generator=generator).tolist(),
+                    "cxr": torch.randn(3, 32, 32, generator=generator).tolist(),
+                    "label": index % 2,
+                }
+            )
+
+        return create_sample_dataset(
+            samples=samples,
+            input_schema={"ehr": "tensor", "cxr": "tensor"},
+            output_schema={"label": "binary"},
+            dataset_name="medfuse_binary_test",
+        )
+
+    @staticmethod
+    def _create_multilabel_dataset():
+        generator = torch.Generator().manual_seed(17)
+        labels = [[0], [1], [0, 1], []]
+        samples = []
+        for index, label in enumerate(labels):
+            samples.append(
+                {
+                    "patient_id": f"patient-multi-{index}",
+                    "visit_id": f"visit-multi-{index}",
+                    "ehr": torch.randn(5, 10, generator=generator).tolist(),
+                    "cxr": torch.randn(3, 32, 32, generator=generator).tolist(),
+                    "label": label,
+                }
+            )
+
+        return create_sample_dataset(
+            samples=samples,
+            input_schema={"ehr": "tensor", "cxr": "tensor"},
+            output_schema={"label": "multilabel"},
+            dataset_name="medfuse_multilabel_test",
+        )
+
+    @staticmethod
+    def _build_model(dataset):
+        model = MedFuse(
+            dataset=dataset,
+            ehr_feature_key="ehr",
+            cxr_feature_key="cxr",
+            cxr_mask_key="cxr_mask",
+            ehr_hidden_dim=8,
+            ehr_num_layers=1,
+            cxr_backbone="resnet18",
+            cxr_pretrained=False,
+            fusion_hidden_dim=16,
+            projection_dim=8,
+            dropout=0.0,
+        )
+        # Speed up unit tests: keep MedFuse API/logic but replace heavyweight
+        # image encoder compute with a tiny synthetic module.
+        projection_in_features = model.layer.projection.in_features
+        model.layer.cxr_encoder = nn.Sequential(
+            nn.Conv2d(3, 8, kernel_size=3, stride=1, padding=1),
+            nn.ReLU(),
+            nn.AdaptiveAvgPool2d((1, 1)),
+            nn.Flatten(start_dim=1),
+            nn.Linear(8, projection_in_features),
+        )
+        return model
+
+    @staticmethod
+    def _next_batch(dataset):
+        loader = get_dataloader(dataset, batch_size=2, shuffle=False)
+        return next(iter(loader))
+
+    def test_instantiation(self):
+        """Model can be created with valid args."""
+        model = self._build_model(self.binary_dataset)
+        self.assertIsInstance(model, MedFuse)
+        self.assertIsInstance(model.layer, MedFuseLayer)
+        self.assertEqual(model.ehr_input_dim, 10)
+
+    def test_forward_pass_both_modalities(self):
+        """Forward pass works with both EHR and CXR input."""
+        model = self._build_model(self.binary_dataset)
+        batch = self._next_batch(self.binary_dataset)
+
+        with torch.no_grad():
+            output = model(**batch)
+
+        self.assertIn("loss", output)
+        self.assertIn("y_prob", output)
+        self.assertIn("y_true", output)
+        self.assertIn("logit", output)
+
+    def test_forward_pass_ehr_only(self):
+        """Forward pass works with EHR only (missing CXR)."""
+        model = self._build_model(self.binary_dataset)
+        batch = self._next_batch(self.binary_dataset)
+
+        with torch.no_grad():
+            output = model(ehr=batch["ehr"], label=batch["label"])
+
+        self.assertIn("loss", output)
+        self.assertIn("y_prob", output)
+        self.assertEqual(output["logit"].shape, (2, 1))
+
+    def test_output_shape(self):
+        """Output tensor has correct shape [batch_size, num_labels]."""
+        model = self._build_model(self.binary_dataset)
+        batch = self._next_batch(self.binary_dataset)
+
+        with torch.no_grad():
+            output = model(**batch)
+
+        self.assertEqual(output["logit"].shape, (2, 1))
+        self.assertEqual(output["y_prob"].shape, (2, 1))
+
+    def test_gradient_computation(self):
+        """Gradients flow through the entire network."""
+        model = self._build_model(self.binary_dataset)
+        batch = self._next_batch(self.binary_dataset)
+
+        output = model(**batch)
+        loss = output["loss"]
+        loss.backward()
+
+        for name, parameter in model.named_parameters():
+            if name == "_dummy_param":
+                continue
+            if parameter.requires_grad:
+                if parameter.grad is None:
+                    print(f"Gradient missing for: {name}")
+                self.assertIsNotNone(parameter.grad)
+
+    def test_missing_modality_robustness(self):
+        """Model produces valid output for mixed modality availability."""
+        model = self._build_model(self.binary_dataset)
+        batch = self._next_batch(self.binary_dataset)
+        cxr_mask = torch.tensor([1, 0], dtype=torch.long)
+
+        with torch.no_grad():
+            output = model(
+                ehr=batch["ehr"],
+                cxr=batch["cxr"],
+                cxr_mask=cxr_mask,
+                label=batch["label"],
+            )
+
+        self.assertEqual(output["logit"].shape, (2, 1))
+        self.assertFalse(torch.isnan(output["y_prob"]).any().item())
+
+    def test_binary_vs_multilabel_mode(self):
+        """Model works in both binary and multilabel modes."""
+        binary_model = self._build_model(self.binary_dataset)
+        binary_batch = self._next_batch(self.binary_dataset)
+
+        with torch.no_grad():
+            binary_output = binary_model(**binary_batch)
+
+        self.assertEqual(binary_output["logit"].shape[1], 1)
+
+        multilabel_model = self._build_model(self.multilabel_dataset)
+        multilabel_batch = self._next_batch(self.multilabel_dataset)
+
+        with torch.no_grad():
+            multilabel_output = multilabel_model(**multilabel_batch)
+
+        self.assertEqual(multilabel_output["logit"].shape[1], 2)
+        self.assertTrue(torch.all(multilabel_output["y_prob"] >= 0).item())
+        self.assertTrue(torch.all(multilabel_output["y_prob"] <= 1).item())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_medfuse.py
+++ b/tests/core/test_medfuse.py
@@ -153,11 +153,10 @@ class TestMedFuse(unittest.TestCase):
         loss.backward()
 
         for name, parameter in model.named_parameters():
+            # _dummy_param is a 0-element BaseModel helper, skip grad check
             if name == "_dummy_param":
                 continue
             if parameter.requires_grad:
-                if parameter.grad is None:
-                    print(f"Gradient missing for: {name}")
                 self.assertIsNotNone(parameter.grad)
 
     def test_missing_modality_robustness(self):


### PR DESCRIPTION
Contributor: Sean Nian (snian2@illinois.edu), Tony Hong (tonyhong@illinois.edu), Yaqi Qiao (yaqiq2@illinois.edu)
Contribution Type: Model
Paper: https://arxiv.org/abs/2207.07027

Description
Add MedFuse, a multimodal clinical prediction model that fuses EHR time-series and chest X-ray representations using LSTM-based sequential fusion, with support for missing CXR modality.

Files to review
pyhealth/models/medfuse.py - New MedFuse model implementation including:

> MedFuse - Main PyHealth-integrated BaseModel subclass
> MedFuseLayer - Fusion layer with EHR LSTM encoder, ResNet CXR encoder, projection, and fusion LSTM

pyhealth/models/init.py - Added imports for MedFuse and MedFuseLayer
tests/core/test_medfuse.py - Unit tests with synthetic data covering instantiation, forward pass, output shape, gradient flow, missing modality, and binary/multilabel modes
examples/mimic4_mortality_medfuse.py - Ablation study varying EHR hidden dim, fusion hidden dim, dropout, learning rate, and modality
docs/api/models/pyhealth.models.MedFuse.rst - Sphinx documentation page
docs/api/models.rst - Added MedFuse entry to models table of contents