### PR TITLE
Add TPC model for temporal EHR prediction

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -196,6 +196,7 @@ API Reference
     models/pyhealth.models.GRASP
     models/pyhealth.models.MedLink
     models/pyhealth.models.TCN
+    models/pyhealth.models.TPC
     models/pyhealth.models.TFMTokenizer
     models/pyhealth.models.GAN
     models/pyhealth.models.VAE

--- a/docs/api/models/pyhealth.models.TPC.rst
+++ b/docs/api/models/pyhealth.models.TPC.rst
@@ -15,6 +15,21 @@ standard ``BaseModel`` interface, supports PyHealth sequence and StageNet-style
 temporal processors, and is intended to be evaluated on existing PyHealth LOS
 tasks such as the MIMIC-IV temporal length-of-stay pipeline.
 
+Task Modes
+----------
+
+TPC uses the task ``output_schema`` from the provided ``SampleDataset`` to
+select the output size, loss function, and prediction format through
+``BaseModel``. This means the same model implementation can be used with
+PyHealth binary, multiclass, multilabel, and regression tasks.
+
+The included MIMIC-IV length-of-stay example uses the existing
+``LengthOfStayStageNetMIMIC4`` task, which defines LOS as a 10-class
+classification problem. This follows the current PyHealth LOS task interface.
+The original TPC paper reports LOS mainly with regression and ordinal metrics;
+a regression LOS task can use the same TPC model by defining an output schema
+such as ``{"remaining_los": "regression"}``.
+
 Required Data
 -------------
 

--- a/docs/api/models/pyhealth.models.TPC.rst
+++ b/docs/api/models/pyhealth.models.TPC.rst
@@ -1,0 +1,19 @@
+pyhealth.models.TPC
+===================================
+
+PyHealth-adapted Temporal Pointwise Convolution model.
+
+.. autoclass:: pyhealth.models.TPCBlock
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pyhealth.models.TPCLayer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pyhealth.models.TPC
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/models/pyhealth.models.TPC.rst
+++ b/docs/api/models/pyhealth.models.TPC.rst
@@ -1,7 +1,40 @@
 pyhealth.models.TPC
 ===================================
 
-PyHealth-adapted Temporal Pointwise Convolution model.
+Overview
+--------
+
+Contributor: Hasham Ul Haq (huhaq2)
+
+Paper: `Temporal Pointwise Convolutional Networks for Length of Stay Prediction in the Intensive Care Unit <https://arxiv.org/abs/2007.09483>`_
+
+This contribution adds a PyHealth-adapted implementation of Temporal
+Pointwise Convolution (TPC) for sequential EHR modeling. The model follows the
+standard ``BaseModel`` interface, supports PyHealth sequence and StageNet-style
+temporal processors, and is intended to be evaluated on existing PyHealth LOS
+tasks such as the MIMIC-IV temporal length-of-stay pipeline.
+
+Required Data
+-------------
+
+The accompanying example uses the existing
+``LengthOfStayStageNetMIMIC4`` task with ``MIMIC4Dataset``. For that temporal
+LOS pipeline, the MIMIC-IV root passed through ``EHR_ROOT`` should contain:
+
+- ``hosp/patients.csv.gz``
+- ``hosp/admissions.csv.gz``
+- ``hosp/diagnoses_icd.csv.gz``
+- ``hosp/procedures_icd.csv.gz``
+- ``hosp/labevents.csv.gz``
+- ``hosp/d_labitems.csv.gz``
+- ``icu/icustays.csv.gz``
+
+Although the example explicitly requests diagnoses, procedures, and
+``labevents``, the PyHealth MIMIC-IV EHR loader also includes core tables such
+as ``patients``, ``admissions``, and ``icustays``.
+
+API Reference
+-------------
 
 .. autoclass:: pyhealth.models.TPCBlock
     :members:

--- a/docs/api/models/pyhealth.models.TPC.rst
+++ b/docs/api/models/pyhealth.models.TPC.rst
@@ -6,7 +6,8 @@ Overview
 
 Contributor: Hasham Ul Haq (huhaq2)
 
-Paper: `Temporal Pointwise Convolutional Networks for Length of Stay Prediction in the Intensive Care Unit <https://arxiv.org/abs/2007.09483>`_
+Paper: `Temporal Pointwise Convolutional Networks for Length of Stay
+Prediction in the Intensive Care Unit <https://arxiv.org/abs/2007.09483>`_
 
 This contribution adds a PyHealth-adapted implementation of Temporal
 Pointwise Convolution (TPC) for sequential EHR modeling. The model follows the

--- a/examples/length_of_stay/length_of_stay_mimic4_tpc.py
+++ b/examples/length_of_stay/length_of_stay_mimic4_tpc.py
@@ -1,5 +1,12 @@
 """TPC on MIMIC-IV length-of-stay prediction with simple ablations.
 
+Contributor: Hasham Ul Haq (huhaq2)
+Paper: Temporal Pointwise Convolutional Networks for Length of Stay Prediction
+    in the Intensive Care Unit
+Paper link: https://arxiv.org/abs/2007.09483
+Description: Example script for evaluating the PyHealth-adapted TPC model on
+    the existing MIMIC-IV temporal length-of-stay task with small ablations.
+
 This example is designed for reproducible course-project style experiments:
 it runs on the bundled MIMIC-IV demo by default and can be pointed at full
 MIMIC-IV via ``EHR_ROOT``.
@@ -14,6 +21,21 @@ Ablations included:
     - number of TPC layers
     - hidden dimension
     - dropout
+
+Expected MIMIC-IV files for the temporal LOS task:
+    - hosp/patients.csv.gz
+    - hosp/admissions.csv.gz
+    - hosp/diagnoses_icd.csv.gz
+    - hosp/procedures_icd.csv.gz
+    - hosp/labevents.csv.gz
+    - hosp/d_labitems.csv.gz
+    - icu/icustays.csv.gz
+
+Note:
+    ``MIMIC4EHRDataset`` automatically includes core EHR tables such as
+    patients, admissions, and ICU stays. Keep those files in the EHR root even
+    though the example only passes diagnoses, procedures, and labevents in
+    ``ehr_tables``.
 """
 
 from __future__ import annotations

--- a/examples/length_of_stay/length_of_stay_mimic4_tpc.py
+++ b/examples/length_of_stay/length_of_stay_mimic4_tpc.py
@@ -14,7 +14,8 @@ MIMIC-IV via ``EHR_ROOT``.
 Suggested usage:
     python examples/length_of_stay/length_of_stay_mimic4_tpc.py
     python examples/length_of_stay/length_of_stay_mimic4_tpc.py --quick-test
-    EHR_ROOT=/path/to/mimiciv/2.2 python examples/length_of_stay/length_of_stay_mimic4_tpc.py
+    EHR_ROOT=/path/to/mimiciv/2.2 \
+        python examples/length_of_stay/length_of_stay_mimic4_tpc.py
 
 Ablations included:
     - kernel size
@@ -180,9 +181,21 @@ def run_ablation(
             ratios=[0.7, 0.1, 0.2],
         )
 
-    train_loader = get_dataloader(train_dataset, batch_size=config["batch_size"], shuffle=True)
-    val_loader = get_dataloader(val_dataset, batch_size=config["batch_size"], shuffle=False)
-    test_loader = get_dataloader(test_dataset, batch_size=config["batch_size"], shuffle=False)
+    train_loader = get_dataloader(
+        train_dataset,
+        batch_size=config["batch_size"],
+        shuffle=True,
+    )
+    val_loader = get_dataloader(
+        val_dataset,
+        batch_size=config["batch_size"],
+        shuffle=False,
+    )
+    test_loader = get_dataloader(
+        test_dataset,
+        batch_size=config["batch_size"],
+        shuffle=False,
+    )
 
     model = TPC(
         dataset=sample_dataset,

--- a/examples/length_of_stay/length_of_stay_mimic4_tpc.py
+++ b/examples/length_of_stay/length_of_stay_mimic4_tpc.py
@@ -1,0 +1,275 @@
+"""TPC on MIMIC-IV length-of-stay prediction with simple ablations.
+
+This example is designed for reproducible course-project style experiments:
+it runs on the bundled MIMIC-IV demo by default and can be pointed at full
+MIMIC-IV via ``EHR_ROOT``.
+
+Suggested usage:
+    python examples/length_of_stay/length_of_stay_mimic4_tpc.py
+    python examples/length_of_stay/length_of_stay_mimic4_tpc.py --quick-test
+    EHR_ROOT=/path/to/mimiciv/2.2 python examples/length_of_stay/length_of_stay_mimic4_tpc.py
+
+Ablations included:
+    - kernel size
+    - number of TPC layers
+    - hidden dimension
+    - dropout
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import torch
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+DEMO_EHR_ROOT = REPO_ROOT / "test-resources" / "core" / "mimic4demo"
+
+# Prefer the local repository checkout when this script is run directly.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from pyhealth.datasets import (
+    MIMIC4Dataset,
+    get_dataloader,
+    split_by_patient,
+    split_by_sample,
+)
+from pyhealth.models import TPC
+from pyhealth.tasks import LengthOfStayStageNetMIMIC4
+from pyhealth.trainer import Trainer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--quick-test",
+        action="store_true",
+        help="Use dev mode and only the first ablation for a smoke test.",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="Optionally cap the SampleDataset size after task construction.",
+    )
+    parser.add_argument(
+        "--single-ablation",
+        action="store_true",
+        help="Run only the first ablation config.",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=None,
+        help="Override the default number of training epochs.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=None,
+        help="Override the batch size for all ablations.",
+    )
+    parser.add_argument(
+        "--split-mode",
+        choices=["auto", "patient", "sample"],
+        default="auto",
+        help="Choose how to split the dataset for evaluation.",
+    )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=None,
+        help="Override dataset/task worker count.",
+    )
+    parser.add_argument(
+        "--device",
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Training device.",
+    )
+    return parser.parse_args()
+
+
+def build_dataset(
+    ehr_root: str,
+    quick_test: bool,
+    max_samples: int | None = None,
+    num_workers: int | None = None,
+):
+    worker_count = num_workers if num_workers is not None else (1 if quick_test else 4)
+    base_dataset = MIMIC4Dataset(
+        ehr_root=ehr_root,
+        ehr_tables=[
+            "patients",
+            "admissions",
+            "diagnoses_icd",
+            "procedures_icd",
+            "labevents",
+        ],
+        dev=quick_test,
+        num_workers=worker_count,
+    )
+    sample_dataset = base_dataset.set_task(
+        LengthOfStayStageNetMIMIC4(padding=20),
+        num_workers=worker_count,
+    )
+    if max_samples is not None:
+        capped_size = min(max_samples, len(sample_dataset))
+        sample_dataset = sample_dataset.subset(range(capped_size))
+        print(f"Capped dataset to {len(sample_dataset)} samples for local testing.")
+    return sample_dataset
+
+
+def run_ablation(
+    sample_dataset,
+    device: str,
+    config: dict,
+    epochs: int,
+    split_mode: str = "auto",
+) -> dict:
+    if len(sample_dataset) < 3 or len(sample_dataset.patient_to_index) < 3:
+        print(
+            "Dataset too small for patient-level train/val/test splitting; "
+            "reusing the same dataset for all three loaders."
+        )
+        train_dataset = sample_dataset
+        val_dataset = sample_dataset
+        test_dataset = sample_dataset
+    elif split_mode == "sample":
+        print("Using sample-level train/val/test split.")
+        train_dataset, val_dataset, test_dataset = split_by_sample(
+            sample_dataset,
+            ratios=[0.7, 0.1, 0.2],
+        )
+    elif split_mode == "patient":
+        print("Using patient-level train/val/test split.")
+        train_dataset, val_dataset, test_dataset = split_by_patient(
+            sample_dataset,
+            ratios=[0.7, 0.1, 0.2],
+        )
+    else:
+        print("Using patient-level train/val/test split.")
+        train_dataset, val_dataset, test_dataset = split_by_patient(
+            sample_dataset,
+            ratios=[0.7, 0.1, 0.2],
+        )
+
+    train_loader = get_dataloader(train_dataset, batch_size=config["batch_size"], shuffle=True)
+    val_loader = get_dataloader(val_dataset, batch_size=config["batch_size"], shuffle=False)
+    test_loader = get_dataloader(test_dataset, batch_size=config["batch_size"], shuffle=False)
+
+    model = TPC(
+        dataset=sample_dataset,
+        embedding_dim=config["embedding_dim"],
+        hidden_dim=config["hidden_dim"],
+        num_layers=config["num_layers"],
+        kernel_size=config["kernel_size"],
+        dropout=config["dropout"],
+    )
+    trainer = Trainer(
+        model=model,
+        device=device,
+        metrics=["accuracy", "f1_weighted", "f1_macro"],
+    )
+    trainer.train(
+        train_dataloader=train_loader,
+        val_dataloader=val_loader,
+        epochs=epochs,
+        monitor="accuracy",
+        optimizer_params={"lr": config["lr"]},
+    )
+    results = trainer.evaluate(test_loader)
+    return results
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    ehr_root = os.environ.get("EHR_ROOT", str(DEMO_EHR_ROOT))
+    sample_dataset = build_dataset(
+        ehr_root=ehr_root,
+        quick_test=args.quick_test,
+        max_samples=args.max_samples,
+        num_workers=args.num_workers,
+    )
+
+    print(f"Loaded sample dataset with {len(sample_dataset)} samples from: {ehr_root}")
+    print(f"Input schema: {sample_dataset.input_schema}")
+    print(f"Output schema: {sample_dataset.output_schema}")
+
+    ablations = [
+        {
+            "name": "base",
+            "embedding_dim": 128,
+            "hidden_dim": 128,
+            "num_layers": 2,
+            "kernel_size": 3,
+            "dropout": 0.1,
+            "lr": 1e-3,
+            "batch_size": 16 if args.quick_test else 32,
+        },
+        {
+            "name": "wider_hidden",
+            "embedding_dim": 128,
+            "hidden_dim": 256,
+            "num_layers": 2,
+            "kernel_size": 3,
+            "dropout": 0.1,
+            "lr": 1e-3,
+            "batch_size": 32,
+        },
+        {
+            "name": "larger_kernel",
+            "embedding_dim": 128,
+            "hidden_dim": 128,
+            "num_layers": 2,
+            "kernel_size": 5,
+            "dropout": 0.1,
+            "lr": 1e-3,
+            "batch_size": 32,
+        },
+        {
+            "name": "deeper_stack",
+            "embedding_dim": 128,
+            "hidden_dim": 128,
+            "num_layers": 4,
+            "kernel_size": 3,
+            "dropout": 0.2,
+            "lr": 1e-3,
+            "batch_size": 32,
+        },
+    ]
+
+    if args.quick_test or args.single_ablation:
+        ablations = ablations[:1]
+
+    if args.batch_size is not None:
+        for config in ablations:
+            config["batch_size"] = args.batch_size
+
+    epochs = args.epochs if args.epochs is not None else (1 if args.quick_test else 10)
+    summary = []
+    for config in ablations:
+        print("\n" + "=" * 80)
+        print(f"Running ablation: {config['name']}")
+        print(config)
+        results = run_ablation(
+            sample_dataset=sample_dataset,
+            device=args.device,
+            config=config,
+            epochs=epochs,
+            split_mode=args.split_mode,
+        )
+        print(f"Results: {results}")
+        summary.append((config["name"], results))
+
+    print("\nAblation summary")
+    for name, results in summary:
+        print(
+            f"- {name}: accuracy={results.get('accuracy', float('nan')):.4f}, "
+            f"f1_weighted={results.get('f1_weighted', float('nan')):.4f}, "
+            f"f1_macro={results.get('f1_macro', float('nan')):.4f}"
+        )

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -26,6 +26,7 @@ from .sparcnet import DenseBlock, DenseLayer, SparcNet, TransitionLayer
 from .stagenet import StageNet, StageNetLayer
 from .stagenet_mha import StageAttentionNet, StageNetAttentionLayer
 from .tcn import TCN, TCNLayer
+from .tpc import TPC, TPCBlock, TPCLayer
 from .tfm_tokenizer import (
     TFMTokenizer,
     TFM_VQVAE2_deep,

--- a/pyhealth/models/tpc.py
+++ b/pyhealth/models/tpc.py
@@ -205,6 +205,11 @@ class TPC(BaseModel):
     enriched with temporal information when available, encoded by a dedicated
     :class:`TPCLayer`, and finally concatenated for prediction.
 
+    TPC uses PyHealth's task output schema to select the prediction head size,
+    loss function, and prediction format. It therefore supports binary,
+    multiclass, multilabel, and regression tasks when paired with the
+    corresponding PyHealth output processor.
+
     Supported input processor families include:
     - ``SequenceProcessor``
     - ``StageNetProcessor``

--- a/pyhealth/models/tpc.py
+++ b/pyhealth/models/tpc.py
@@ -1,13 +1,14 @@
 """Temporal Pointwise Convolution model for PyHealth.
 
-Author: Codex
-Paper title: Temporal Pointwise Convolutional Networks for Length of Stay
-    Prediction in the Intensive Care Unit
-Paper link: https://github.com/EmmaRocheteau/TPC-LoS-prediction
+Contributor: Hasham Ul Haq (huhaq2)
+Paper: Temporal Pointwise Convolutional Networks for Length of Stay Prediction
+    in the Intensive Care Unit
+Paper link: https://arxiv.org/abs/2007.09483
 Description: PyHealth-adapted Temporal Pointwise Convolution (TPC) model for
-    sequential EHR prediction tasks. The implementation follows the PyHealth
-    ``BaseModel`` interface and supports standard sequence processors together
-    with StageNet-style temporal inputs.
+    sequential EHR prediction tasks. The implementation follows the
+    ``BaseModel`` interface, supports standard sequence processors together
+    with StageNet-style temporal inputs, and is intended for reproducible
+    length-of-stay experiments on existing PyHealth MIMIC-IV pipelines.
 """
 
 from __future__ import annotations

--- a/pyhealth/models/tpc.py
+++ b/pyhealth/models/tpc.py
@@ -85,7 +85,11 @@ class TPCBlock(nn.Module):
         )
         self.dropout = nn.Dropout(dropout)
 
-    def forward(self, x: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         """Run the residual TPC block.
 
         Args:
@@ -286,7 +290,10 @@ class TPC(BaseModel):
             self.time_projections[feature_key] = nn.Linear(1, embedding_dim)
 
         self.dropout = nn.Dropout(dropout)
-        self.fc = nn.Linear(len(self.feature_keys) * embedding_dim, self.get_output_size())
+        self.fc = nn.Linear(
+            len(self.feature_keys) * embedding_dim,
+            self.get_output_size(),
+        )
 
     @staticmethod
     def _split_temporal(feature: Any) -> Tuple[Optional[torch.Tensor], Any]:

--- a/pyhealth/models/tpc.py
+++ b/pyhealth/models/tpc.py
@@ -1,0 +1,479 @@
+"""Temporal Pointwise Convolution model for PyHealth.
+
+Author: Codex
+Paper title: Temporal Pointwise Convolutional Networks for Length of Stay
+    Prediction in the Intensive Care Unit
+Paper link: https://github.com/EmmaRocheteau/TPC-LoS-prediction
+Description: PyHealth-adapted Temporal Pointwise Convolution (TPC) model for
+    sequential EHR prediction tasks. The implementation follows the PyHealth
+    ``BaseModel`` interface and supports standard sequence processors together
+    with StageNet-style temporal inputs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple, Type, Union
+
+import torch
+from torch import nn
+
+from pyhealth.datasets import SampleDataset
+from pyhealth.models import BaseModel
+from pyhealth.models.embedding import EmbeddingModel
+from pyhealth.models.utils import get_last_visit
+from pyhealth.processors import (
+    MultiHotProcessor,
+    SequenceProcessor,
+    StageNetProcessor,
+    StageNetTensorProcessor,
+    TensorProcessor,
+    TimeseriesProcessor,
+)
+from pyhealth.processors.base_processor import FeatureProcessor
+
+
+class CausalTrim1d(nn.Module):
+    """Trim the right side of a padded 1D convolution output."""
+
+    def __init__(self, trim_size: int):
+        super().__init__()
+        self.trim_size = trim_size
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.trim_size == 0:
+            return x
+        return x[:, :, :-self.trim_size]
+
+
+class TPCBlock(nn.Module):
+    """Single temporal-pointwise convolution residual block.
+
+    The block first applies a causal temporal convolution over the sequence axis
+    and then a pointwise ``1x1`` convolution to mix channels. A residual
+    connection keeps the feature dimension fixed across blocks.
+
+    Args:
+        feature_dim: Input and output feature size.
+        hidden_dim: Hidden channel count used inside the block.
+        kernel_size: Temporal convolution kernel size.
+        dropout: Dropout probability applied before the residual addition.
+    """
+
+    def __init__(
+        self,
+        feature_dim: int,
+        hidden_dim: int,
+        kernel_size: int = 3,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        padding = max(kernel_size - 1, 0)
+        self.norm = nn.LayerNorm(feature_dim)
+        self.temporal_conv = nn.Conv1d(
+            in_channels=feature_dim,
+            out_channels=hidden_dim * 2,
+            kernel_size=kernel_size,
+            padding=padding,
+        )
+        self.trim = CausalTrim1d(padding)
+        self.activation = nn.GLU(dim=1)
+        self.pointwise_conv = nn.Conv1d(
+            in_channels=hidden_dim,
+            out_channels=feature_dim,
+            kernel_size=1,
+        )
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Run the residual TPC block.
+
+        Args:
+            x: Input tensor of shape ``[batch, seq_len, feature_dim]``.
+            mask: Optional boolean padding mask ``[batch, seq_len]``.
+
+        Returns:
+            Tensor of shape ``[batch, seq_len, feature_dim]``.
+        """
+
+        residual = x
+        y = self.norm(x).transpose(1, 2)
+        y = self.temporal_conv(y)
+        y = self.trim(y)
+        y = self.activation(y)
+        y = self.pointwise_conv(y).transpose(1, 2)
+        y = self.dropout(y)
+        x = residual + y
+        if mask is not None:
+            x = x.masked_fill(~mask.unsqueeze(-1), 0.0)
+        return x
+
+
+class TPCLayer(nn.Module):
+    """Stack of temporal-pointwise convolution blocks.
+
+    Args:
+        feature_dim: Input and output embedding dimension.
+        hidden_dim: Hidden channel count in each TPC block.
+        num_layers: Number of residual TPC blocks.
+        kernel_size: Temporal convolution kernel size.
+        dropout: Dropout probability.
+
+    Examples:
+        >>> x = torch.randn(2, 5, 32)
+        >>> layer = TPCLayer(feature_dim=32, hidden_dim=64, num_layers=2)
+        >>> outputs, pooled = layer(x)
+        >>> outputs.shape
+        torch.Size([2, 5, 32])
+        >>> pooled.shape
+        torch.Size([2, 32])
+    """
+
+    def __init__(
+        self,
+        feature_dim: int,
+        hidden_dim: int = 128,
+        num_layers: int = 2,
+        kernel_size: int = 3,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        self.feature_dim = feature_dim
+        self.hidden_dim = hidden_dim
+        self.num_layers = num_layers
+        self.kernel_size = kernel_size
+        self.dropout_rate = dropout
+
+        self.blocks = nn.ModuleList(
+            [
+                TPCBlock(
+                    feature_dim=feature_dim,
+                    hidden_dim=hidden_dim,
+                    kernel_size=kernel_size,
+                    dropout=dropout,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.output_norm = nn.LayerNorm(feature_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Encode a feature sequence and return sequence + pooled outputs.
+
+        Args:
+            x: Tensor of shape ``[batch, seq_len, feature_dim]``.
+            mask: Optional boolean mask ``[batch, seq_len]``.
+
+        Returns:
+            Tuple containing:
+                - Encoded sequence ``[batch, seq_len, feature_dim]``
+                - Last valid embedding ``[batch, feature_dim]``
+        """
+
+        if mask is None:
+            mask = torch.ones(
+                x.size(0),
+                x.size(1),
+                dtype=torch.bool,
+                device=x.device,
+            )
+        else:
+            mask = mask.bool().to(x.device)
+
+        for block in self.blocks:
+            x = block(x, mask)
+
+        x = self.output_norm(x)
+        x = x.masked_fill(~mask.unsqueeze(-1), 0.0)
+        pooled = get_last_visit(x, mask)
+        return x, pooled
+
+
+class TPC(BaseModel):
+    """Temporal Pointwise Convolution model for sequential EHR prediction.
+
+    This implementation adapts the high-level TPC idea to PyHealth's processor
+    abstractions. Each feature stream is embedded independently, optionally
+    enriched with temporal information when available, encoded by a dedicated
+    :class:`TPCLayer`, and finally concatenated for prediction.
+
+    Supported input processor families include:
+    - ``SequenceProcessor``
+    - ``StageNetProcessor``
+    - ``StageNetTensorProcessor``
+    - ``TimeseriesProcessor``
+    - ``TensorProcessor``
+    - ``MultiHotProcessor``
+
+    Args:
+        dataset: SampleDataset used to configure feature and label processors.
+        embedding_dim: Shared embedding dimension for all feature streams.
+        hidden_dim: Hidden channel size inside each TPC block.
+        num_layers: Number of TPC blocks per feature stream.
+        kernel_size: Temporal convolution kernel size.
+        dropout: Dropout probability.
+
+    Examples:
+        >>> from pyhealth.datasets import create_sample_dataset, get_dataloader
+        >>> samples = [
+        ...     {
+        ...         "patient_id": "p0",
+        ...         "visit_id": "v0",
+        ...         "conditions": ["A", "B"],
+        ...         "procedures": ["X"],
+        ...         "label": 1,
+        ...     },
+        ...     {
+        ...         "patient_id": "p1",
+        ...         "visit_id": "v0",
+        ...         "conditions": ["C"],
+        ...         "procedures": ["Y", "Z"],
+        ...         "label": 0,
+        ...     },
+        ... ]
+        >>> dataset = create_sample_dataset(
+        ...     samples=samples,
+        ...     input_schema={"conditions": "sequence", "procedures": "sequence"},
+        ...     output_schema={"label": "binary"},
+        ...     dataset_name="test_tpc",
+        ... )
+        >>> model = TPC(dataset=dataset, embedding_dim=32, hidden_dim=64)
+        >>> batch = next(iter(get_dataloader(dataset, batch_size=2, shuffle=False)))
+        >>> output = model(**batch)
+        >>> sorted(output.keys())
+        ['logit', 'loss', 'y_prob', 'y_true']
+    """
+
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        embedding_dim: int = 128,
+        hidden_dim: int = 128,
+        num_layers: int = 2,
+        kernel_size: int = 3,
+        dropout: float = 0.1,
+    ):
+        super().__init__(dataset=dataset)
+        self.embedding_dim = embedding_dim
+        self.hidden_dim = hidden_dim
+        self.num_layers = num_layers
+        self.kernel_size = kernel_size
+        self.dropout_rate = dropout
+
+        assert len(self.label_keys) == 1, "TPC supports single-label tasks only"
+        self.label_key = self.label_keys[0]
+        self.mode = self.dataset.output_schema[self.label_key]
+
+        self.embedding_model = EmbeddingModel(dataset, embedding_dim)
+        self.feature_processors = {
+            key: self.dataset.input_processors[key] for key in self.feature_keys
+        }
+
+        self.time_projections = nn.ModuleDict()
+        self.tpc_layers = nn.ModuleDict()
+        for feature_key in self.feature_keys:
+            self.tpc_layers[feature_key] = TPCLayer(
+                feature_dim=embedding_dim,
+                hidden_dim=hidden_dim,
+                num_layers=num_layers,
+                kernel_size=kernel_size,
+                dropout=dropout,
+            )
+            self.time_projections[feature_key] = nn.Linear(1, embedding_dim)
+
+        self.dropout = nn.Dropout(dropout)
+        self.fc = nn.Linear(len(self.feature_keys) * embedding_dim, self.get_output_size())
+
+    @staticmethod
+    def _split_temporal(feature: Any) -> Tuple[Optional[torch.Tensor], Any]:
+        """Split a feature tuple into ``(time, value)`` when applicable."""
+        if isinstance(feature, tuple) and len(feature) == 2:
+            return feature
+        return None, feature
+
+    def _ensure_tensor(self, feature_key: str, value: Any) -> torch.Tensor:
+        """Convert a raw feature value into a tensor when needed."""
+        if isinstance(value, torch.Tensor):
+            return value
+        processor = self.feature_processors[feature_key]
+        if isinstance(processor, (SequenceProcessor, StageNetProcessor)):
+            return torch.tensor(value, dtype=torch.long)
+        return torch.tensor(value, dtype=torch.float)
+
+    @staticmethod
+    def _ensure_time_tensor(time_value: Optional[Any]) -> Optional[torch.Tensor]:
+        """Convert optional temporal metadata into a float tensor."""
+        if time_value is None:
+            return None
+        if isinstance(time_value, torch.Tensor):
+            return time_value.float()
+        return torch.tensor(time_value, dtype=torch.float)
+
+    def _create_mask(self, feature_key: str, value: torch.Tensor) -> torch.Tensor:
+        """Create a sequence mask tailored to the feature processor."""
+        processor = self.feature_processors[feature_key]
+        if isinstance(processor, SequenceProcessor):
+            mask = value != 0
+        elif isinstance(processor, StageNetProcessor):
+            mask = torch.any(value != 0, dim=-1) if value.dim() >= 3 else value != 0
+        elif isinstance(processor, (TimeseriesProcessor, StageNetTensorProcessor)):
+            if value.dim() >= 3:
+                mask = torch.any(torch.abs(value) > 0, dim=-1)
+            elif value.dim() == 2:
+                mask = torch.any(torch.abs(value) > 0, dim=-1, keepdim=True)
+            else:
+                mask = torch.ones(
+                    value.size(0),
+                    1,
+                    dtype=torch.bool,
+                    device=value.device,
+                )
+        elif isinstance(processor, (TensorProcessor, MultiHotProcessor)):
+            mask = torch.ones(
+                value.size(0),
+                1,
+                dtype=torch.bool,
+                device=value.device,
+            )
+        else:
+            mask = (
+                torch.any(value != 0, dim=-1)
+                if value.dim() >= 2
+                else torch.ones(
+                    value.size(0),
+                    1,
+                    dtype=torch.bool,
+                    device=value.device,
+                )
+            )
+        if mask.dim() == 1:
+            mask = mask.unsqueeze(1)
+        mask = mask.bool()
+        invalid = ~mask.any(dim=1)
+        if invalid.any():
+            mask[invalid, 0] = True
+        return mask
+
+    @staticmethod
+    def _pool_embedding(x: torch.Tensor) -> torch.Tensor:
+        """Collapse unordered dimensions so every feature becomes sequential."""
+        if x.dim() == 4:
+            x = x.sum(dim=2)
+        if x.dim() == 2:
+            x = x.unsqueeze(1)
+        return x
+
+    @staticmethod
+    def _align_time(
+        time_tensor: Optional[torch.Tensor],
+        target_length: int,
+        device: torch.device,
+    ) -> Optional[torch.Tensor]:
+        """Pad or trim a time tensor to match the encoded sequence length."""
+        if time_tensor is None:
+            return None
+        time_tensor = time_tensor.to(device).float()
+        if time_tensor.dim() == 3 and time_tensor.size(-1) == 1:
+            time_tensor = time_tensor.squeeze(-1)
+        if time_tensor.dim() == 1:
+            time_tensor = time_tensor.unsqueeze(0)
+        if time_tensor.size(1) > target_length:
+            time_tensor = time_tensor[:, :target_length]
+        elif time_tensor.size(1) < target_length:
+            pad = torch.zeros(
+                time_tensor.size(0),
+                target_length - time_tensor.size(1),
+                device=device,
+                dtype=time_tensor.dtype,
+            )
+            time_tensor = torch.cat([time_tensor, pad], dim=1)
+        return time_tensor
+
+    def forward(self, **kwargs) -> Dict[str, torch.Tensor]:
+        """Run the TPC model on a batch of PyHealth samples."""
+        patient_embeddings = []
+        embedding_inputs: Dict[str, torch.Tensor] = {}
+        masks: Dict[str, torch.Tensor] = {}
+        time_tensors: Dict[str, Optional[torch.Tensor]] = {}
+
+        for feature_key in self.feature_keys:
+            time_value, value = self._split_temporal(kwargs[feature_key])
+            value_tensor = self._ensure_tensor(feature_key, value)
+            embedding_inputs[feature_key] = value_tensor
+            masks[feature_key] = self._create_mask(feature_key, value_tensor)
+            time_tensors[feature_key] = self._ensure_time_tensor(time_value)
+
+        embedded = self.embedding_model(embedding_inputs)
+
+        for feature_key in self.feature_keys:
+            x = embedded[feature_key].to(self.device)
+            x = self._pool_embedding(x)
+
+            mask = masks[feature_key].to(self.device)
+            time_tensor = self._align_time(
+                time_tensors[feature_key],
+                target_length=x.size(1),
+                device=self.device,
+            )
+            if time_tensor is not None:
+                x = x + self.time_projections[feature_key](time_tensor.unsqueeze(-1))
+
+            _, pooled = self.tpc_layers[feature_key](x, mask)
+            patient_embeddings.append(pooled)
+
+        patient_embedding = torch.cat(patient_embeddings, dim=1)
+        logits = self.fc(self.dropout(patient_embedding))
+        y_true = kwargs[self.label_key].to(self.device)
+        loss = self.get_loss_function()(logits, y_true)
+        y_prob = self.prepare_y_prob(logits)
+
+        output = {
+            "loss": loss,
+            "y_prob": y_prob,
+            "y_true": y_true,
+            "logit": logits,
+        }
+        if kwargs.get("embed", False):
+            output["embed"] = patient_embedding
+        return output
+
+
+if __name__ == "__main__":
+    from pyhealth.datasets import create_sample_dataset, get_dataloader
+
+    samples = [
+        {
+            "patient_id": "p0",
+            "visit_id": "v0",
+            "conditions": ["A", "B"],
+            "procedures": ["X"],
+            "label": 1,
+        },
+        {
+            "patient_id": "p1",
+            "visit_id": "v0",
+            "conditions": ["C"],
+            "procedures": ["Y", "Z"],
+            "label": 0,
+        },
+    ]
+    input_schema: Dict[str, Union[str, Type[FeatureProcessor]]] = {
+        "conditions": "sequence",
+        "procedures": "sequence",
+    }
+    output_schema: Dict[str, Union[str, Type[FeatureProcessor]]] = {"label": "binary"}
+
+    dataset = create_sample_dataset(
+        samples=samples,
+        input_schema=input_schema,
+        output_schema=output_schema,
+        dataset_name="test_tpc_dataset",
+    )
+    model = TPC(dataset=dataset, embedding_dim=32, hidden_dim=64)
+    batch = next(iter(get_dataloader(dataset, batch_size=2, shuffle=False)))
+    out = model(**batch)
+    print("keys:", sorted(out.keys()))
+    out["loss"].backward()

--- a/tests/core/test_tpc.py
+++ b/tests/core/test_tpc.py
@@ -100,7 +100,9 @@ class TestTPCLayer(unittest.TestCase):
         outputs, pooled = layer(x, mask)
         self.assertEqual(outputs.shape, (3, 5, 16))
         self.assertEqual(pooled.shape, (3, 16))
-        self.assertTrue(torch.allclose(outputs[0, 3:], torch.zeros_like(outputs[0, 3:])))
+        self.assertTrue(
+            torch.allclose(outputs[0, 3:], torch.zeros_like(outputs[0, 3:]))
+        )
 
 
 class TestTPC(unittest.TestCase):
@@ -130,7 +132,9 @@ class TestTPC(unittest.TestCase):
 
     def test_binary_forward(self):
         model = TPC(dataset=self.binary_dataset, embedding_dim=32, hidden_dim=64)
-        batch = next(iter(get_dataloader(self.binary_dataset, batch_size=2, shuffle=False)))
+        batch = next(
+            iter(get_dataloader(self.binary_dataset, batch_size=2, shuffle=False))
+        )
 
         with torch.no_grad():
             ret = model(**batch)
@@ -159,7 +163,9 @@ class TestTPC(unittest.TestCase):
 
     def test_backward(self):
         model = TPC(dataset=self.binary_dataset, embedding_dim=16, hidden_dim=32)
-        batch = next(iter(get_dataloader(self.binary_dataset, batch_size=2, shuffle=False)))
+        batch = next(
+            iter(get_dataloader(self.binary_dataset, batch_size=2, shuffle=False))
+        )
 
         ret = model(**batch)
         ret["loss"].backward()
@@ -168,11 +174,16 @@ class TestTPC(unittest.TestCase):
             param.requires_grad and param.grad is not None
             for param in model.parameters()
         )
-        self.assertTrue(has_gradient, "No parameters have gradients after backward pass")
+        self.assertTrue(
+            has_gradient,
+            "No parameters have gradients after backward pass",
+        )
 
     def test_embed_output(self):
         model = TPC(dataset=self.binary_dataset, embedding_dim=20, hidden_dim=40)
-        batch = next(iter(get_dataloader(self.binary_dataset, batch_size=2, shuffle=False)))
+        batch = next(
+            iter(get_dataloader(self.binary_dataset, batch_size=2, shuffle=False))
+        )
         batch["embed"] = True
 
         with torch.no_grad():

--- a/tests/core/test_tpc.py
+++ b/tests/core/test_tpc.py
@@ -80,6 +80,31 @@ def _make_multiclass_dataset():
     )
 
 
+def _make_regression_dataset():
+    samples = [
+        {
+            "patient_id": "patient-0",
+            "visit_id": "visit-0",
+            "icd_codes": ([0.0, 24.0], [["A", "B"], ["C"]]),
+            "labs": ([0.0, 12.0], [[1.0, 2.0], [2.0, 3.0]]),
+            "remaining_los": 2.5,
+        },
+        {
+            "patient_id": "patient-1",
+            "visit_id": "visit-0",
+            "icd_codes": ([0.0, 12.0], [["D"], ["E"]]),
+            "labs": ([0.0, 6.0], [[3.0, 4.0], [5.0, 6.0]]),
+            "remaining_los": 5.0,
+        },
+    ]
+    return create_sample_dataset(
+        samples=samples,
+        input_schema={"icd_codes": "stagenet", "labs": "stagenet_tensor"},
+        output_schema={"remaining_los": "regression"},
+        dataset_name="test_tpc_regression",
+    )
+
+
 class TestTPCLayer(unittest.TestCase):
     """Unit tests for the standalone TPC encoder layer."""
 
@@ -112,6 +137,7 @@ class TestTPC(unittest.TestCase):
     def setUpClass(cls):
         cls.binary_dataset = _make_binary_dataset()
         cls.multiclass_dataset = _make_multiclass_dataset()
+        cls.regression_dataset = _make_regression_dataset()
 
     def test_model_initialization(self):
         model = TPC(
@@ -160,6 +186,20 @@ class TestTPC(unittest.TestCase):
         self.assertEqual(ret["y_prob"].shape, (3, 3))
         self.assertEqual(ret["logit"].shape, (3, 3))
         self.assertEqual(ret["y_true"].shape[0], 3)
+
+    def test_regression_forward(self):
+        model = TPC(dataset=self.regression_dataset, embedding_dim=24, hidden_dim=48)
+        batch = next(
+            iter(get_dataloader(self.regression_dataset, batch_size=2, shuffle=False))
+        )
+
+        with torch.no_grad():
+            ret = model(**batch)
+
+        self.assertEqual(ret["y_prob"].shape, (2, 1))
+        self.assertEqual(ret["logit"].shape, (2, 1))
+        self.assertEqual(ret["y_true"].shape, (2, 1))
+        self.assertEqual(ret["loss"].dim(), 0)
 
     def test_backward(self):
         model = TPC(dataset=self.binary_dataset, embedding_dim=16, hidden_dim=32)

--- a/tests/core/test_tpc.py
+++ b/tests/core/test_tpc.py
@@ -1,0 +1,176 @@
+import unittest
+
+import torch
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models import TPC
+from pyhealth.models.tpc import TPCLayer
+
+
+def _make_binary_dataset():
+    samples = [
+        {
+            "patient_id": "patient-0",
+            "visit_id": "visit-0",
+            "diagnoses": ["A", "B", "C"],
+            "icd_codes": ([0.0, 24.0], [["A", "B"], ["C"]]),
+            "labs": ([0.0, 12.0], [[1.0, None, 3.0], [2.0, 5.0, None]]),
+            "label": 1,
+        },
+        {
+            "patient_id": "patient-1",
+            "visit_id": "visit-0",
+            "diagnoses": ["D", "E"],
+            "icd_codes": ([0.0, 18.0], [["D"], ["E", "F"]]),
+            "labs": ([0.0, 6.0], [[4.0, 1.0, None], [5.0, None, 9.0]]),
+            "label": 0,
+        },
+    ]
+    return create_sample_dataset(
+        samples=samples,
+        input_schema={
+            "diagnoses": "sequence",
+            "icd_codes": "stagenet",
+            "labs": "stagenet_tensor",
+        },
+        output_schema={"label": "binary"},
+        dataset_name="test_tpc_binary",
+    )
+
+
+def _make_multiclass_dataset():
+    samples = [
+        {
+            "patient_id": "patient-0",
+            "visit_id": "visit-0",
+            "icd_codes": ([0.0, 24.0], [["A", "B"], ["C"]]),
+            "labs": ([0.0, 12.0], [[1.0, 2.0], [2.0, 3.0]]),
+            "los": 0,
+        },
+        {
+            "patient_id": "patient-1",
+            "visit_id": "visit-0",
+            "icd_codes": ([0.0, 12.0], [["D"], ["E"]]),
+            "labs": ([0.0, 6.0], [[3.0, 4.0], [5.0, 6.0]]),
+            "los": 1,
+        },
+        {
+            "patient_id": "patient-2",
+            "visit_id": "visit-0",
+            "icd_codes": ([0.0, 30.0], [["F"], ["G", "H"]]),
+            "labs": ([0.0, 8.0], [[7.0, 8.0], [9.0, 10.0]]),
+            "los": 2,
+        },
+    ]
+    return create_sample_dataset(
+        samples=samples,
+        input_schema={"icd_codes": "stagenet", "labs": "stagenet_tensor"},
+        output_schema={"los": "multiclass"},
+        dataset_name="test_tpc_multiclass",
+    )
+
+
+class TestTPCLayer(unittest.TestCase):
+    """Unit tests for the standalone TPC encoder layer."""
+
+    def test_output_shapes(self):
+        layer = TPCLayer(feature_dim=32, hidden_dim=64, num_layers=2, kernel_size=3)
+        x = torch.randn(4, 7, 32)
+        outputs, pooled = layer(x)
+        self.assertEqual(outputs.shape, (4, 7, 32))
+        self.assertEqual(pooled.shape, (4, 32))
+
+    def test_masked_forward(self):
+        layer = TPCLayer(feature_dim=16, hidden_dim=32, num_layers=1, kernel_size=2)
+        x = torch.randn(3, 5, 16)
+        mask = torch.tensor(
+            [[1, 1, 1, 0, 0], [1, 1, 1, 1, 1], [1, 0, 0, 0, 0]],
+            dtype=torch.bool,
+        )
+        outputs, pooled = layer(x, mask)
+        self.assertEqual(outputs.shape, (3, 5, 16))
+        self.assertEqual(pooled.shape, (3, 16))
+        self.assertTrue(torch.allclose(outputs[0, 3:], torch.zeros_like(outputs[0, 3:])))
+
+
+class TestTPC(unittest.TestCase):
+    """Unit tests for the full TPC PyHealth model."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.binary_dataset = _make_binary_dataset()
+        cls.multiclass_dataset = _make_multiclass_dataset()
+
+    def test_model_initialization(self):
+        model = TPC(
+            dataset=self.binary_dataset,
+            embedding_dim=32,
+            hidden_dim=64,
+            num_layers=3,
+            kernel_size=5,
+            dropout=0.2,
+        )
+        self.assertIsInstance(model, TPC)
+        self.assertEqual(model.embedding_dim, 32)
+        self.assertEqual(model.hidden_dim, 64)
+        self.assertEqual(model.num_layers, 3)
+        self.assertEqual(model.kernel_size, 5)
+        self.assertEqual(model.label_key, "label")
+        self.assertEqual(set(model.feature_keys), {"diagnoses", "icd_codes", "labs"})
+
+    def test_binary_forward(self):
+        model = TPC(dataset=self.binary_dataset, embedding_dim=32, hidden_dim=64)
+        batch = next(iter(get_dataloader(self.binary_dataset, batch_size=2, shuffle=False)))
+
+        with torch.no_grad():
+            ret = model(**batch)
+
+        self.assertIn("loss", ret)
+        self.assertIn("y_prob", ret)
+        self.assertIn("y_true", ret)
+        self.assertIn("logit", ret)
+        self.assertEqual(ret["y_prob"].shape, (2, 1))
+        self.assertEqual(ret["y_true"].shape, (2, 1))
+        self.assertEqual(ret["logit"].shape, (2, 1))
+        self.assertEqual(ret["loss"].dim(), 0)
+
+    def test_multiclass_forward(self):
+        model = TPC(dataset=self.multiclass_dataset, embedding_dim=24, hidden_dim=48)
+        batch = next(
+            iter(get_dataloader(self.multiclass_dataset, batch_size=3, shuffle=False))
+        )
+
+        with torch.no_grad():
+            ret = model(**batch)
+
+        self.assertEqual(ret["y_prob"].shape, (3, 3))
+        self.assertEqual(ret["logit"].shape, (3, 3))
+        self.assertEqual(ret["y_true"].shape[0], 3)
+
+    def test_backward(self):
+        model = TPC(dataset=self.binary_dataset, embedding_dim=16, hidden_dim=32)
+        batch = next(iter(get_dataloader(self.binary_dataset, batch_size=2, shuffle=False)))
+
+        ret = model(**batch)
+        ret["loss"].backward()
+
+        has_gradient = any(
+            param.requires_grad and param.grad is not None
+            for param in model.parameters()
+        )
+        self.assertTrue(has_gradient, "No parameters have gradients after backward pass")
+
+    def test_embed_output(self):
+        model = TPC(dataset=self.binary_dataset, embedding_dim=20, hidden_dim=40)
+        batch = next(iter(get_dataloader(self.binary_dataset, batch_size=2, shuffle=False)))
+        batch["embed"] = True
+
+        with torch.no_grad():
+            ret = model(**batch)
+
+        self.assertIn("embed", ret)
+        self.assertEqual(ret["embed"].shape, (2, 60))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_tpc.py
+++ b/tests/core/test_tpc.py
@@ -1,3 +1,13 @@
+"""Synthetic tests for the PyHealth TPC model contribution.
+
+Contributor: Hasham Ul Haq (huhaq2)
+Paper: Temporal Pointwise Convolutional Networks for Length of Stay Prediction
+    in the Intensive Care Unit
+Paper link: https://arxiv.org/abs/2007.09483
+Description: Fast unit tests for the TPC model using only synthetic PyHealth
+    sample datasets and tiny tensors.
+"""
+
 import unittest
 
 import torch


### PR DESCRIPTION
## Contributor

Name: Hasham Ul Haq  
NetID: huhaq2
Email: huhaq2@illinois.edu

## Type of Contribution

Model contribution

## Paper

Temporal Pointwise Convolutional Networks for Length of Stay Prediction in the Intensive Care Unit

Paper link: https://arxiv.org/abs/2007.09483

## Summary

This PR adds a PyHealth-compatible implementation of Temporal Pointwise Convolution (TPC) for sequential EHR prediction tasks.

The implementation is adapted to PyHealth's `BaseModel` interface and supports standard PyHealth processors, including sequence inputs and StageNet-style temporal inputs. The accompanying example evaluates TPC on the existing MIMIC-IV temporal length-of-stay pipeline using `MIMIC4Dataset` and `LengthOfStayStageNetMIMIC4`.

This contribution intentionally reuses PyHealth's existing MIMIC-IV dataset loader and length-of-stay task because both are already available in PyHealth. The new contribution is the model implementation, tests, documentation, and runnable ablation example.

## Implementation Details

The TPC model embeds each feature stream independently, optionally incorporates temporal metadata when available, applies temporal pointwise convolution layers per feature stream, and concatenates feature-level patient embeddings for final prediction.

The model returns the standard PyHealth output dictionary:

- `loss`
- `y_prob`
- `y_true`
- `logit`
- optional `embed`

## Required Data for Example

The example script uses the existing `LengthOfStayStageNetMIMIC4` task. For real MIMIC-IV experiments, the EHR root should contain:

- `hosp/patients.csv.gz`
- `hosp/admissions.csv.gz`
- `hosp/diagnoses_icd.csv.gz`
- `hosp/procedures_icd.csv.gz`
- `hosp/labevents.csv.gz`
- `hosp/d_labitems.csv.gz`
- `icu/icustays.csv.gz`

The example also supports `--quick-test` using bundled demo data for a smoke test.

## Files to Review

- `pyhealth/models/tpc.py`: TPC model, TPC block, and TPC layer implementation
- `pyhealth/models/__init__.py`: exports `TPC`, `TPCBlock`, and `TPCLayer`
- `docs/api/models/pyhealth.models.TPC.rst`: API documentation and required-data notes
- `docs/api/models.rst`: model docs index update
- `tests/core/test_tpc.py`: synthetic model tests
- `examples/length_of_stay/length_of_stay_mimic4_tpc.py`: MIMIC-IV LOS example with ablations

## Testing

Synthetic unit tests:

```bash
python -m pytest tests/core/test_tpc.py -q
