### PR TITLE
Add EhrMamba Conv1D model, GRU baseline, tests, and various ablation …

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -204,3 +204,4 @@ API Reference
     models/pyhealth.models.TextEmbedding
     models/pyhealth.models.BIOT
     models/pyhealth.models.unified_multimodal_embedding_docs
+    models/pyhealth.models.ehr_mamba

--- a/docs/api/models/pyhealth.models.ehr_mamba.rst
+++ b/docs/api/models/pyhealth.models.ehr_mamba.rst
@@ -1,0 +1,6 @@
+EhrMamba
+========
+.. automodule:: pyhealth.models.ehr_mamba
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/mimic3_readmission_ehrmamba.py
+++ b/examples/mimic3_readmission_ehrmamba.py
@@ -1,0 +1,107 @@
+import torch
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models.ehr_mamba import EhrMamba
+from pyhealth.models.gru_baseline import GRUBaseline
+ 
+ # python examples/mimic3_readmission_ehrmamba.py
+def make_dataset(feature_keys=("conditions",)):
+    samples = []
+    for i in range(20):
+        sample = {
+            "patient_id": f"p-{i}",
+            "visit_id": f"v-{i}",
+            "label": i % 2,
+        }
+        if "conditions" in feature_keys:
+            sample["conditions"] = [f"cond-{(i * 3 + j) % 20}" for j in range(3)]
+        if "procedures" in feature_keys:
+            sample["procedures"] = [f"proc-{(i * 2 + j) % 15}" for j in range(2)]
+        samples.append(sample)
+ 
+    input_schema = {k: "sequence" for k in feature_keys}
+    return create_sample_dataset(
+        samples=samples,
+        input_schema=input_schema,
+        output_schema={"label": "binary"},
+        dataset_name="synthetic_ehr",
+    )
+ 
+ 
+def train_model(model, dataset, epochs=5, lr=0.001):
+    loader = get_dataloader(dataset, batch_size=8, shuffle=True)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+ 
+    final_loss = None
+    for epoch in range(epochs):
+        for batch in loader:
+            output = model(**batch)
+            loss = output["loss"]
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            final_loss = loss.item()
+ 
+    return final_loss
+ 
+ 
+def ablation_model_type():
+    print("ABLATION 1: EhrMamba vs GRU Baseline")
+    dataset = make_dataset(["conditions"])
+ 
+    for model_class, name in [
+        (EhrMamba, "EhrMamba (Conv1D)"),
+        (GRUBaseline, "GRU Baseline"),
+    ]:
+        model = model_class(dataset=dataset, hidden_dim=128)
+        loss = train_model(model, dataset)
+        print(f"  {name:30s} | Final Loss: {loss:.4f}")
+ 
+ 
+def ablation_hidden_dim():
+    print("ABLATION 2: Hidden Dimension Scaling (EhrMamba)")
+    dataset = make_dataset(["conditions"])
+ 
+    for hidden_dim in [64, 128, 256]:
+        model = EhrMamba(dataset=dataset, hidden_dim=hidden_dim)
+        n_params = sum(p.numel() for p in model.parameters())
+        loss = train_model(model, dataset)
+        print(f"  hidden_dim={hidden_dim:3d} | Params: {n_params:,} | Final Loss: {loss:.4f}")
+ 
+ 
+def ablation_dropout():
+    print("ABLATION 3: Dropout Rate (EhrMamba)")
+    dataset = make_dataset(["conditions"])
+ 
+    for dropout in [0.1, 0.3, 0.5]:
+        model = EhrMamba(dataset=dataset, dropout=dropout)
+        loss = train_model(model, dataset)
+        print(f"  dropout={dropout:.1f} | Final Loss: {loss:.4f}")
+ 
+ 
+def ablation_feature_sets():
+    print("ABLATION 4: Feature Set Variations (EhrMamba)")
+
+    configs = [
+        (["conditions"], "Conditions only"),
+        (["procedures"], "Procedures only"),
+        (["conditions", "procedures"], "Conditions + Procedures"),
+    ]
+ 
+    for feature_keys, name in configs:
+        dataset = make_dataset(feature_keys)
+        model = EhrMamba(dataset=dataset)
+        loss = train_model(model, dataset)
+        print(f"  {name:35s} | Final Loss: {loss:.4f}")
+ 
+ 
+if __name__ == "__main__":
+    print("EhrMamba Ablation Study")
+    print("Paper: Fallahpour et al., ML4H 2024")
+    print("https://proceedings.mlr.press/v259/fallahpour24a.html")
+ 
+    ablation_model_type()
+    ablation_hidden_dim()
+    ablation_dropout()
+    ablation_feature_sets()
+ 
+    print("\nDone.")

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -44,3 +44,5 @@ from .text_embedding import TextEmbedding
 from .sdoh import SdohClassifier
 from .medlink import MedLink
 from .unified_embedding import UnifiedMultimodalEmbeddingModel, SinusoidalTimeEmbedding
+from .ehr_mamba import EhrMamba
+from .gru_baseline import GRUBaseline

--- a/pyhealth/models/ehr_mamba.py
+++ b/pyhealth/models/ehr_mamba.py
@@ -1,0 +1,83 @@
+import torch
+import torch.nn as nn
+from typing import Dict, List
+from pyhealth.datasets import SampleDataset
+from pyhealth.models import BaseModel
+from pyhealth.models.rnn import EmbeddingModel
+ 
+ 
+class EhrMamba(BaseModel):
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        embedding_dim: int = 128,
+        hidden_dim: int = 128,
+        dropout: float = 0.3,
+    ) -> None:
+        super(EhrMamba, self).__init__(dataset=dataset)
+ 
+        self.embedding_dim = embedding_dim
+        self.hidden_dim = hidden_dim
+ 
+        assert len(self.label_keys) == 1, "EhrMamba supports exactly one label key."
+        self.label_key = self.label_keys[0]
+        self.mode = self.dataset.output_schema[self.label_key]
+ 
+        self.embedding_model = EmbeddingModel(dataset, embedding_dim)
+ 
+        self.convs = nn.ModuleDict()
+        for feature_key in self.dataset.input_processors.keys():
+            self.convs[feature_key] = nn.Sequential(
+                nn.Conv1d(embedding_dim, hidden_dim, kernel_size=3, padding=1),
+                nn.GELU(),
+            )
+ 
+        output_size = self.get_output_size()
+        self.dropout = nn.Dropout(p=dropout)
+        self.fc = nn.Linear(len(self.feature_keys) * hidden_dim, output_size)
+ 
+    def forward(self, **kwargs) -> Dict[str, torch.Tensor]:
+        inputs = {}
+        masks = {}
+ 
+        for feature_key in self.feature_keys:
+            feature = kwargs[feature_key]
+            if isinstance(feature, torch.Tensor):
+                feature = (feature,)
+ 
+            schema = self.dataset.input_processors[feature_key].schema()
+            value = feature[schema.index("value")] if "value" in schema else None
+            mask = feature[schema.index("mask")] if "mask" in schema else None
+ 
+            if value is None:
+                raise ValueError(f"Feature '{feature_key}' must contain 'value' in schema.")
+ 
+            inputs[feature_key] = value
+            if mask is not None:
+                masks[feature_key] = mask
+ 
+        embedded = self.embedding_model(inputs, masks=masks)
+ 
+        patient_emb = []
+        for feature_key in self.feature_keys:
+            x = embedded[feature_key]
+ 
+            if x.dim() == 4:
+                x = x.sum(dim=2)
+            elif x.dim() == 2:
+                x = x.unsqueeze(1)
+ 
+            x = x.transpose(1, 2)
+            x = self.convs[feature_key](x)
+            x = x.mean(dim=-1)
+            patient_emb.append(x)
+ 
+        patient_emb = torch.cat(patient_emb, dim=1)
+        patient_emb = self.dropout(patient_emb)
+        logits = self.fc(patient_emb)
+ 
+        y_true = kwargs[self.label_key].to(self.device)
+        loss = self.get_loss_function()(logits, y_true)
+        y_prob = self.prepare_y_prob(logits)
+ 
+        return {"loss": loss, "y_prob": y_prob, "y_true": y_true, "logit": logits}

--- a/pyhealth/models/gru_baseline.py
+++ b/pyhealth/models/gru_baseline.py
@@ -1,0 +1,85 @@
+from typing import Dict
+ 
+import torch
+import torch.nn as nn
+ 
+from pyhealth.datasets import SampleDataset
+from pyhealth.models import BaseModel
+from pyhealth.models.rnn import EmbeddingModel
+ 
+ 
+class GRUBaseline(BaseModel):
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        embedding_dim: int = 128,
+        hidden_dim: int = 128,
+        dropout: float = 0.3,
+    ) -> None:
+        super(GRUBaseline, self).__init__(dataset=dataset)
+ 
+        self.embedding_dim = embedding_dim
+        self.hidden_dim = hidden_dim
+ 
+        assert len(self.label_keys) == 1, "GRUBaseline supports exactly one label key."
+        self.label_key = self.label_keys[0]
+        self.mode = self.dataset.output_schema[self.label_key]
+ 
+        self.embedding_model = EmbeddingModel(dataset, embedding_dim)
+ 
+        self.grus = nn.ModuleDict()
+        for feature_key in self.dataset.input_processors.keys():
+            self.grus[feature_key] = nn.GRU(
+                input_size=embedding_dim,
+                hidden_size=hidden_dim,
+                batch_first=True,
+            )
+ 
+        output_size = self.get_output_size()
+        self.dropout = nn.Dropout(p=dropout)
+        self.fc = nn.Linear(len(self.feature_keys) * hidden_dim, output_size)
+ 
+    def forward(self, **kwargs) -> Dict[str, torch.Tensor]:
+        inputs = {}
+        masks = {}
+ 
+        for feature_key in self.feature_keys:
+            feature = kwargs[feature_key]
+            if isinstance(feature, torch.Tensor):
+                feature = (feature,)
+ 
+            schema = self.dataset.input_processors[feature_key].schema()
+            value = feature[schema.index("value")] if "value" in schema else None
+            mask = feature[schema.index("mask")] if "mask" in schema else None
+ 
+            if value is None:
+                raise ValueError(f"Feature '{feature_key}' must contain 'value' in schema.")
+ 
+            inputs[feature_key] = value
+            if mask is not None:
+                masks[feature_key] = mask
+ 
+        embedded = self.embedding_model(inputs, masks=masks)
+ 
+        patient_emb = []
+        for feature_key in self.feature_keys:
+            x = embedded[feature_key]
+ 
+            if x.dim() == 4:
+                x = x.sum(dim=2)
+            elif x.dim() == 2:
+                x = x.unsqueeze(1)
+ 
+            output, _ = self.grus[feature_key](x)
+            x = output[:, -1, :]
+            patient_emb.append(x)
+ 
+        patient_emb = torch.cat(patient_emb, dim=1)
+        patient_emb = self.dropout(patient_emb)
+        logits = self.fc(patient_emb)
+ 
+        y_true = kwargs[self.label_key].to(self.device)
+        loss = self.get_loss_function()(logits, y_true)
+        y_prob = self.prepare_y_prob(logits)
+ 
+        return {"loss": loss, "y_prob": y_prob, "y_true": y_true, "logit": logits}

--- a/tests/test_ehrmamba.py
+++ b/tests/test_ehrmamba.py
@@ -1,0 +1,100 @@
+import pytest
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models.ehr_mamba import EhrMamba
+from pyhealth.models.gru_baseline import GRUBaseline
+ 
+SAMPLES = [
+    {"patient_id": "p-0", "visit_id": "v-0", "conditions": ["cond-1", "cond-2", "cond-3"], "label": 1},
+    {"patient_id": "p-1", "visit_id": "v-1", "conditions": ["cond-2", "cond-4"], "label": 0},
+    {"patient_id": "p-2", "visit_id": "v-2", "conditions": ["cond-1", "cond-5"], "label": 1},
+]
+ 
+ 
+@pytest.fixture
+def dataset():
+    return create_sample_dataset(
+        samples=SAMPLES,
+        input_schema={"conditions": "sequence"},
+        output_schema={"label": "binary"},
+        dataset_name="test_ehrmamba",
+    )
+ 
+ 
+@pytest.fixture
+def batch(dataset):
+    loader = get_dataloader(dataset, batch_size=3, shuffle=False)
+    return next(iter(loader))
+ 
+ 
+class TestEhrMamba:
+    def test_instantiation(self, dataset):
+        model = EhrMamba(dataset=dataset)
+        assert model is not None
+ 
+    def test_forward_output_keys(self, dataset, batch):
+        model = EhrMamba(dataset=dataset)
+        output = model(**batch)
+        assert "loss" in output
+        assert "y_prob" in output
+        assert "y_true" in output
+ 
+    def test_output_shape(self, dataset, batch):
+        model = EhrMamba(dataset=dataset)
+        output = model(**batch)
+        assert output["y_prob"].shape[0] == 3
+ 
+    def test_loss_is_scalar(self, dataset, batch):
+        model = EhrMamba(dataset=dataset)
+        output = model(**batch)
+        assert output["loss"].ndim == 0
+ 
+    def test_probabilities_in_range(self, dataset, batch):
+        model = EhrMamba(dataset=dataset)
+        output = model(**batch)
+        probs = output["y_prob"]
+        assert (probs >= 0).all() and (probs <= 1).all()
+ 
+    def test_gradients_flow(self, dataset, batch):
+        model = EhrMamba(dataset=dataset)
+        output = model(**batch)
+        output["loss"].backward()
+        for name, param in model.named_parameters():
+            if param.requires_grad and not name.endswith("_dummy_param"):
+                assert param.grad is not None, f"No gradient for {name}"
+ 
+    def test_different_hidden_dims(self, dataset, batch):
+        for hidden_dim in [64, 128, 256]:
+            model = EhrMamba(dataset=dataset, hidden_dim=hidden_dim)
+            output = model(**batch)
+            assert output["y_prob"].shape[0] == 3
+ 
+    def test_different_dropout(self, dataset, batch):
+        for dropout in [0.1, 0.3, 0.5]:
+            model = EhrMamba(dataset=dataset, dropout=dropout)
+            output = model(**batch)
+            assert "loss" in output
+ 
+ 
+class TestGRUBaseline:
+    def test_instantiation(self, dataset):
+        model = GRUBaseline(dataset=dataset)
+        assert model is not None
+ 
+    def test_forward_output_keys(self, dataset, batch):
+        model = GRUBaseline(dataset=dataset)
+        output = model(**batch)
+        assert "loss" in output
+        assert "y_prob" in output
+ 
+    def test_output_shape(self, dataset, batch):
+        model = GRUBaseline(dataset=dataset)
+        output = model(**batch)
+        assert output["y_prob"].shape[0] == 3
+ 
+    def test_gradients_flow(self, dataset, batch):
+        model = GRUBaseline(dataset=dataset)
+        output = model(**batch)
+        output["loss"].backward()
+        for name, param in model.named_parameters():
+            if param.requires_grad and not name.endswith("_dummy_param"):
+                assert param.grad is not None, f"No gradient for {name}"


### PR DESCRIPTION
Name: Gana Ventrapragada
NetID: gv13
Email: gv13@illinois.edu

Type: Model Contribution

Paper: https://arxiv.org/pdf/2405.14567

Description:
The goal of this pr was the implement EhrMamba which is a lightweight Conv1D approximation of the original architecture propsed in Fallahpour et al. (ML4H 2024). This model approximated the linear time behaviour using standard Conv1D layers, making it faster to train on limited compute while also preserving the core design principles mentioned in the paper. Also included is GRUBaseline which is the comparison model which was used for the ablation study. 

Ablation Study (examples/mimic3_readmission_ehrmamba.py):
1. EhrMamba vs GRU Baseline
2. Hidden dimension scaling (64, 128, 256)
3. Dropout rate (0.1, 0.3, 0.5)
4. Feature set variations (conditions, procedures, both)

Files to review:
- pyhealth/models/ehr_mamba.py
- pyhealth/models/gru_baseline.py
- tests/test_ehrmamba.py
- examples/mimic3_readmission_ehrmamba.py
- docs/api/models/pyhealth.models.ehr_mamba.rst
