### PR TITLE
[DL4H Sp26] Add ICU Reentry and Clinical Aggregation tasks, tests, and example

### DIFF
--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -217,6 +217,8 @@ Available Tasks
     Mortality Prediction (Next Visit) <tasks/pyhealth.tasks.mortality_prediction>
     Mortality Prediction (StageNet MIMIC-IV) <tasks/pyhealth.tasks.mortality_prediction_stagenet_mimic4>
     Patient Linkage (MIMIC-III) <tasks/pyhealth.tasks.patient_linkage_mimic3_fn>
+    ICU Re-entry Classification (MIMIC-III) <tasks/pyhealth.tasks.mimic3_icu_reentry>
+    MIMIC-III Clinical Aggregation <tasks/pyhealth.tasks.mimic3_clinical_aggregation>
     Readmission Prediction <tasks/pyhealth.tasks.readmission_prediction>
     Sleep Staging <tasks/pyhealth.tasks.sleep_staging>
     Sleep Staging (SleepEDF) <tasks/pyhealth.tasks.SleepStagingSleepEDF>

--- a/docs/api/tasks/pyhealth.tasks.mimic3_clinical_aggregation.rst
+++ b/docs/api/tasks/pyhealth.tasks.mimic3_clinical_aggregation.rst
@@ -1,0 +1,10 @@
+pyhealth.tasks.mimic3_clinical_aggregation
+===========================================
+
+.. autodata:: pyhealth.tasks.mimic3_clinical_aggregation.CLINICAL_CATEGORIES
+    :annotation: List[str] — ordered list of 65 clinical category names
+
+.. autodata:: pyhealth.tasks.mimic3_clinical_aggregation.CLINICAL_AGGREGATION_MAP
+    :annotation: Dict[str, List[str]] — maps each category to its LEVEL2 source columns
+
+.. autofunction:: pyhealth.tasks.mimic3_clinical_aggregation.apply_clinical_aggregation

--- a/docs/api/tasks/pyhealth.tasks.mimic3_icu_reentry.rst
+++ b/docs/api/tasks/pyhealth.tasks.mimic3_icu_reentry.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.mimic3_icu_reentry
+==================================
+
+.. autoclass:: pyhealth.tasks.mimic3_icu_reentry.ICUReEntryClassification
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/icu_reentry_pred_lstm_mimic3.py
+++ b/examples/icu_reentry_pred_lstm_mimic3.py
@@ -1,0 +1,211 @@
+"""
+PyHealth LSTM Example: ICU Re-entry Prediction with Clinical Features
+=====================================================================
+This script demonstrates how to:
+  1. Generate synthetic ICU stay data (mimicking MIMIC-III structure)
+  2. Apply the ICUReEntryClassification task using from_arrays()
+  3. Build a SampleDataset with create_sample_dataset()
+  4. Train an LSTM model for 7-day ICU re-entry prediction
+  5. Evaluate on a held-out test set
+
+The ICU re-entry task (Nestor et al. 2019) predicts whether a patient will
+return to the ICU within 7 days of their current ICU episode's end, using
+the first 24 hours of hourly vitals and labs as input.
+
+In a real workflow, the (24, 65) vitals arrays come from MIMIC_Extract's
+all_hourly_data.h5 after applying clinical aggregation to map LEVEL2 columns
+to the 65 expert-defined feature categories.
+
+Requirements:
+    pip install pyhealth torch
+
+References:
+    - Nestor et al. 2019: https://proceedings.mlr.press/v106/nestor19a.html
+    - PyHealth docs: https://pyhealth.readthedocs.io
+"""
+
+# ─── Imports ──────────────────────────────────────────────────────────────────
+import os
+import random
+import numpy as np
+import torch
+
+from pyhealth.datasets import create_sample_dataset, split_by_patient, get_dataloader
+from pyhealth.tasks.mimic3_icu_reentry import ICUReEntryClassification
+from pyhealth.models import RNN
+from pyhealth.trainer import Trainer
+
+# ─── Reproducibility ──────────────────────────────────────────────────────────
+SEED = 42
+random.seed(SEED)
+np.random.seed(SEED)
+torch.manual_seed(SEED)
+
+# ─── 1. Generate Synthetic ICU Data ──────────────────────────────────────────
+# Simulate 200 ICU stays across 100 patients, each with a (24, 65) vitals
+# tensor representing 24 hours of hourly measurements across 65 clinical
+# feature categories (clinical aggregation from Nestor et al. 2019).
+#
+# For real MIMIC-III data, replace this section with:
+#   dataset = MIMIC3Dataset(root="/path/to/mimic3", tables=[...])
+#   followed by the MIMICExtract pipeline + apply_clinical_aggregation().
+
+print("=" * 60)
+print("Step 1 – Generating Synthetic ICU Stay Data")
+print("=" * 60)
+
+N_PATIENTS = 100
+N_STAYS    = 200
+N_HOURS    = 24
+N_FEATURES = 65   # 65-category clinical aggregation (Nestor et al. 2019)
+
+rng = np.random.default_rng(SEED)
+
+# (N_STAYS, 24, 65) float32 vitals tensors
+features = rng.standard_normal((N_STAYS, N_HOURS, N_FEATURES)).astype(np.float32)
+
+# Patient assignments (multi-stay patients are common in MIMIC-III)
+patient_ids = rng.integers(1001, 1001 + N_PATIENTS, size=N_STAYS).tolist()
+stay_ids    = list(range(200_001, 200_001 + N_STAYS))
+
+# Synthetic 7-day re-entry labels (~25% positive rate)
+labels = rng.choice([0, 1], size=N_STAYS, p=[0.75, 0.25]).tolist()
+
+n_pos = sum(labels)
+print(f"  Stays            : {N_STAYS}")
+print(f"  Unique patients  : {len(set(patient_ids))}")
+print(f"  Positives        : {n_pos}  ({100 * n_pos / N_STAYS:.0f}%)")
+print(f"  Feature shape    : ({N_HOURS}, {N_FEATURES})")
+
+# ─── 2. Apply ICU Re-entry Task ───────────────────────────────────────────────
+# ICUReEntryClassification.from_arrays() converts numpy arrays into PyHealth
+# sample dicts.  Each dict contains:
+#   - patient_id (str), visit_id (str)
+#   - vitals_labs: np.ndarray of shape (24, 65)
+#   - reentry_7day: int (0 or 1)
+
+print("\n" + "=" * 60)
+print("Step 2 – Applying ICU Re-entry Task")
+print("=" * 60)
+
+task = ICUReEntryClassification(feature_set="clinical")
+samples = task.from_arrays(
+    features    = features,
+    labels      = np.array(labels),
+    stay_ids    = stay_ids,
+    patient_ids = patient_ids,
+)
+print(f"  Total samples  : {len(samples)}")
+print(f"  Sample keys    : {list(samples[0].keys())}")
+print(f"  vitals_labs    : shape {samples[0]['vitals_labs'].shape}")
+print(f"  reentry_7day   : {samples[0]['reentry_7day']}")
+
+# ─── 3. Build SampleDataset ───────────────────────────────────────────────────
+# create_sample_dataset() fits feature processors (TensorProcessor for
+# vitals_labs, BinaryProcessor for reentry_7day) and returns an
+# InMemorySampleDataset ready for model training.
+
+print("\n" + "=" * 60)
+print("Step 3 – Creating SampleDataset")
+print("=" * 60)
+
+dataset = create_sample_dataset(
+    samples       = samples,
+    input_schema  = task.input_schema,    # {"vitals_labs": "tensor"}
+    output_schema = task.output_schema,   # {"reentry_7day": "binary"}
+    dataset_name  = "mimic3_icu_reentry_synthetic",
+    task_name     = task.task_name,
+)
+print(f"  Dataset size   : {len(dataset)}")
+print(f"  Input schema   : {dataset.input_schema}")
+print(f"  Output schema  : {dataset.output_schema}")
+
+# ─── 4. Train / Val / Test Split ─────────────────────────────────────────────
+print("\n" + "=" * 60)
+print("Step 4 – Splitting Dataset (70 / 10 / 20)")
+print("=" * 60)
+
+train_ds, val_ds, test_ds = split_by_patient(
+    dataset, [0.70, 0.10, 0.20], seed=SEED
+)
+print(f"  Train : {len(train_ds)} | Val : {len(val_ds)} | Test : {len(test_ds)}")
+
+train_loader = get_dataloader(train_ds, batch_size=32, shuffle=True)
+val_loader   = get_dataloader(val_ds,   batch_size=32, shuffle=False)
+test_loader  = get_dataloader(test_ds,  batch_size=32, shuffle=False)
+
+# ─── 5. Build LSTM Model ─────────────────────────────────────────────────────
+# RNN derives feature_keys and label_key from the dataset schemas.
+# For vitals_labs of shape (24, 65), EmbeddingModel adds a Linear(65 →
+# embedding_dim) projection before the LSTM sees (B, 24, embedding_dim).
+
+print("\n" + "=" * 60)
+print("Step 5 – Building LSTM Model")
+print("=" * 60)
+
+model = RNN(
+    dataset       = dataset,
+    embedding_dim = 128,
+    hidden_dim    = 256,
+    rnn_type      = "LSTM",
+    num_layers    = 2,
+    dropout       = 0.3,
+)
+
+total_params = sum(p.numel() for p in model.parameters())
+print(f"  Feature        : vitals_labs  ({N_HOURS}h × {N_FEATURES} features)")
+print(f"  Embedding dim  : 128")
+print(f"  Hidden dim     : 256")
+print(f"  Layers         : 2")
+print(f"  Total params   : {total_params:,}")
+
+# ─── 6. Train with PyHealth Trainer ───────────────────────────────────────────
+print("\n" + "=" * 60)
+print("Step 6 – Training LSTM")
+print("=" * 60)
+
+trainer = Trainer(
+    model   = model,
+    metrics = ["pr_auc", "roc_auc", "f1"],
+)
+
+trainer.train(
+    train_dataloader = train_loader,
+    val_dataloader   = val_loader,
+    epochs           = 10,
+    optimizer_params = {"lr": 1e-3},
+    monitor          = "roc_auc",
+)
+
+# ─── 7. Evaluate on Test Set ──────────────────────────────────────────────────
+print("\n" + "=" * 60)
+print("Step 7 – Evaluating on Test Set")
+print("=" * 60)
+
+results = trainer.evaluate(test_loader)
+print(f"  ROC-AUC : {results.get('roc_auc', 'N/A'):.4f}")
+print(f"  PR-AUC  : {results.get('pr_auc',  'N/A'):.4f}")
+print(f"  F1      : {results.get('f1',      'N/A'):.4f}")
+
+# ─── 8. Single-Sample Inference Demo ─────────────────────────────────────────
+print("\n" + "=" * 60)
+print("Step 8 – Single-Sample Inference Demo")
+print("=" * 60)
+
+model.eval()
+sample_batch = next(iter(test_loader))
+with torch.no_grad():
+    output = model(**sample_batch)
+
+y_prob  = output["y_prob"].squeeze(-1)
+y_true  = output["y_true"].squeeze(-1)
+for i in range(min(3, len(y_prob))):
+    prob  = y_prob[i].item()
+    truth = int(y_true[i].item())
+    print(
+        f"  Sample {i+1}: P(re-entry within 7d) = {prob:.3f}  |  "
+        f"True = {truth}  |  "
+        f"Pred = {'HIGH risk' if prob > 0.5 else 'LOW  risk'}"
+    )
+
+print("\nDone!")

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -22,6 +22,12 @@ from .drug_recommendation import (
     drug_recommendation_omop_fn,
 )
 from .in_hospital_mortality_mimic4 import InHospitalMortalityMIMIC4
+from .mimic3_clinical_aggregation import (
+    CLINICAL_AGGREGATION_MAP,
+    CLINICAL_CATEGORIES,
+    apply_clinical_aggregation,
+)
+from .mimic3_icu_reentry import ICUReEntryClassification
 from .length_of_stay_prediction import (
     LengthOfStayPredictioneICU,
     LengthOfStayPredictionMIMIC3,

--- a/pyhealth/tasks/mimic3_clinical_aggregation.py
+++ b/pyhealth/tasks/mimic3_clinical_aggregation.py
@@ -1,0 +1,242 @@
+"""
+PyHealth task for ICU Re-entry classification using the MIMIC-III dataset.
+
+Reproducing and extending: Feature Robustness in Non-Stationary Health Records
+(Nestor et al. 2019). This task predicts whether a patient will have an
+unplanned return to the ICU within 7 days of their current ICU episode end,
+using the first 24 hours of hourly vitals and labs as input features.
+
+A direct transfer (ICU stay beginning within 24 hours of a prior stay) is not
+considered a re-entry. Re-entry is defined at the episode level: a patient must
+return to the ICU after a gap of > 24 hours and <= 168 hours (7 days) from the
+end of their current episode.
+
+The clinical aggregation mapping collapses MIMIC_Extract LEVEL2 columns into
+65 expert-defined clinical categories following Nestor et al. 2019. Three
+categories from the paper's original 68 (bicarbonate, capillary refill rate,
+lactate dehydrogenase) were absent from the available MIMIC_Extract output and
+are excluded, resulting in a 65-category feature set.
+
+Reference:
+    Nestor et al. (2019). Feature Robustness in Non-Stationary Health Records:
+    Caveats to Deployable Model Performance in Common Clinical Machine Learning
+    Tasks. Proceedings of the 4th Machine Learning for Healthcare Conference,
+    PMLR 106, 381-405.
+
+Author:
+    Jenna Reno (jlreno2@illinois.edu)
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from pyhealth.tasks import BaseTask
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Clinical Aggregation Map — 65 categories
+#
+# Maps expert-defined clinical category names to one or more LEVEL2 column
+# names from MIMIC_Extract output (all_hourly_data.h5). Where multiple LEVEL2
+# names map to one category, their hourly values are averaged. This is the
+# mechanism that provides robustness across the CareVue (pre-2008) and
+# MetaVision (post-2008) EHR systems in MIMIC-III.
+#
+# All LEVEL2 strings are lowercase and match the HDF5 column MultiIndex
+# produced by MIMIC_Extract exactly.
+#
+# Deviations from Nestor et al. 2019 (original 68 categories):
+#   - bicarbonate: absent from available MIMIC_Extract output — excluded
+#   - capillary refill rate: absent from available MIMIC_Extract output — excluded
+#   - lactate dehydrogenase: absent from available MIMIC_Extract output — excluded
+# ---------------------------------------------------------------------------
+
+CLINICAL_AGGREGATION_MAP: Dict[str, List[str]] = {
+
+    # --- Vitals (9) ---
+    "heart rate":                               ["heart rate"],
+    "systolic blood pressure":                  ["systolic blood pressure"],
+    "diastolic blood pressure":                 ["diastolic blood pressure"],
+    "mean blood pressure":                      ["mean blood pressure"],
+    "respiratory rate":                         ["respiratory rate"],
+    "temperature":                              ["temperature"],
+    "oxygen saturation":                        ["oxygen saturation"],
+    "weight":                                   ["weight"],
+    "height":                                   ["height"],
+
+    # --- Neurological (1) ---
+    "glascow coma scale total":                 ["glascow coma scale total"],
+
+    # --- Respiratory / Ventilation (13) ---
+    # Measured and set values kept separate: they represent distinct clinical
+    # quantities (what the patient is doing vs. what the ventilator is told).
+    # PaCO2: 'co2 (etco2, pco2, etc.)' and 'co2' merged as proxies.
+    "respiratory rate set":                     ["respiratory rate set"],
+    "fraction inspired oxygen":                 ["fraction inspired oxygen"],
+    "fraction inspired oxygen set":             ["fraction inspired oxygen set"],
+    "positive end-expiratory pressure":         ["positive end-expiratory pressure"],
+    "positive end-expiratory pressure set":     ["positive end-expiratory pressure set"],
+    "tidal volume observed":                    ["tidal volume observed"],
+    "tidal volume set":                         ["tidal volume set"],
+    "tidal volume spontaneous":                 ["tidal volume spontaneous"],
+    "peak inspiratory pressure":                ["peak inspiratory pressure"],
+    "plateau pressure":                         ["plateau pressure"],
+    "partial pressure of oxygen":               ["partial pressure of oxygen"],
+    "partial pressure of carbon dioxide":       ["partial pressure of carbon dioxide",
+                                                 "co2 (etco2, pco2, etc.)",
+                                                 "co2"],
+    "ph":                                       ["ph"],
+
+    # --- Chemistry / Metabolic (13) ---
+    # Potassium and potassium serum kept separate: specimen context differs
+    # and the two columns come from different EHR systems.
+    "sodium":                                   ["sodium"],
+    "potassium":                                ["potassium"],
+    "potassium serum":                          ["potassium serum"],
+    "chloride":                                 ["chloride"],
+    "anion gap":                                ["anion gap"],
+    "blood urea nitrogen":                      ["blood urea nitrogen"],
+    "creatinine":                               ["creatinine"],
+    "glucose":                                  ["glucose"],
+    "calcium":                                  ["calcium"],
+    "calcium ionized":                          ["calcium ionized"],
+    "magnesium":                                ["magnesium"],
+    "phosphorous":                              ["phosphorous"],
+    "lactic acid":                              ["lactic acid"],
+
+    # --- Other Chemistry (2) ---
+    "cholesterol":                              ["cholesterol"],
+    "total protein":                            ["total protein"],
+
+    # --- Liver (4) ---
+    "bilirubin":                                ["bilirubin"],
+    "alanine aminotransferase":                 ["alanine aminotransferase"],
+    "asparate aminotransferase":                ["asparate aminotransferase"],
+    "alkaline phosphate":                       ["alkaline phosphate"],
+
+    # --- Hematology (9) ---
+    "white blood cell count":                   ["white blood cell count"],
+    "hemoglobin":                               ["hemoglobin"],
+    "hematocrit":                               ["hematocrit"],
+    "platelets":                                ["platelets"],
+    "red blood cell count":                     ["red blood cell count"],
+    "partial thromboplastin time":              ["partial thromboplastin time"],
+    "prothrombin time inr":                     ["prothrombin time inr"],
+    "prothrombin time pt":                      ["prothrombin time pt"],
+    "fibrinogen":                               ["fibrinogen"],
+
+    # --- Cardiac / Hemodynamic (12) ---
+    # Cardiac output fick and thermodilution kept separate: distinct
+    # measurement methods, not EHR-system aliases of the same event.
+    "cardiac output fick":                      ["cardiac output fick"],
+    "cardiac output thermodilution":            ["cardiac output thermodilution"],
+    "cardiac index":                            ["cardiac index"],
+    "central venous pressure":                  ["central venous pressure"],
+    "pulmonary artery pressure systolic":       ["pulmonary artery pressure systolic"],
+    "pulmonary artery pressure mean":           ["pulmonary artery pressure mean"],
+    "pulmonary capillary wedge pressure":       ["pulmonary capillary wedge pressure"],
+    "troponin-i":                               ["troponin-i"],
+    "troponin-t":                               ["troponin-t"],
+    "albumin":                                  ["albumin"],
+    "systemic vascular resistance":             ["systemic vascular resistance"],
+    "venous pvo2":                              ["venous pvo2"],
+
+    # --- Other / Renal (2) ---
+    "urine output":                             ["urine output"],
+    "post void residual":                       ["post void residual"],
+}
+
+# Ordered list of the 65 category names — defines feature ordering in tensors.
+CLINICAL_CATEGORIES: List[str] = list(CLINICAL_AGGREGATION_MAP.keys())
+
+assert len(CLINICAL_CATEGORIES) == 65, (
+    f"Expected 65 clinical categories, got {len(CLINICAL_CATEGORIES)}. "
+    "Check CLINICAL_AGGREGATION_MAP for accidental additions or removals."
+)
+
+
+def apply_clinical_aggregation(
+    hourly_data: "pd.DataFrame",
+    agg_func: str = "mean",
+    n_hours: int = 24,
+) -> "tuple[np.ndarray, List[str], List[int]]":
+    """
+    Applies clinical aggregation to MIMIC_Extract hourly output.
+
+    Collapses LEVEL2 feature columns into 65 expert-defined clinical categories
+    following Nestor et al. 2019. Where multiple LEVEL2 columns map to one
+    category, their values are averaged per hour.
+
+    Args:
+        hourly_data: DataFrame loaded from all_hourly_data.h5 'vitals_labs'.
+                     MultiIndex columns: (LEVEL2, Aggregation Function).
+                     MultiIndex rows: (subject_id, hadm_id, icustay_id,
+                     hours_in).
+        agg_func: Aggregation function to select from column MultiIndex.
+                  Default: 'mean'.
+        n_hours: Number of hourly windows per stay. Default: 24.
+
+    Returns:
+        Tuple of:
+        - clinical_array: np.ndarray of shape (n_stays, n_hours, 65).
+        - category_names: List of 65 category name strings.
+        - stay_ids: List of icustay_id integers.
+
+    Examples:
+        >>> import pandas as pd
+        >>> data = pd.read_hdf("all_hourly_data.h5", "vitals_labs")
+        >>> arr, cats, stays = apply_clinical_aggregation(data)
+        >>> arr.shape
+        (n_stays, 24, 65)
+    """
+    import pandas as pd
+
+    if isinstance(hourly_data.columns, pd.MultiIndex):
+        df = hourly_data.xs(agg_func, axis=1, level="Aggregation Function")
+    else:
+        df = hourly_data.copy()
+
+    available = set(df.columns.tolist())
+    category_names = list(CLINICAL_AGGREGATION_MAP.keys())
+    n_categories = len(category_names)
+
+    # Build one column per clinical category
+    clinical_cols = {}
+    for category, source_cols in CLINICAL_AGGREGATION_MAP.items():
+        present = [c for c in source_cols if c in available]
+        if present:
+            clinical_cols[category] = df[present].mean(axis=1)
+        else:
+            clinical_cols[category] = pd.Series(
+                np.nan, index=df.index, dtype=np.float32
+            )
+    clinical_df = pd.DataFrame(clinical_cols, index=df.index)
+
+    # Reshape into (n_stays, n_hours, n_categories)
+    stay_ids = clinical_df.index.get_level_values("icustay_id").unique().tolist()
+    n_stays = len(stay_ids)
+    clinical_array = np.full(
+        (n_stays, n_hours, n_categories), fill_value=np.nan, dtype=np.float32
+    )
+
+    for i, stay_id in enumerate(stay_ids):
+        stay_data = clinical_df.xs(stay_id, level="icustay_id").reset_index()
+        hours_col = "hours_in" if "hours_in" in stay_data.columns \
+            else stay_data.columns[0]
+        for _, row in stay_data.iterrows():
+            try:
+                hour = int(row[hours_col])
+            except (TypeError, ValueError):
+                continue
+            if 0 <= hour < n_hours:
+                clinical_array[i, hour, :] = row[category_names].values.astype(
+                    np.float32
+                )
+
+    return clinical_array, category_names, stay_ids
+
+

--- a/pyhealth/tasks/mimic3_icu_reentry.py
+++ b/pyhealth/tasks/mimic3_icu_reentry.py
@@ -1,0 +1,328 @@
+"""
+PyHealth task for ICU Re-entry classification using the MIMIC-III dataset.
+
+Reproducing and extending: Feature Robustness in Non-Stationary Health Records
+(Nestor et al. 2019). This task predicts whether a patient will have an
+unplanned return to the ICU within 7 days of their current ICU episode end,
+using the first 24 hours of hourly vitals and labs as input features.
+
+A direct transfer (ICU stay beginning within 24 hours of a prior stay) is not
+considered a re-entry. Re-entry is defined at the episode level: a patient must
+return to the ICU after a gap of > 24 hours and <= 168 hours (7 days) from the
+end of their current episode.
+
+Reference:
+    Nestor et al. (2019). Feature Robustness in Non-Stationary Health Records:
+    Caveats to Deployable Model Performance in Common Clinical Machine Learning
+    Tasks. Proceedings of the 4th Machine Learning for Healthcare Conference,
+    PMLR 106, 381-405.
+
+Author:
+    Jenna Reno (jlreno2@illinois.edu)
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from pyhealth.tasks import BaseTask
+
+from pyhealth.tasks.mimic3_clinical_aggregation import (
+    CLINICAL_AGGREGATION_MAP,
+    CLINICAL_CATEGORIES,
+    apply_clinical_aggregation,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ICUReEntryClassification(BaseTask):
+    """
+    Task for predicting 7-day unplanned ICU re-entry using MIMIC-III data.
+
+    Given the first 24 hours of hourly vitals and lab values from a patient's
+    ICU stay, this task predicts whether the patient will have an unplanned
+    return to the ICU within 7 days of their current episode's end.
+
+    Input features are expected to be pre-aggregated into either the clinical
+    aggregation representation (65 expert-defined categories, see
+    ``CLINICAL_AGGREGATION_MAP``) or the raw LEVEL2 representation from
+    MIMIC_Extract, and forward-fill imputed prior to use.
+
+    Direct transfers (ICU stays beginning within 24 hours of a prior stay)
+    are excluded from both the cohort and the set of qualifying re-entries.
+    Re-entry is evaluated at the episode level: a chain of transfer-linked
+    stays is treated as a single episode, and re-entry requires a new episode
+    to begin more than 24 hours and no more than 168 hours after the
+    episode's end.
+
+    Attributes:
+        task_name (str): The name of the task.
+        input_schema (Dict[str, str]): Maps ``vitals_labs`` to ``"tensor"``.
+        output_schema (Dict[str, str]): Maps ``reentry_7day`` to ``"binary"``.
+        feature_set (str): Feature representation in use. Either
+            ``"clinical"`` (65 aggregated categories) or ``"raw"`` (all
+            LEVEL2 columns from MIMIC_Extract). Documentation only.
+        reentry_window_hours (int): Maximum gap qualifying as re-entry.
+            Default: 168 (7 days).
+        transfer_threshold_hours (int): Maximum gap treated as direct
+            transfer. Default: 24.
+
+    Examples:
+        Using ``from_arrays()`` with preprocessed tensors:
+
+        >>> import numpy as np
+        >>> from pyhealth.datasets import SampleDataset
+        >>> task = ICUReEntryClassification(feature_set="clinical")
+        >>> samples = task.from_arrays(
+        ...     features=np.zeros((5, 24, 65), dtype="float32"),
+        ...     labels=np.array([0, 1, 0, 0, 1]),
+        ...     stay_ids=[200001, 200002, 200003, 200004, 200005],
+        ... )
+        >>> dataset = SampleDataset(samples, dataset_name="mimic3_reentry")
+        >>> len(dataset)
+        5
+    """
+
+    task_name: str = "ICUReEntryClassification"
+    input_schema: Dict[str, str] = {"vitals_labs": "tensor"}
+    output_schema: Dict[str, str] = {"reentry_7day": "binary"}
+
+    def __init__(
+        self,
+        feature_set: str = "clinical",
+        reentry_window_hours: int = 168,
+        transfer_threshold_hours: int = 24,
+    ):
+        """
+        Initializes the ICUReEntryClassification task.
+
+        Args:
+            feature_set: Feature representation to document. Either
+                ``"clinical"`` or ``"raw"``. Does not affect processing logic.
+                Default: ``"clinical"``.
+            reentry_window_hours: Hours after episode end within which a new
+                ICU episode qualifies as re-entry. Default: 168 (7 days).
+            transfer_threshold_hours: Hours between stays below which the
+                transition is a direct transfer (not re-entry). Default: 24.
+
+        Raises:
+            ValueError: If ``feature_set`` is not ``"clinical"`` or ``"raw"``.
+            ValueError: If ``reentry_window_hours`` is not positive.
+            ValueError: If ``transfer_threshold_hours`` is not positive or
+                is >= ``reentry_window_hours``.
+        """
+        if feature_set not in ("clinical", "raw"):
+            raise ValueError(
+                f"feature_set must be 'clinical' or 'raw', got '{feature_set}'"
+            )
+        if reentry_window_hours <= 0:
+            raise ValueError(
+                f"reentry_window_hours must be positive, "
+                f"got {reentry_window_hours}"
+            )
+        if transfer_threshold_hours <= 0:
+            raise ValueError(
+                f"transfer_threshold_hours must be positive, "
+                f"got {transfer_threshold_hours}"
+            )
+        if transfer_threshold_hours >= reentry_window_hours:
+            raise ValueError(
+                f"transfer_threshold_hours ({transfer_threshold_hours}) must "
+                f"be less than reentry_window_hours ({reentry_window_hours})"
+            )
+
+        self.feature_set = feature_set
+        self.reentry_window_hours = reentry_window_hours
+        self.transfer_threshold_hours = transfer_threshold_hours
+
+        logger.info(
+            f"ICUReEntryClassification initialized: "
+            f"feature_set={feature_set}, "
+            f"reentry_window={reentry_window_hours}h, "
+            f"transfer_threshold={transfer_threshold_hours}h"
+        )
+
+    def __call__(self, patient: Any) -> List[Dict[str, Any]]:
+        """
+        Processes a single patient for the ICU re-entry classification task.
+
+        Iterates over the patient's ICU stays, groups them into episodes
+        (chains of stays separated by less than ``transfer_threshold_hours``),
+        and labels each episode based on whether a subsequent episode begins
+        within ``reentry_window_hours`` of the current episode's end.
+
+        Args:
+            patient: A PyHealth Patient object with ICU stay events accessible
+                via ``patient.get_events(event_type="icustays")``. Each event
+                must have ``icustay_id``, ``intime``, ``outtime``, and
+                ``vitals_labs`` attributes, where ``vitals_labs`` is a
+                (24, n_features) float32 numpy array of pre-aggregated,
+                forward-fill imputed hourly features.
+
+        Returns:
+            List of sample dicts, one per qualifying ICU episode:
+
+            - ``patient_id`` (str): Subject ID.
+            - ``visit_id`` (str): ICUSTAY_ID of the index stay.
+            - ``vitals_labs`` (np.ndarray): Shape (24, n_features).
+            - ``reentry_7day`` (int): 1 if qualifying re-entry, 0 otherwise.
+
+            Returns an empty list if the patient has no ICU stays or if no
+            stays have ``vitals_labs`` data.
+        """
+        samples = []
+
+        icu_stays = patient.get_events(event_type="icustays")
+        if not icu_stays:
+            return samples
+
+        icu_stays = sorted(icu_stays, key=lambda s: s.intime)
+
+        # ── Group stays into episodes ─────────────────────────────────────
+        episodes = []
+        current_episode = [icu_stays[0]]
+        for stay in icu_stays[1:]:
+            gap_hours = (
+                (stay.intime - current_episode[-1].outtime).total_seconds()
+                / 3600
+            )
+            if gap_hours < self.transfer_threshold_hours:
+                current_episode.append(stay)
+            else:
+                episodes.append(current_episode)
+                current_episode = [stay]
+        episodes.append(current_episode)
+
+        # ── Label each episode ────────────────────────────────────────────
+        for ep_idx, episode in enumerate(episodes):
+            index_stay  = episode[0]
+            episode_end = max(s.outtime for s in episode)
+
+            reentry_label = 0
+            if ep_idx + 1 < len(episodes):
+                next_start = episodes[ep_idx + 1][0].intime
+                gap_hours  = (
+                    (next_start - episode_end).total_seconds() / 3600
+                )
+                if (
+                    gap_hours > self.transfer_threshold_hours
+                    and gap_hours <= self.reentry_window_hours
+                ):
+                    reentry_label = 1
+
+            if not hasattr(index_stay, "vitals_labs") or \
+                    index_stay.vitals_labs is None:
+                logger.debug(
+                    f"No vitals_labs for stay {index_stay.icustay_id} "
+                    f"— skipping."
+                )
+                continue
+
+            samples.append({
+                "patient_id":   str(patient.patient_id),
+                "visit_id":     str(index_stay.icustay_id),
+                "vitals_labs":  index_stay.vitals_labs,
+                "reentry_7day": reentry_label,
+            })
+
+        return samples
+
+    def from_arrays(
+        self,
+        features: np.ndarray,
+        labels: np.ndarray,
+        stay_ids: List[int],
+        patient_ids: Optional[List[int]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Constructs sample dicts from preprocessed numpy arrays.
+
+        Use this method when working with tensors produced by
+        ``apply_clinical_aggregation()`` rather than a PyHealth dataset object.
+        The returned list is compatible with PyHealth's ``SampleDataset``.
+
+        Args:
+            features: Float32 array of shape (n_stays, 24, n_features)
+                containing pre-aggregated, forward-fill imputed hourly
+                vitals and labs. For the clinical representation, n_features
+                should be 65 (matching ``CLINICAL_CATEGORIES``).
+            labels: Integer array of shape (n_stays,) containing binary
+                re-entry labels (0 or 1).
+            stay_ids: List of ICUSTAY_ID integers, length n_stays.
+            patient_ids: Optional list of SUBJECT_ID integers, length
+                n_stays. If None, stay_ids are used as patient_ids.
+
+        Returns:
+            List of sample dicts, one per stay:
+
+            - ``patient_id`` (str): Subject or stay ID.
+            - ``visit_id`` (str): ICUSTAY_ID.
+            - ``vitals_labs`` (np.ndarray): Shape (24, n_features).
+            - ``reentry_7day`` (int): Binary re-entry label.
+
+        Raises:
+            ValueError: If array lengths are mismatched.
+            ValueError: If ``features`` is not 3-dimensional or does not
+                have 24 time steps.
+
+        Examples:
+            >>> import numpy as np
+            >>> task = ICUReEntryClassification(feature_set="clinical")
+            >>> features = np.zeros((3, 24, 65), dtype="float32")
+            >>> labels   = np.array([0, 1, 0])
+            >>> stay_ids = [200001, 200002, 200003]
+            >>> samples  = task.from_arrays(features, labels, stay_ids)
+            >>> len(samples)
+            3
+            >>> samples[1]["reentry_7day"]
+            1
+        """
+        n_stays = len(stay_ids)
+
+        if features.shape[0] != n_stays:
+            raise ValueError(
+                f"features has {features.shape[0]} rows but "
+                f"stay_ids has {n_stays} entries."
+            )
+        if len(labels) != n_stays:
+            raise ValueError(
+                f"labels has {len(labels)} entries but "
+                f"stay_ids has {n_stays} entries."
+            )
+        if features.ndim != 3:
+            raise ValueError(
+                f"features must be 3-dimensional (n_stays, 24, n_features), "
+                f"got shape {features.shape}."
+            )
+        if features.shape[1] != 24:
+            raise ValueError(
+                f"features must have 24 time steps, got {features.shape[1]}."
+            )
+        if patient_ids is not None and len(patient_ids) != n_stays:
+            raise ValueError(
+                f"patient_ids has {len(patient_ids)} entries but "
+                f"stay_ids has {n_stays} entries."
+            )
+
+        pid_list = patient_ids if patient_ids is not None else stay_ids
+        n_pos    = int(sum(labels))
+
+        samples = [
+            {
+                "patient_id":   str(pid),
+                "visit_id":     str(stay_id),
+                "vitals_labs":  features[i],
+                "reentry_7day": int(labels[i]),
+            }
+            for i, (stay_id, pid) in enumerate(zip(stay_ids, pid_list))
+        ]
+
+        logger.info(
+            f"from_arrays: {len(samples)} samples "
+            f"(pos={n_pos}, neg={n_stays - n_pos}), "
+            f"feature_set={self.feature_set}, "
+            f"feature_dim={features.shape[2]}"
+        )
+        return samples

--- a/tests/core/test_mimic3_icu_reentry.py
+++ b/tests/core/test_mimic3_icu_reentry.py
@@ -1,0 +1,1116 @@
+"""
+Synthetic test fixtures and unit tests for ICUReEntryClassification.
+
+Fixtures
+--------
+Provides a minimal set of 17 ICU stays across 9 patients with known
+re-entry labels, designed to exercise all branches of the task logic:
+
+    - Single-stay patients (no re-entry possible)
+    - Multi-stay patients with qualifying re-entry (gap > 24h, <= 168h)
+    - Multi-stay patients with gap > 7 days (not a re-entry)
+    - Multi-stay patients with direct transfer (gap < 24h, same episode)
+    - Transfer chain followed by qualifying re-entry
+
+All feature tensors are synthetic float32 arrays of shape (24, 65),
+populated with physiologically plausible ranges for key vitals so that
+spot-checks are meaningful. Labels are deterministic and verified by hand
+against the episode grouping logic in ICUReEntryClassification.
+
+Unit tests
+----------
+TestICUReEntryClassification covers:
+    - Task class schema attributes
+    - Constructor defaults and validation (ValueError on bad args)
+    - from_arrays() happy path and shape/length error cases
+    - __call__() episode grouping and re-entry labeling for each patient
+      scenario defined in the fixture set
+
+Usage:
+    >>> from tests.test_mimic3_icu_reentry import SYNTHETIC_STAYS, EXPECTED_LABELS
+    >>> task = ICUReEntryClassification(feature_set="clinical")
+    >>> samples = task.from_arrays(
+    ...     features=np.stack([s["vitals_labs"] for s in SYNTHETIC_STAYS]),
+    ...     labels=np.array([s["reentry_7day"] for s in SYNTHETIC_STAYS]),
+    ...     stay_ids=[s["icustay_id"] for s in SYNTHETIC_STAYS],
+    ...     patient_ids=[s["subject_id"] for s in SYNTHETIC_STAYS],
+    ... )
+"""
+
+import unittest
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Feature tensor construction helpers
+# ---------------------------------------------------------------------------
+
+# Index positions in the 65-category feature vector for key vitals,
+# used to populate synthetic tensors with plausible values.
+# Matches the ordering in CLINICAL_CATEGORIES from mimic3_icu_reentry.py.
+_FEATURE_INDICES = {
+    "heart rate":             0,
+    "systolic blood pressure": 1,
+    "diastolic blood pressure": 2,
+    "mean blood pressure":    3,
+    "respiratory rate":       4,
+    "temperature":            5,
+    "oxygen saturation":      6,
+}
+
+N_FEATURES = 65
+N_HOURS    = 24
+
+
+def make_vitals_tensor(
+    heart_rate: float = 80.0,
+    systolic_bp: float = 120.0,
+    diastolic_bp: float = 75.0,
+    mean_bp: float = 90.0,
+    resp_rate: float = 16.0,
+    temperature: float = 37.0,
+    spo2: float = 97.0,
+    noise_scale: float = 2.0,
+    seed: int = 0,
+) -> np.ndarray:
+    """
+    Constructs a (24, 65) float32 feature tensor with plausible vital signs.
+
+    Core vitals are populated with the provided base values plus small
+    Gaussian noise across hours. All other features are set to 0.0
+    (representing no observation, consistent with forward-fill imputation
+    of missing values).
+
+    Args:
+        heart_rate: Base heart rate (bpm). Normal: 60-100.
+        systolic_bp: Base systolic blood pressure (mmHg). Normal: 90-140.
+        diastolic_bp: Base diastolic blood pressure (mmHg). Normal: 60-90.
+        mean_bp: Base mean arterial pressure (mmHg). Normal: 70-100.
+        resp_rate: Base respiratory rate (breaths/min). Normal: 12-20.
+        temperature: Base temperature (Celsius). Normal: 36.5-37.5.
+        spo2: Base oxygen saturation (%). Normal: 95-100.
+        noise_scale: Standard deviation of per-hour Gaussian noise.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        np.ndarray of shape (24, 65), dtype float32.
+    """
+    rng    = np.random.default_rng(seed)
+    tensor = np.zeros((N_HOURS, N_FEATURES), dtype=np.float32)
+
+    base_values = {
+        "heart rate":              heart_rate,
+        "systolic blood pressure": systolic_bp,
+        "diastolic blood pressure": diastolic_bp,
+        "mean blood pressure":     mean_bp,
+        "respiratory rate":        resp_rate,
+        "temperature":             temperature,
+        "oxygen saturation":       spo2,
+    }
+
+    for feat_name, base_val in base_values.items():
+        idx = _FEATURE_INDICES[feat_name]
+        noise = rng.normal(0, noise_scale, size=N_HOURS).astype(np.float32)
+        tensor[:, idx] = np.clip(base_val + noise, 0, None)
+
+    return tensor
+
+
+# ---------------------------------------------------------------------------
+# Patient definitions
+# ---------------------------------------------------------------------------
+# Each patient dict defines one or more ICU stays with INTIME, OUTTIME,
+# and a pre-computed vitals tensor. The expected re-entry label for the
+# index stay (first stay per episode) is included for test assertion.
+#
+# Episode grouping rule: stays separated by < 24h are the same episode.
+# Re-entry rule: next episode starts > 24h and <= 168h after episode_end.
+#
+# Patient roster:
+#   P001 — single stay, no re-entry (label=0)
+#   P002 — two stays, gap=72h -> re-entry (label=1)
+#   P003 — two stays, gap=200h -> no re-entry, gap too long (label=0)
+#   P004 — two stays, gap=6h -> direct transfer, one episode (label=0)
+#   P005 — three stays: stays 1+2 are a transfer chain, stay 3 is
+#           re-entry 96h after chain end (chain label=1, stay 3 is new ep)
+#   P006 — single stay, no subsequent admission (label=0)
+#   P007 — two stays, gap=168h -> re-entry, exactly at boundary (label=1)
+#   P008 — two stays, gap=169h -> no re-entry, just over boundary (label=0)
+#   P009 — three stays: all three are separate episodes with qualifying
+#           re-entry between ep1->ep2 (label=1) and no re-entry ep2->ep3
+#           because gap > 7 days (ep2 label=0)
+#   P010 — two stays, gap=25h -> re-entry, just over transfer threshold
+#           (label=1)
+# ---------------------------------------------------------------------------
+
+T0 = datetime(2100, 1, 1, 8, 0, 0)   # Arbitrary base time
+
+
+def date_time(days: float = 0, hours: float = 0) -> datetime:
+    """Returns _T0 offset by the given days and hours."""
+    return T0 + timedelta(days=days, hours=hours)
+
+
+# ── P001: Single stay, no re-entry ───────────────────────────────────────
+P001_STAY1 = {
+    "subject_id":  1001,
+    "icustay_id":  100101,
+    "intime":      date_time(0),
+    "outtime":     date_time(3),           # 3-day stay
+    "vitals_labs": make_vitals_tensor(seed=1),
+    # No subsequent stay -> label 0
+    "reentry_7day": 0,
+}
+
+# ── P002: Two stays, gap = 72h -> qualifying re-entry ────────────────────
+P002_STAY1 = {
+    "subject_id":  1002,
+    "icustay_id":  100201,
+    "intime":      date_time(0),
+    "outtime":     date_time(2),           # discharged after 2 days
+    "vitals_labs": make_vitals_tensor(heart_rate=95.0, seed=2),
+    "reentry_7day": 1,               # stay2 starts 72h later -> re-entry
+}
+P002_STAY2 = {
+    "subject_id":  1002,
+    "icustay_id":  100202,
+    "intime":      date_time(5),           # gap = 72h from stay1 outtime
+    "outtime":     date_time(7),
+    "vitals_labs": make_vitals_tensor(heart_rate=88.0, seed=3),
+    "reentry_7day": 0,               # no subsequent stay
+}
+
+# ── P003: Two stays, gap = 200h -> too long, not a re-entry ──────────────
+P003_STAY1 = {
+    "subject_id":  1003,
+    "icustay_id":  100301,
+    "intime":      date_time(0),
+    "outtime":     date_time(2),
+    "vitals_labs": make_vitals_tensor(systolic_bp=145.0, seed=4),
+    "reentry_7day": 0,               # gap 200h > 168h -> not re-entry
+}
+P003_STAY2 = {
+    "subject_id":  1003,
+    "icustay_id":  100302,
+    "intime":      date_time(2, hours=200),  # gap = 200h
+    "outtime":     date_time(2, hours=210),
+    "vitals_labs": make_vitals_tensor(seed=5),
+    "reentry_7day": 0,
+}
+
+# ── P004: Two stays, gap = 6h -> direct transfer, same episode ───────────
+# Both stays belong to one episode. The index stay's label reflects
+# whether the episode has a qualifying re-entry, which it does not.
+P004_STAY1 = {
+    "subject_id":  1004,
+    "icustay_id":  100401,
+    "intime":      date_time(0),
+    "outtime":     date_time(1),
+    "vitals_labs": make_vitals_tensor(spo2=91.0, seed=6),
+    "reentry_7day": 0,               # stay2 is a transfer, no re-entry after
+}
+P004_STAY2 = {
+    "subject_id":  1004,
+    "icustay_id":  100402,
+    "intime":      date_time(1, hours=6),  # gap = 6h -> same episode
+    "outtime":     date_time(4),
+    "vitals_labs": make_vitals_tensor(seed=7),
+    "reentry_7day": 0,               # part of same episode as stay1
+}
+
+# ── P005: Transfer chain (stays 1+2) followed by re-entry (stay 3) ───────
+# Stay1 + Stay2 form one episode (gap=10h). Stay3 arrives 96h after
+# episode end -> qualifying re-entry for the episode.
+P005_STAY1 = {
+    "subject_id":  1005,
+    "icustay_id":  100501,
+    "intime":      date_time(0),
+    "outtime":     date_time(1),
+    "vitals_labs": make_vitals_tensor(resp_rate=22.0, seed=8),
+    "reentry_7day": 1,               # episode (stays 1+2) -> re-entry via stay3
+}
+P005_STAY2 = {
+    "subject_id":  1005,
+    "icustay_id":  100502,
+    "intime":      date_time(1, hours=10),  # gap = 10h -> transfer, same episode
+    "outtime":     date_time(3),
+    "vitals_labs": make_vitals_tensor(seed=9),
+    "reentry_7day": 1,               # also part of episode with re-entry
+}
+P005_STAY3 = {
+    "subject_id":  1005,
+    "icustay_id":  100503,
+    "intime":      date_time(3, hours=96),  # gap = 96h from episode end (stay2 outtime)
+    "outtime":     date_time(5, hours=96),
+    "vitals_labs": make_vitals_tensor(heart_rate=105.0, seed=10),
+    "reentry_7day": 0,               # no subsequent stay
+}
+
+# ── P006: Single stay, no re-entry ───────────────────────────────────────
+P006_STAY1 = {
+    "subject_id":  1006,
+    "icustay_id":  100601,
+    "intime":      date_time(0),
+    "outtime":     date_time(5),
+    "vitals_labs": make_vitals_tensor(temperature=38.5, seed=11),
+    "reentry_7day": 0,
+}
+
+# ── P007: Gap = 168h exactly -> re-entry (boundary, inclusive) ───────────
+P007_STAY1 = {
+    "subject_id":  1007,
+    "icustay_id":  100701,
+    "intime":      date_time(0),
+    "outtime":     date_time(2),
+    "vitals_labs": make_vitals_tensor(seed=12),
+    "reentry_7day": 1,               # gap = exactly 168h -> qualifies
+}
+P007_STAY2 = {
+    "subject_id":  1007,
+    "icustay_id":  100702,
+    "intime":      date_time(2, hours=168),  # gap = exactly 168h
+    "outtime":     date_time(4, hours=168),
+    "vitals_labs": make_vitals_tensor(seed=13),
+    "reentry_7day": 0,
+}
+
+# ── P008: Gap = 169h -> no re-entry (just over boundary) ─────────────────
+P008_STAY1 = {
+    "subject_id":  1008,
+    "icustay_id":  100801,
+    "intime":      date_time(0),
+    "outtime":     date_time(2),
+    "vitals_labs": make_vitals_tensor(seed=14),
+    "reentry_7day": 0,               # gap = 169h > 168h -> not re-entry
+}
+P008_STAY2 = {
+    "subject_id":  1008,
+    "icustay_id":  100802,
+    "intime":      date_time(2, hours=169),
+    "outtime":     date_time(4, hours=169),
+    "vitals_labs": make_vitals_tensor(seed=15),
+    "reentry_7day": 0,
+}
+
+# ── P009: Three stays, three separate episodes ───────────────────────────────
+# ep1 -> ep2: gap = 72h -> qualifying re-entry (ep1 label=1)
+# ep2 -> ep3: gap = 200h -> too long, not a re-entry (ep2 label=0)
+P009_STAY1 = {
+    "subject_id":  1009,
+    "icustay_id":  100901,
+    "intime":      date_time(0),
+    "outtime":     date_time(2),
+    "vitals_labs": make_vitals_tensor(seed=18),
+    "reentry_7day": 1,               # gap to stay2 = 72h -> re-entry
+}
+P009_STAY2 = {
+    "subject_id":  1009,
+    "icustay_id":  100902,
+    "intime":      date_time(5),           # gap = 72h from stay1 outtime
+    "outtime":     date_time(7),
+    "vitals_labs": make_vitals_tensor(seed=19),
+    "reentry_7day": 0,               # gap to stay3 = 200h -> not re-entry
+}
+P009_STAY3 = {
+    "subject_id":  1009,
+    "icustay_id":  100903,
+    "intime":      date_time(7, hours=200),  # gap = 200h from stay2 outtime
+    "outtime":     date_time(7, hours=210),
+    "vitals_labs": make_vitals_tensor(seed=20),
+    "reentry_7day": 0,               # no subsequent stay
+}
+
+# ── P010: Gap = 25h -> re-entry (just over transfer threshold) ───────────
+P010_STAY1 = {
+    "subject_id":  1010,
+    "icustay_id":  101001,
+    "intime":      date_time(0),
+    "outtime":     date_time(2),
+    "vitals_labs": make_vitals_tensor(mean_bp=65.0, seed=16),
+    "reentry_7day": 1,               # gap = 25h > 24h and <= 168h -> re-entry
+}
+P010_STAY2 = {
+    "subject_id":  1010,
+    "icustay_id":  101002,
+    "intime":      date_time(2, hours=25),  # gap = 25h
+    "outtime":     date_time(4, hours=25),
+    "vitals_labs": make_vitals_tensor(seed=17),
+    "reentry_7day": 0,
+}
+
+# ---------------------------------------------------------------------------
+# Collected stays and expected labels
+# ---------------------------------------------------------------------------
+
+SYNTHETIC_STAYS: List[Dict] = [
+    P001_STAY1,
+    P002_STAY1, P002_STAY2,
+    P003_STAY1, P003_STAY2,
+    P004_STAY1, P004_STAY2,
+    P005_STAY1, P005_STAY2, P005_STAY3,
+    P006_STAY1,
+    P007_STAY1, P007_STAY2,
+    P008_STAY1, P008_STAY2,
+    P009_STAY1, P009_STAY2, P009_STAY3,
+    P010_STAY1, P010_STAY2,
+]
+
+# Ground-truth labels keyed by icustay_id for use in assertions
+EXPECTED_LABELS: Dict[int, int] = {
+    s["icustay_id"]: s["reentry_7day"]
+    for s in SYNTHETIC_STAYS
+}
+
+# Ground-truth episode groupings for structural validation
+EXPECTED_EPISODES: Dict[int, List[int]] = {
+    # subject_id -> list of icustay_ids per episode (grouped)
+    1001: [[100101]],
+    1002: [[100201], [100202]],
+    1003: [[100301], [100302]],
+    1004: [[100401, 100402]],        # transfer chain -> one episode
+    1005: [[100501, 100502], [100503]],  # chain then separate episode
+    1006: [[100601]],
+    1007: [[100701], [100702]],
+    1008: [[100801], [100802]],
+    1009: [[100901], [100902], [100903]],  # three episodes: ep1->ep2 qualifies, ep2->ep3 does not
+    1010: [[101001], [101002]],
+}
+
+# ---------------------------------------------------------------------------
+# Mock helpers for __call__() testing
+# ---------------------------------------------------------------------------
+
+class _MockStay:
+    """Minimal ICU stay object accepted by ICUReEntryClassification.__call__."""
+    def __init__(self, stay_dict: Dict):
+        self.icustay_id  = stay_dict["icustay_id"]
+        self.intime      = stay_dict["intime"]
+        self.outtime     = stay_dict["outtime"]
+        self.vitals_labs = stay_dict.get("vitals_labs")
+
+
+class _MockPatient:
+    """Minimal patient object accepted by ICUReEntryClassification.__call__."""
+    def __init__(self, subject_id: int, stay_dicts: List[Dict]):
+        self.patient_id = subject_id
+        self._stays     = [_MockStay(s) for s in stay_dicts]
+
+    def get_events(self, event_type: str) -> List[_MockStay]:  # noqa: ARG002
+        return self._stays
+
+
+# ---------------------------------------------------------------------------
+# Shared test utilities
+# ---------------------------------------------------------------------------
+
+class _PassMessageMixin:
+    """
+    Mixin that prints a one-line success message for every passing test.
+
+    Uses self._outcome.success, which CPython's TestCase.run() sets to True
+    after setUp and the test body both complete without error, before tearDown
+    is invoked.  Falls back silently if _outcome is unavailable (e.g. under
+    alternative test runners).
+    """
+
+    def tearDown(self):
+        super().tearDown()
+        outcome = getattr(self, "_outcome", None)
+        if outcome is not None and getattr(outcome, "success", False):
+            print(f"  PASS  {self._testMethodName}")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+class TestICUReEntryClassification(_PassMessageMixin, unittest.TestCase):
+
+    # ── Imports ──────────────────────────────────────────────────────────────
+    # Deferred to class level so import errors surface as test failures,
+    # not module-load errors.
+    @classmethod
+    def setUpClass(cls):
+
+        from pyhealth.tasks.mimic3_icu_reentry import ICUReEntryClassification
+        from pyhealth.tasks.mimic3_clinical_aggregation import (
+            CLINICAL_CATEGORIES,
+            apply_clinical_aggregation,
+        )
+        cls.Task = ICUReEntryClassification
+        cls.clinical_categories = CLINICAL_CATEGORIES
+        cls.apply_clinical_aggregation = staticmethod(apply_clinical_aggregation)
+
+    # ── Schema ───────────────────────────────────────────────────────────────
+
+    def test_task_schema_attributes_present(self):
+        self.assertIn("task_name",     vars(self.Task))
+        self.assertIn("input_schema",  vars(self.Task))
+        self.assertIn("output_schema", vars(self.Task))
+
+    def test_task_schema_values(self):
+        self.assertEqual("ICUReEntryClassification", self.Task.task_name)
+        self.assertIn("vitals_labs",  self.Task.input_schema)
+        self.assertEqual("tensor",    self.Task.input_schema["vitals_labs"])
+        self.assertIn("reentry_7day", self.Task.output_schema)
+        self.assertEqual("binary",    self.Task.output_schema["reentry_7day"])
+
+    # ── Constructor defaults and validation ──────────────────────────────────
+
+    def test_defaults(self):
+        task = self.Task()
+        self.assertEqual(task.feature_set,              "clinical")
+        self.assertEqual(task.reentry_window_hours,     168)
+        self.assertEqual(task.transfer_threshold_hours, 24)
+
+    def test_feature_set_raw_instantiates(self):
+        """feature_set='raw' is a valid value and must not raise."""
+        task = self.Task(feature_set="raw")
+        self.assertEqual(task.feature_set, "raw")
+
+    def test_invalid_feature_set(self):
+        with self.assertRaises(ValueError):
+            self.Task(feature_set="unknown")
+
+    def test_zero_reentry_window_raises(self):
+        with self.assertRaises(ValueError):
+            self.Task(reentry_window_hours=0)
+
+    def test_negative_reentry_window_raises(self):
+        with self.assertRaises(ValueError):
+            self.Task(reentry_window_hours=-1)
+
+    def test_zero_transfer_threshold_raises(self):
+        with self.assertRaises(ValueError):
+            self.Task(transfer_threshold_hours=0)
+
+    def test_transfer_threshold_equals_reentry_window_raises(self):
+        with self.assertRaises(ValueError):
+            self.Task(reentry_window_hours=48, transfer_threshold_hours=48)
+
+    def test_transfer_threshold_exceeds_reentry_window_raises(self):
+        with self.assertRaises(ValueError):
+            self.Task(reentry_window_hours=24, transfer_threshold_hours=48)
+
+    # ── from_arrays() happy path ─────────────────────────────────────────────
+
+    def _make_from_arrays_samples(self):
+        task     = self.Task()
+        features = np.stack([s["vitals_labs"] for s in SYNTHETIC_STAYS])
+        labels   = np.array([s["reentry_7day"] for s in SYNTHETIC_STAYS])
+        stay_ids = [s["icustay_id"] for s in SYNTHETIC_STAYS]
+        pids     = [s["subject_id"]  for s in SYNTHETIC_STAYS]
+        return task.from_arrays(features, labels, stay_ids, patient_ids=pids)
+
+    def test_from_arrays_returns_correct_count(self):
+        samples = self._make_from_arrays_samples()
+        self.assertEqual(len(samples), len(SYNTHETIC_STAYS))
+
+    def test_from_arrays_sample_schema(self):
+        for sample in self._make_from_arrays_samples():
+            self.assertIn("patient_id",   sample)
+            self.assertIn("visit_id",     sample)
+            self.assertIn("vitals_labs",  sample)
+            self.assertIn("reentry_7day", sample)
+
+    def test_from_arrays_ids_are_strings(self):
+        for sample in self._make_from_arrays_samples():
+            self.assertIsInstance(sample["patient_id"], str)
+            self.assertIsInstance(sample["visit_id"],   str)
+
+    def test_from_arrays_tensor_shape(self):
+        for sample in self._make_from_arrays_samples():
+            self.assertEqual(sample["vitals_labs"].shape, (N_HOURS, N_FEATURES))
+
+    def test_from_arrays_tensor_dtype(self):
+        """vitals_labs must be float32 — the dtype required by the LSTM model."""
+        for sample in self._make_from_arrays_samples():
+            self.assertEqual(sample["vitals_labs"].dtype, np.float32)
+
+    def test_from_arrays_label_values_match_expected(self):
+        for sample in self._make_from_arrays_samples():
+            stay_id  = int(sample["visit_id"])
+            expected = EXPECTED_LABELS[stay_id]
+            self.assertEqual(
+                sample["reentry_7day"], expected,
+                msg=f"icustay_id={stay_id}: expected label {expected}, "
+                    f"got {sample['reentry_7day']}"
+            )
+
+    def test_from_arrays_label_type_is_int(self):
+        """reentry_7day must be a plain Python int, not numpy.int64."""
+        for sample in self._make_from_arrays_samples():
+            self.assertIsInstance(
+                sample["reentry_7day"], int,
+                msg=f"visit_id={sample['visit_id']}: reentry_7day is "
+                    f"{type(sample['reentry_7day'])}, expected int"
+            )
+
+    def test_from_arrays_labels_are_binary(self):
+        """reentry_7day must be exactly 0 or 1 — never another integer."""
+        for sample in self._make_from_arrays_samples():
+            self.assertIn(
+                sample["reentry_7day"], (0, 1),
+                msg=f"visit_id={sample['visit_id']}: reentry_7day="
+                    f"{sample['reentry_7day']} is not a binary label"
+            )
+
+    def test_call_labels_are_binary(self):
+        """__call__() must only produce labels of 0 or 1 across all patient scenarios."""
+        scenarios = [
+            (1001, [P001_STAY1]),
+            (1002, [P002_STAY1, P002_STAY2]),
+            (1004, [P004_STAY1, P004_STAY2]),
+            (1005, [P005_STAY1, P005_STAY2, P005_STAY3]),
+            (1009, [P009_STAY1, P009_STAY2, P009_STAY3]),
+        ]
+        for pid, stay_dicts in scenarios:
+            patient = _MockPatient(pid, stay_dicts)
+            for sample in self.Task()(patient):
+                self.assertIn(
+                    sample["reentry_7day"], (0, 1),
+                    msg=f"patient={pid}, visit_id={sample['visit_id']}: "
+                        f"reentry_7day={sample['reentry_7day']} is not binary"
+                )
+
+    def test_from_arrays_patient_ids_default_to_stay_ids(self):
+        """When patient_ids is None, visit_id and patient_id should match."""
+        task     = self.Task()
+        features = np.zeros((3, 24, 65), dtype="float32")
+        labels   = np.array([0, 1, 0])
+        stay_ids = [200001, 200002, 200003]
+        samples  = task.from_arrays(features, labels, stay_ids)
+        for s in samples:
+            self.assertEqual(s["patient_id"], s["visit_id"])
+
+    def test_from_arrays_vital_values_preserved(self):
+        """Values in the tensor must be passed through unchanged."""
+        task     = self.Task()
+        features = np.arange(24 * 65, dtype="float32").reshape(1, 24, 65)
+        samples  = task.from_arrays(features, np.array([0]), [999])
+        np.testing.assert_array_equal(samples[0]["vitals_labs"], features[0])
+
+    # ── from_arrays() error cases ────────────────────────────────────────────
+
+    def test_from_arrays_features_row_mismatch_raises(self):
+        task = self.Task()
+        with self.assertRaises(ValueError):
+            task.from_arrays(
+                np.zeros((3, 24, 65), dtype="float32"),
+                np.array([0, 1]),       # 2 labels for 3 feature rows
+                [1, 2],
+            )
+
+    def test_from_arrays_labels_length_mismatch_raises(self):
+        task = self.Task()
+        with self.assertRaises(ValueError):
+            task.from_arrays(
+                np.zeros((2, 24, 65), dtype="float32"),
+                np.array([0, 1, 0]),    # 3 labels for 2 feature rows
+                [1, 2],
+            )
+
+    def test_from_arrays_patient_ids_length_mismatch_raises(self):
+        task = self.Task()
+        with self.assertRaises(ValueError):
+            task.from_arrays(
+                np.zeros((2, 24, 65), dtype="float32"),
+                np.array([0, 1]),
+                [1, 2],
+                patient_ids=[100],      # only 1 for 2 stays
+            )
+
+    def test_from_arrays_wrong_ndim_raises(self):
+        task = self.Task()
+        with self.assertRaises(ValueError):
+            task.from_arrays(
+                np.zeros((2, 65), dtype="float32"),  # 2-D instead of 3-D
+                np.array([0, 1]),
+                [1, 2],
+            )
+
+    def test_from_arrays_wrong_time_steps_raises(self):
+        task = self.Task()
+        with self.assertRaises(ValueError):
+            task.from_arrays(
+                np.zeros((2, 12, 65), dtype="float32"),  # 12h not 24h
+                np.array([0, 1]),
+                [1, 2],
+            )
+
+    # ── __call__() – empty patient ───────────────────────────────────────────
+
+    def test_call_empty_patient_returns_empty(self):
+        patient = _MockPatient(9999, [])
+        samples = self.Task()(patient)
+        self.assertEqual(samples, [])
+
+    def test_call_stay_without_vitals_is_skipped(self):
+        stay = {**P001_STAY1, "vitals_labs": None}
+        patient = _MockPatient(1001, [stay])
+        samples = self.Task()(patient)
+        self.assertEqual(samples, [])
+
+    # ── __call__() sample schema ─────────────────────────────────────────────
+
+    def test_call_sample_schema(self):
+        patient = _MockPatient(1002, [P002_STAY1, P002_STAY2])
+        for sample in self.Task()(patient):
+            self.assertIn("patient_id",   sample)
+            self.assertIn("visit_id",     sample)
+            self.assertIn("vitals_labs",  sample)
+            self.assertIn("reentry_7day", sample)
+            self.assertIsInstance(sample["patient_id"], str)
+            self.assertIsInstance(sample["visit_id"],   str)
+
+    # ── __call__() – single-stay patients (no re-entry possible) ─────────────
+
+    def test_call_p001_single_stay_label_0(self):
+        """P001: one stay, no re-entry."""
+        patient = _MockPatient(1001, [P001_STAY1])
+        samples = self.Task()(patient)
+        self.assertEqual(len(samples), 1)
+        self.assertEqual(samples[0]["reentry_7day"], 0)
+        self.assertEqual(samples[0]["visit_id"], str(P001_STAY1["icustay_id"]))
+
+    def test_call_p006_single_stay_label_0(self):
+        """P006: one stay, no re-entry."""
+        patient = _MockPatient(1006, [P006_STAY1])
+        samples = self.Task()(patient)
+        self.assertEqual(len(samples), 1)
+        self.assertEqual(samples[0]["reentry_7day"], 0)
+
+    # ── __call__() – qualifying re-entry ─────────────────────────────────────
+
+    def test_call_p002_gap_72h_label_1(self):
+        """P002: gap = 72h between episodes -> re-entry."""
+        patient = _MockPatient(1002, [P002_STAY1, P002_STAY2])
+        samples = self.Task()(patient)
+        # Two episodes -> two samples
+        self.assertEqual(len(samples), 2)
+        ep1 = next(s for s in samples if s["visit_id"] == str(P002_STAY1["icustay_id"]))
+        ep2 = next(s for s in samples if s["visit_id"] == str(P002_STAY2["icustay_id"]))
+        self.assertEqual(ep1["reentry_7day"], 1)
+        self.assertEqual(ep2["reentry_7day"], 0)
+
+    def test_call_p007_boundary_inclusive_168h_label_1(self):
+        """P007: gap = exactly 168h -> qualifies as re-entry (boundary inclusive)."""
+        patient = _MockPatient(1007, [P007_STAY1, P007_STAY2])
+        samples = self.Task()(patient)
+        self.assertEqual(len(samples), 2)
+        ep1 = next(s for s in samples if s["visit_id"] == str(P007_STAY1["icustay_id"]))
+        self.assertEqual(ep1["reentry_7day"], 1)
+
+    def test_call_p010_gap_25h_label_1(self):
+        """P010: gap = 25h (just over transfer threshold) -> re-entry."""
+        patient = _MockPatient(1010, [P010_STAY1, P010_STAY2])
+        samples = self.Task()(patient)
+        self.assertEqual(len(samples), 2)
+        ep1 = next(s for s in samples if s["visit_id"] == str(P010_STAY1["icustay_id"]))
+        self.assertEqual(ep1["reentry_7day"], 1)
+
+    # ── __call__() – non-qualifying gaps ─────────────────────────────────────
+
+    def test_call_p003_gap_too_long_label_0(self):
+        """P003: gap = 200h > 168h -> not a re-entry."""
+        patient = _MockPatient(1003, [P003_STAY1, P003_STAY2])
+        samples = self.Task()(patient)
+        self.assertEqual(len(samples), 2)
+        ep1 = next(s for s in samples if s["visit_id"] == str(P003_STAY1["icustay_id"]))
+        self.assertEqual(ep1["reentry_7day"], 0)
+
+    def test_call_p008_boundary_exclusive_169h_label_0(self):
+        """P008: gap = 169h (just over boundary) -> not a re-entry."""
+        patient = _MockPatient(1008, [P008_STAY1, P008_STAY2])
+        samples = self.Task()(patient)
+        self.assertEqual(len(samples), 2)
+        ep1 = next(s for s in samples if s["visit_id"] == str(P008_STAY1["icustay_id"]))
+        self.assertEqual(ep1["reentry_7day"], 0)
+
+    # ── __call__() – episode grouping ────────────────────────────────────────
+
+    def test_call_p004_direct_transfer_one_episode(self):
+        """P004: gap = 6h -> direct transfer; both stays become one episode."""
+        patient = _MockPatient(1004, [P004_STAY1, P004_STAY2])
+        samples = self.Task()(patient)
+        # One episode -> one sample, indexed by STAY1
+        self.assertEqual(len(samples), 1)
+        self.assertEqual(samples[0]["visit_id"],     str(P004_STAY1["icustay_id"]))
+        self.assertEqual(samples[0]["reentry_7day"], 0)
+
+    def test_call_p005_transfer_chain_then_reentry(self):
+        """P005: stays 1+2 form one episode (gap=10h); stay3 is re-entry 96h later."""
+        patient = _MockPatient(1005, [P005_STAY1, P005_STAY2, P005_STAY3])
+        samples = self.Task()(patient)
+        # Two episodes: [STAY1, STAY2] and [STAY3]
+        self.assertEqual(len(samples), 2)
+        ep1 = next(s for s in samples if s["visit_id"] == str(P005_STAY1["icustay_id"]))
+        ep2 = next(s for s in samples if s["visit_id"] == str(P005_STAY3["icustay_id"]))
+        # Episode 1 re-enters via stay3 (gap from stay2.outtime=3d to stay3.intime=3d+96h)
+        self.assertEqual(ep1["reentry_7day"], 1)
+        self.assertEqual(ep2["reentry_7day"], 0)
+
+    def test_call_p004_transfer_stay2_not_an_index_stay(self):
+        """STAY2 of a transfer chain must not appear as a separate sample."""
+        patient  = _MockPatient(1004, [P004_STAY1, P004_STAY2])
+        visit_ids = [s["visit_id"] for s in self.Task()(patient)]
+        self.assertNotIn(str(P004_STAY2["icustay_id"]), visit_ids)
+
+    def test_call_p009_three_episodes_mixed_labels(self):
+        """P009: three stays, three episodes. ep1->ep2 gap=72h (label=1); ep2->ep3 gap=200h (label=0)."""
+        patient = _MockPatient(1009, [P009_STAY1, P009_STAY2, P009_STAY3])
+        samples = self.Task()(patient)
+        # Three separate episodes -> three samples
+        self.assertEqual(len(samples), 3)
+        ep1 = next(s for s in samples if s["visit_id"] == str(P009_STAY1["icustay_id"]))
+        ep2 = next(s for s in samples if s["visit_id"] == str(P009_STAY2["icustay_id"]))
+        ep3 = next(s for s in samples if s["visit_id"] == str(P009_STAY3["icustay_id"]))
+        self.assertEqual(ep1["reentry_7day"], 1)   # 72h gap -> qualifies
+        self.assertEqual(ep2["reentry_7day"], 0)   # 200h gap -> too long
+        self.assertEqual(ep3["reentry_7day"], 0)   # no subsequent episode
+
+    def test_call_unsorted_stays_produce_correct_labels(self):
+        """__call__() must sort stays by intime internally; reversed input must match forward input."""
+        forward = _MockPatient(1002, [P002_STAY1, P002_STAY2])
+        reversed_ = _MockPatient(1002, [P002_STAY2, P002_STAY1])
+        samples_forward  = self.Task()(forward)
+        samples_reversed = self.Task()(reversed_)
+        labels_forward  = {s["visit_id"]: s["reentry_7day"] for s in samples_forward}
+        labels_reversed = {s["visit_id"]: s["reentry_7day"] for s in samples_reversed}
+        self.assertEqual(labels_forward, labels_reversed)
+
+    # ── Clinical feature index spot-check ────────────────────────────────────
+
+    def test_clinical_categories_count(self):
+        """CLINICAL_CATEGORIES must export exactly 65 entries."""
+        self.assertEqual(len(self.clinical_categories), 65)
+
+    def test_feature_index_heart_rate_nonzero(self):
+        """Heart-rate column (index 0) must be non-zero in tensors built by make_vitals_tensor."""
+        tensor = make_vitals_tensor(heart_rate=80.0, seed=42)
+        self.assertTrue(np.all(tensor[:, _FEATURE_INDICES["heart rate"]] > 0))
+
+    def test_make_vitals_tensor_shape(self):
+        self.assertEqual(make_vitals_tensor().shape, (N_HOURS, N_FEATURES))
+
+    def test_make_vitals_tensor_dtype(self):
+        self.assertEqual(make_vitals_tensor().dtype, np.float32)
+
+    # ── End-to-end sample output ─────────────────────────────────────────────
+
+    def test_end_to_end_from_arrays_sample_output(self):
+        """
+        Complete input → output trace for from_arrays().
+
+        Verifies that a single known feature tensor and label, fed through
+        from_arrays(), produces a sample dict whose every field has the
+        exact expected value and type — exercising data loading, integrity,
+        and output format in one narrative test.
+        """
+        task    = self.Task(feature_set="clinical")
+        feature = np.arange(N_HOURS * N_FEATURES, dtype="float32").reshape(
+            1, N_HOURS, N_FEATURES
+        )
+        samples = task.from_arrays(
+            features    = feature,
+            labels      = np.array([1]),
+            stay_ids    = [999001],
+            patient_ids = [888001],
+        )
+
+        self.assertEqual(len(samples), 1)
+        s = samples[0]
+
+        # All four required keys are present and nothing extra
+        self.assertEqual(set(s.keys()), {"patient_id", "visit_id", "vitals_labs", "reentry_7day"})
+
+        # IDs are strings with correct values
+        self.assertEqual(s["patient_id"], "888001")
+        self.assertEqual(s["visit_id"],   "999001")
+
+        # Feature tensor is passed through unchanged, with the right shape and dtype
+        self.assertEqual(s["vitals_labs"].shape, (N_HOURS, N_FEATURES))
+        self.assertEqual(s["vitals_labs"].dtype, np.float32)
+        np.testing.assert_array_equal(s["vitals_labs"], feature[0])
+
+        # Label is correct value, type, and in the binary range
+        self.assertEqual(s["reentry_7day"], 1)
+        self.assertIsInstance(s["reentry_7day"], int)
+        self.assertIn(s["reentry_7day"], (0, 1))
+
+    def test_end_to_end_call_sample_output(self):
+        """
+        Complete input → output trace for __call__().
+
+        Drives a two-stay patient (P002: gap=72h, qualifying re-entry) through
+        the full __call__() pipeline and verifies every field of the episode-1
+        sample: patient_id, visit_id, vitals_labs, and the re-entry label.
+        """
+        task    = self.Task(feature_set="clinical")
+        patient = _MockPatient(1002, [P002_STAY1, P002_STAY2])
+        samples = task(patient)
+
+        self.assertEqual(len(samples), 2)
+
+        ep1 = next(s for s in samples if s["visit_id"] == str(P002_STAY1["icustay_id"]))
+
+        # All required keys present
+        self.assertEqual(set(ep1.keys()), {"patient_id", "visit_id", "vitals_labs", "reentry_7day"})
+
+        # Patient and visit IDs are strings
+        self.assertIsInstance(ep1["patient_id"], str)
+        self.assertIsInstance(ep1["visit_id"],   str)
+        self.assertEqual(ep1["patient_id"], "1002")
+        self.assertEqual(ep1["visit_id"],   str(P002_STAY1["icustay_id"]))
+
+        # vitals_labs is the index stay's tensor, shape and dtype intact
+        self.assertEqual(ep1["vitals_labs"].shape, (N_HOURS, N_FEATURES))
+        self.assertEqual(ep1["vitals_labs"].dtype, np.float32)
+        np.testing.assert_array_equal(ep1["vitals_labs"], P002_STAY1["vitals_labs"])
+
+        # Label: 72h gap -> re-entry
+        self.assertEqual(ep1["reentry_7day"], 1)
+        self.assertIsInstance(ep1["reentry_7day"], int)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for apply_clinical_aggregation() tests
+# ---------------------------------------------------------------------------
+
+def _make_mock_hourly_data(
+    stay_ids: List[int] = None,
+    n_hours: int = 24,
+    col_names: List[str] = None,
+    value: float = 80.0,
+) -> "object":
+    """
+    Builds a minimal MultiIndex DataFrame matching the MIMIC_Extract
+    all_hourly_data.h5 'vitals_labs' structure.
+
+    Column MultiIndex: (LEVEL2, Aggregation Function) with 'mean' as the
+    aggregation level.  Row MultiIndex: (subject_id, hadm_id, icustay_id,
+    hours_in).  Requires pandas; the caller must skip the test if pandas is
+    not available.
+
+    Args:
+        stay_ids: ICU stay IDs. Defaults to [300001].
+        n_hours: Number of hourly rows per stay. Defaults to 24.
+        col_names: LEVEL2 column names to include. Defaults to
+            ['heart rate', 'systolic blood pressure'].
+        value: Constant value to fill all cells with. Defaults to 80.0.
+
+    Returns:
+        pd.DataFrame with MultiIndex rows and columns.
+    """
+    import pandas as pd
+
+    if stay_ids is None:
+        stay_ids = [300001]
+    if col_names is None:
+        col_names = ["heart rate", "systolic blood pressure"]
+
+    rows = [
+        (9001, 8001, stay_id, h)
+        for stay_id in stay_ids
+        for h in range(n_hours)
+    ]
+    index = pd.MultiIndex.from_tuples(
+        rows,
+        names=["subject_id", "hadm_id", "icustay_id", "hours_in"],
+    )
+    columns = pd.MultiIndex.from_tuples(
+        [(col, "mean") for col in col_names],
+        names=["LEVEL2", "Aggregation Function"],
+    )
+    data = np.full((len(rows), len(col_names)), value, dtype=np.float32)
+    return pd.DataFrame(data, index=index, columns=columns)
+
+
+class TestApplyClinicalAggregation(_PassMessageMixin, unittest.TestCase):
+    """Tests for apply_clinical_aggregation() in mimic3_clinical_aggregation.py."""
+
+    @classmethod
+    def setUpClass(cls):
+        from pyhealth.tasks.mimic3_clinical_aggregation import (
+            apply_clinical_aggregation,
+            CLINICAL_CATEGORIES,
+        )
+        cls.fn = staticmethod(apply_clinical_aggregation)
+        cls.clinical_categories = CLINICAL_CATEGORIES
+
+        import importlib.util
+        cls.pandas_available = importlib.util.find_spec("pandas") is not None
+
+    def setUp(self):
+        if not self.pandas_available:
+            self.skipTest("pandas not installed — skipping apply_clinical_aggregation tests")
+
+    # ── Output shape and types ────────────────────────────────────────────────
+
+    def test_output_array_shape(self):
+        """Array shape must be (n_stays, 24, 65)."""
+        df = _make_mock_hourly_data(stay_ids=[300001, 300002])
+        arr, _, _ = self.fn(df)
+        self.assertEqual(arr.shape, (2, 24, 65))
+
+    def test_output_category_names_match_clinical_categories(self):
+        """Returned category_names must equal CLINICAL_CATEGORIES exactly."""
+        df = _make_mock_hourly_data()
+        _, cats, _ = self.fn(df)
+        self.assertEqual(cats, self.clinical_categories)
+
+    def test_output_stay_ids_match_input(self):
+        """Returned stay_ids must match the icustay_ids in the input index."""
+        input_stay_ids = [300001, 300002, 300003]
+        df = _make_mock_hourly_data(stay_ids=input_stay_ids)
+        _, _, stay_ids = self.fn(df)
+        self.assertEqual(sorted(stay_ids), sorted(input_stay_ids))
+
+    def test_output_dtype_is_float32(self):
+        df = _make_mock_hourly_data()
+        arr, _, _ = self.fn(df)
+        self.assertEqual(arr.dtype, np.float32)
+
+    # ── Column mapping ────────────────────────────────────────────────────────
+
+    def test_present_column_produces_nonnan_values(self):
+        """A column that exists in the input must produce non-NaN output values."""
+        df = _make_mock_hourly_data(col_names=["heart rate"], value=75.0)
+        arr, cats, _ = self.fn(df)
+        hr_idx = cats.index("heart rate")
+        self.assertFalse(
+            np.all(np.isnan(arr[:, :, hr_idx])),
+            msg="heart rate column should be non-NaN when present in input",
+        )
+
+    def test_absent_column_produces_nan_values(self):
+        """A category whose LEVEL2 columns are all absent must produce NaN values."""
+        # Only supply 'heart rate'; all other categories are absent.
+        df = _make_mock_hourly_data(col_names=["heart rate"])
+        arr, cats, _ = self.fn(df)
+        # "systolic blood pressure" (index 1) should be all NaN
+        sbp_idx = cats.index("systolic blood pressure")
+        self.assertTrue(
+            np.all(np.isnan(arr[:, :, sbp_idx])),
+            msg="systolic blood pressure should be NaN when absent from input",
+        )
+
+    def test_multi_source_column_averaged(self):
+        """A category mapped to multiple LEVEL2 columns must average their values."""
+        # "partial pressure of carbon dioxide" maps to three LEVEL2 names.
+        # Supply two of them with values 60.0 and 100.0; the output must be ~80.0.
+        col_a = "partial pressure of carbon dioxide"
+        col_b = "co2 (etco2, pco2, etc.)"
+        df = _make_mock_hourly_data(col_names=[col_a, col_b], value=0.0)
+        # Overwrite column values
+        df[(col_a, "mean")] = 60.0
+        df[(col_b, "mean")] = 100.0
+
+        arr, cats, _ = self.fn(df)
+        pco2_idx = cats.index("partial pressure of carbon dioxide")
+        expected_mean = 80.0
+        np.testing.assert_allclose(
+            arr[:, :, pco2_idx],
+            expected_mean,
+            rtol=1e-4,
+            err_msg="Multi-source category should average its source columns",
+        )
+
+    # ── Flat (non-MultiIndex) columns ─────────────────────────────────────────
+
+    def test_flat_columns_accepted(self):
+        """DataFrame with plain (non-MultiIndex) columns must work without error."""
+        # Build the mock then flatten the column MultiIndex.
+        df_multi = _make_mock_hourly_data(col_names=["heart rate"])
+        df_flat = df_multi.copy()
+        df_flat.columns = [col for col, _ in df_multi.columns]
+        arr, _, stay_ids = self.fn(df_flat)
+        self.assertEqual(arr.shape[2], 65)
+        self.assertEqual(len(stay_ids), 1)
+
+    # ── Hour indexing ─────────────────────────────────────────────────────────
+
+    def test_values_placed_at_correct_hour(self):
+        """Values for hours_in=0..23 must land in the correct time-step slice."""
+        df = _make_mock_hourly_data(col_names=["heart rate"], value=0.0)
+        # Set a distinct sentinel value only at hour 5.
+        mask = df.index.get_level_values("hours_in") == 5
+        df.loc[mask, ("heart rate", "mean")] = 999.0
+
+        arr, cats, _ = self.fn(df)
+        hr_idx = cats.index("heart rate")
+        self.assertAlmostEqual(float(arr[0, 5, hr_idx]), 999.0, places=1)
+
+    def test_complete_pipeline_sample_output(self):
+        """
+        Complete input → output trace for apply_clinical_aggregation().
+
+        Builds a single-stay mock DataFrame with one known column ('heart rate'
+        = 75.0 at every hour), runs it through the function, and verifies every
+        aspect of the output: shape, dtype, category order, correct value at the
+        expected feature index, and NaN for an absent feature.
+        """
+        df = _make_mock_hourly_data(
+            stay_ids  = [400001],
+            n_hours   = 24,
+            col_names = ["heart rate"],
+            value     = 75.0,
+        )
+        arr, cats, stay_ids = self.fn(df, n_hours=24)
+
+        # Shape: (1 stay, 24 hours, 65 categories)
+        self.assertEqual(arr.shape, (1, 24, 65))
+
+        # Dtype is float32
+        self.assertEqual(arr.dtype, np.float32)
+
+        # Category list matches the authoritative CLINICAL_CATEGORIES
+        self.assertEqual(cats, self.clinical_categories)
+
+        # Stay IDs round-trip
+        self.assertEqual(stay_ids, [400001])
+
+        # heart rate (index 0) should be 75.0 at every hour
+        hr_idx = cats.index("heart rate")
+        np.testing.assert_allclose(
+            arr[0, :, hr_idx], 75.0, rtol=1e-5,
+            err_msg="heart rate column should be 75.0 at all 24 hours",
+        )
+
+        # An absent category (e.g., sodium, index >0) should be NaN
+        sodium_idx = cats.index("sodium")
+        self.assertTrue(
+            np.all(np.isnan(arr[0, :, sodium_idx])),
+            msg="sodium should be NaN because it was not in the input DataFrame",
+        )
+
+    def test_out_of_range_hours_ignored(self):
+        """Rows with hours_in >= n_hours must not raise and must not corrupt the array."""
+        import pandas as pd
+
+        df = _make_mock_hourly_data(n_hours=24, col_names=["heart rate"], value=1.0)
+        # Inject a row with hours_in = 99 (out of range).
+        extra_index = pd.MultiIndex.from_tuples(
+            [(9001, 8001, 300001, 99)],
+            names=["subject_id", "hadm_id", "icustay_id", "hours_in"],
+        )
+        extra_cols = pd.MultiIndex.from_tuples(
+            [("heart rate", "mean")],
+            names=["LEVEL2", "Aggregation Function"],
+        )
+        extra_row = pd.DataFrame([[999.0]], index=extra_index, columns=extra_cols)
+        df_extended = pd.concat([df, extra_row])
+
+        arr, cats, _ = self.fn(df_extended)
+        hr_idx = cats.index("heart rate")
+        # No time step should contain 999.0
+        self.assertFalse(
+            np.any(arr[:, :, hr_idx] == 999.0),
+            msg="Out-of-range hours_in=99 should be silently ignored",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Author**: Jenna Reno (jlreno2@illinois.edu)
**Contribution Type**: Standalone Task 
**Original Paper**: Feature Robustness in Non-Stationary Health Records: Caveats to Deployable Model Performance in Common Clinical Machine Learning Tasks
**Original Paper link**: https://proceedings.mlr.press/v106/nestor19a.html
**Implementation Desc**: Implements a new standalone task for predicting 7-day ICU re-entry using MIMIC-III data, reproducing and extending Nestor et al. (2019).
## File guide
### New Files
**`pyhealth/tasks/mimic3_clinical_aggregation.py`**
Implements the Nestor et al. 65-category clinical aggregation scheme. Maps MIMIC_Extract LEVEL2 columns from `all_hourly_data.h5` into expert-defined feature categories (e.g., collapsing CareVue and MetaVision aliases for the same physiological quantity into one channel). Exports:
- `CLINICAL_AGGREGATION_MAP` — dict mapping each of the 65 category names to its source LEVEL2 column(s)
- `CLINICAL_CATEGORIES` — ordered list defining feature-vector index positions
- `apply_clinical_aggregation()` — converts a raw MIMIC_Extract DataFrame into a `(n_stays, 24, 65)` float32 array

**`pyhealth/tasks/mimic3_icu_reentry.py`**
Implements `ICUReEntryClassification(BaseTask)`. Core logic:
- __call__(patient) — groups ICU stays into episodes (stays with gaps < 24 h are the same episode), then labels each episode based on whether the next episode begins within 168 h (7 days). Direct transfers are excluded from re-entry counts.
- from_arrays(features, labels, stay_ids) — accepts pre-aggregated numpy arrays for workflows that start from already-processed tensors rather than a PyHealth dataset object. Validates array shapes and length consistency and returns standard PyHealth sample dicts.

**`examples/icu_reentry_pred_lstm_mimic3.py`**
End-to-end script: synthetic data generation → task application → `SampleDataset` creation → patient-stratified train/val/test split → LSTM training via `Trainer` → test-set evaluation → single-sample inference demo. Documents how a real MIMIC_Extract workflow would substitute the synthetic arrays.

**`tests/core/test_mimic3_icu_reentry.py`**
Two test classes, 50+ tests, all synthetic data:
- `TestICUReEntryClassification` — constructor validation, `from_arrays` happy path and error cases, `__call__` episode grouping across 10 hand-verified patient scenarios (single stay, transfer chain, boundary-inclusive/exclusive gaps, multi-episode mixed labels, unsorted input), output schema and type assertions, end-to-end input→output traces
- `TestApplyClinicalAggregation` — output shape/dtype, category name round-trip, stay ID round-trip, present/absent/multi-source column mapping, flat vs. MultiIndex column handling, hour-index placement, out-of-range hour filtering, complete pipeline sample output

### Modified Files

- `pyhealth/tasks/__init__.py` : Added exports for `ICUReEntryClassification`, `CLINICAL_AGGREGATION_MAP`, `CLINICAL_CATEGORIES`, `apply_clinical_aggregation `
- `docs/api/tasks.rst` : Added both new modules to the Available Tasks 
- `docs/api/tasks/pyhealth.tasks.mimic3_icu_reentry.rst` : New Sphinx autodoc page for `ICUReEntryClassification`
- `docs/api/tasks/pyhealth.tasks.mimic3_clinical_aggregation.rst` : New Sphinx autodoc page for constants and `apply_clinical_aggregation`