### PR TITLE
Model Implementation of EBCL Paper

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -48,6 +48,9 @@ routes each feature type automatically.
    * - :doc:`models/pyhealth.models.GraphCare`
      - You want to augment EHR codes with a medical knowledge graph
      - Combines code sequences with a :class:`~pyhealth.graph.KnowledgeGraph`
+   * - :doc:`models/pyhealth.models.EBCL`
+     - You have paired pre- and post–index event code sequences and want CLIP-style contrastive pretraining
+     - Shared RNN encoder over two windows; see :mod:`pyhealth.models.ebcl`
 
 How BaseModel Works
 --------------------
@@ -184,6 +187,7 @@ API Reference
     models/pyhealth.models.SafeDrug
     models/pyhealth.models.MoleRec
     models/pyhealth.models.Deepr
+    models/pyhealth.models.EBCL
     models/pyhealth.models.EHRMamba
     models/pyhealth.models.JambaEHR
     models/pyhealth.models.ContraWR

--- a/docs/api/models/pyhealth.models.EBCL.rst
+++ b/docs/api/models/pyhealth.models.EBCL.rst
@@ -1,0 +1,11 @@
+pyhealth.models.EBCL
+===================================
+
+Event-Based Contrastive Learning (EBCL) for paired pre- and post-index-event
+clinical code sequences. Uses a shared RNN encoder and CLIP-style symmetric
+InfoNCE loss.
+
+.. autoclass:: pyhealth.models.EBCL
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/ebcl_eval_probe_demo.py
+++ b/examples/ebcl_eval_probe_demo.py
@@ -1,0 +1,99 @@
+"""
+EBCL: training loop + validation metrics (synthetic data).
+
+Demonstrates :class:`~pyhealth.trainer.Trainer` with :class:`~pyhealth.models.EBCL`
+when ``supervised_weight > 0`` so the linear probe is trained jointly with the
+contrastive loss. Validation reports **roc_auc** (and other binary metrics) via
+``pyhealth.metrics``.
+
+Requires **no** MIMIC files. For contrastive-only pretraining (probe not trained),
+use ``supervised_weight=0`` and either omit ``val_dataloader`` or monitor **loss**
+only (see ``Trainer.evaluate`` when classification metrics are not meaningful).
+
+Paper: https://arxiv.org/abs/2312.10308
+
+Run::
+
+    cd /path/to/PyHealth
+    python examples/ebcl_eval_probe_demo.py
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, List
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models import EBCL
+from pyhealth.trainer import Trainer
+
+
+def _samples(n: int, seed: int = 0) -> List[Dict[str, Any]]:
+    rng = random.Random(seed)
+    pool = ["A", "B", "C", "D", "E", "F", "G"]
+    out = []
+    for i in range(n):
+        out.append(
+            {
+                "patient_id": f"p{i}",
+                "visit_id": f"v{i}",
+                "conditions_pre": [pool[rng.randrange(7)], pool[rng.randrange(7)]],
+                "conditions_post": [pool[rng.randrange(7)], pool[rng.randrange(7)]],
+                "label": i % 2,
+            }
+        )
+    return out
+
+
+def main() -> None:
+    # One dataset so SequenceProcessor vocab is shared; split for train/val.
+    n_total = 40
+    n_train = 28
+    all_samples = _samples(n_total, seed=42)
+    full_ds = create_sample_dataset(
+        samples=all_samples,
+        input_schema={
+            "conditions_pre": "sequence",
+            "conditions_post": "sequence",
+        },
+        output_schema={"label": "binary"},
+        dataset_name="ebcl_probe_demo",
+    )
+    train_ds = full_ds.subset(range(n_train))
+    val_ds = full_ds.subset(range(n_train, n_total))
+
+    model = EBCL(
+        train_ds,
+        embedding_dim=48,
+        hidden_dim=48,
+        projection_dim=24,
+        temperature=0.15,
+        supervised_weight=0.3,
+        dropout=0.2,
+    )
+
+    train_loader = get_dataloader(train_ds, batch_size=8, shuffle=True)
+    val_loader = get_dataloader(val_ds, batch_size=8, shuffle=False)
+
+    trainer = Trainer(
+        model=model,
+        metrics=["roc_auc", "pr_auc", "f1"],
+        enable_logging=False,
+    )
+
+    print("Training EBCL (contrastive + probe). Val metrics: roc_auc, pr_auc, f1\n")
+    trainer.train(
+        train_dataloader=train_loader,
+        val_dataloader=val_loader,
+        epochs=8,
+        optimizer_params={"lr": 3e-3},
+        monitor="roc_auc",
+        monitor_criterion="max",
+        patience=4,
+        load_best_model_at_last=False,
+    )
+    print("\nDone. Best checkpoint not saved (enable_logging=False).")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mimic4_ebcl_pretrain_ebcl.py
+++ b/examples/mimic4_ebcl_pretrain_ebcl.py
@@ -1,0 +1,205 @@
+"""
+MIMIC-IV–style EBCL pretraining demo with **synthetic** paired sequences (no PhysioNet).
+
+This script is the course ``examples/{dataset}_{task_name}_{model}.py`` entry for the
+:class:`~pyhealth.models.EBCL` model. It mirrors the *intent* of Event-Based
+Contrastive Learning (Oufattole et al., MLHC 2024): contrastive alignment of
+pre- and post–index event code sequences. Full MIMIC-IV runs require credentialed
+data; here we use small synthetic samples so the script runs everywhere.
+
+**Paper:** `Event-Based Contrastive Learning for Medical Time Series
+<https://arxiv.org/abs/2312.10308>`__
+
+Ablation study (same synthetic data and seed for each row)
+----------------------------------------------------------
+We sweep hyperparameters and report the **mean contrastive loss** over one epoch
+of minibatches (pure contrastive, ``supervised_weight=0``). Lower is not always
+“better” on synthetic noise; the point is to show how each knob moves the
+objective and to give a reproducible table for the PR.
+
++------------------+--------------+-------------+----------+----------+---------------------------+
+| temperature      | hidden_dim   | emb_dim     | dropout  | batch    | mean contrastive loss     |
++==================+==============+=============+==========+==========+===========================+
+| 0.05             | 32           | 32          | 0.0      | 4        | (printed at runtime)      |
+| 0.10             | 32           | 32          | 0.0      | 4        |                             |
+| 0.20             | 32           | 32          | 0.0      | 4        |                             |
+| 0.10             | 16           | 32          | 0.0      | 4        |                             |
+| 0.10             | 64           | 32          | 0.0      | 4        |                             |
+| 0.10             | 32           | 32          | 0.5      | 4        |                             |
++------------------+--------------+-------------+----------+----------+---------------------------+
+
+**Shuffled-post baseline:** For the last row we permute ``conditions_post`` within
+the batch before ``forward``. This breaks correct pre/post pairing and should
+**increase** contrastive loss relative to the matched setting (event-based
+structure vs. random pairing).
+
+**Findings (fill in after you run):** See console table; typically shuffled-post
+loss >> matched loss for batch size > 1.
+
+Run::
+
+    cd /path/to/PyHealth
+    python examples/mimic4_ebcl_pretrain_ebcl.py
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, List, Tuple
+
+import torch
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models import EBCL
+
+
+def build_synthetic_samples(
+    n: int = 8,
+    seed: int = 42,
+) -> List[Dict[str, Any]]:
+    """Create paired pre/post code lists (same pool as tests; 2–8 patients)."""
+    rng = random.Random(seed)
+    pool = ["E11.9", "I50.9", "N18.3", "J44.1", "Z79.4", "N17.9", "I21.9"]
+    samples = []
+    for i in range(n):
+        pre = [pool[rng.randrange(len(pool))], pool[rng.randrange(len(pool))]]
+        post = [pool[rng.randrange(len(pool))], pool[rng.randrange(len(pool))]]
+        samples.append(
+            {
+                "patient_id": f"p{i}",
+                "visit_id": f"v{i}",
+                "conditions_pre": pre,
+                "conditions_post": post,
+                "label": i % 2,
+            }
+        )
+    return samples
+
+
+def _shuffle_batch_dim_post(batch: Dict[str, Any], post_key: str) -> Dict[str, Any]:
+    """Break pre/post pairing by permuting the post feature along batch axis."""
+    b = dict(batch)
+    if post_key not in b:
+        return b
+    feat = b[post_key]
+    if isinstance(feat, torch.Tensor):
+        n = feat.size(0)
+        perm = torch.randperm(n)
+        b[post_key] = feat[perm]
+        return b
+    if isinstance(feat, tuple) and len(feat) >= 1:
+        n = feat[0].size(0)
+        perm = torch.randperm(n)
+        parts = list(feat)
+        parts[0] = parts[0][perm]
+        for i in range(1, len(parts)):
+            if isinstance(parts[i], torch.Tensor) and parts[i].size(0) == n:
+                parts[i] = parts[i][perm]
+        b[post_key] = tuple(parts)
+        return b
+    return b
+
+
+def mean_contrastive_loss(
+    dataset,
+    *,
+    embedding_dim: int = 32,
+    hidden_dim: int = 32,
+    projection_dim: int = 16,
+    temperature: float = 0.1,
+    dropout: float = 0.0,
+    batch_size: int = 4,
+    shuffle_post: bool = False,
+) -> float:
+    """One pass over the dataset; optional within-batch post shuffle (ablation)."""
+    torch.manual_seed(0)
+    model = EBCL(
+        dataset,
+        embedding_dim=embedding_dim,
+        hidden_dim=hidden_dim,
+        projection_dim=projection_dim,
+        temperature=temperature,
+        supervised_weight=0.0,
+        dropout=dropout,
+    )
+    model.eval()
+    loader = get_dataloader(dataset, batch_size=batch_size, shuffle=False)
+    losses = []
+    for batch in loader:
+        b = _shuffle_batch_dim_post(batch, "conditions_post") if shuffle_post else batch
+        with torch.no_grad():
+            out = model(**b)
+        losses.append(float(out["loss"]))
+    return sum(losses) / max(len(losses), 1)
+
+
+def main() -> None:
+    samples = build_synthetic_samples(n=8, seed=42)
+    base_ds = create_sample_dataset(
+        samples=samples,
+        input_schema={
+            "conditions_pre": "sequence",
+            "conditions_post": "sequence",
+        },
+        output_schema={"label": "binary"},
+        dataset_name="mimic4_ebcl_synth",
+    )
+
+    # --- Ablation grid (hyperparameters) ---
+    configs: List[Tuple[str, Dict[str, Any]]] = [
+        ("t=0.05", {"temperature": 0.05}),
+        ("t=0.10", {"temperature": 0.10}),
+        ("t=0.20", {"temperature": 0.20}),
+        ("hidden=16", {"hidden_dim": 16}),
+        ("hidden=64", {"hidden_dim": 64}),
+        ("dropout=0.5", {"dropout": 0.5}),
+    ]
+
+    print("EBCL synthetic ablation (mean contrastive loss)\n")
+    rows = []
+    defaults = {
+        "embedding_dim": 32,
+        "hidden_dim": 32,
+        "projection_dim": 16,
+        "temperature": 0.10,
+        "dropout": 0.0,
+        "batch_size": 4,
+    }
+    for name, overrides in configs:
+        kw = {**defaults, **overrides}
+        loss = mean_contrastive_loss(base_ds, **kw)
+        rows.append((name, loss))
+        print(f"  {name:16s}  loss={loss:.4f}")
+
+    torch.manual_seed(123)
+    matched = mean_contrastive_loss(
+        base_ds,
+        **defaults,
+        shuffle_post=False,
+    )
+    torch.manual_seed(123)
+    shuffled = mean_contrastive_loss(
+        base_ds,
+        **defaults,
+        shuffle_post=True,
+    )
+    print("\n  Baseline (matched pre/post):     {:.4f}".format(matched))
+    print("  Ablation (shuffled post codes):  {:.4f}".format(shuffled))
+    if shuffled > matched + 1e-6:
+        print(
+            "  => Shuffled-post loss is higher: "
+            "mismatched pre/post pairs hurt as expected."
+        )
+    elif shuffled < matched - 1e-6:
+        print(
+            "  => Shuffled loss lower (random batch effects on tiny data)."
+        )
+    else:
+        print(
+            "  => Loss tie: collated batch may use tensor layout where "
+            "shuffle matched baseline seed; increase n or batch_size."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -37,6 +37,7 @@ from .tfm_tokenizer import (
 from .torchvision_model import TorchvisionModel
 from .transformer import Transformer, TransformerLayer
 from .transformers_model import TransformersModel
+from .ebcl import EBCL
 from .ehrmamba import EHRMamba, MambaBlock
 from .vae import VAE
 from .vision_embedding import VisionEmbeddingModel

--- a/pyhealth/models/ebcl.py
+++ b/pyhealth/models/ebcl.py
@@ -1,0 +1,248 @@
+"""Event-Based Contrastive Learning (EBCL) for paired pre/post clinical sequences.
+
+Implements a symmetric InfoNCE objective between embeddings of a pre-index-event
+window and a post-index-event window, following the spirit of
+`Event-Based Contrastive Learning for Medical Time Series` (Oufattole et al., MLHC 2024).
+
+The model expects exactly two sequence inputs (e.g. ``conditions_pre`` and
+``conditions_post``). A shared :class:`~pyhealth.models.embedding.EmbeddingModel`
+and shared :class:`~pyhealth.models.rnn.RNNLayer` encode both windows; optional
+linear probe uses concatenated pooled states when ``supervised_weight > 0``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from pyhealth.datasets import SampleDataset
+from pyhealth.processors import SequenceProcessor
+
+from .base_model import BaseModel
+from .embedding import EmbeddingModel
+from .rnn import RNNLayer
+
+
+class EBCL(BaseModel):
+    """Event-based contrastive encoder for paired pre/post sequences.
+
+    Use two sequence feature keys representing clinical codes (or other discrete
+    tokens) before and after an index event. The contrastive loss aligns the
+    pre-window embedding with the post-window embedding for the same patient-event
+    and separates mismatched pairs in the batch.
+
+    Args:
+        dataset: :class:`~pyhealth.datasets.SampleDataset` with exactly two input
+            sequence features and optionally one supervised label for probing.
+        embedding_dim: Code embedding size.
+        hidden_dim: RNN hidden size.
+        projection_dim: Dimension of L2-normalized contrastive vectors.
+        temperature: Temperature for InfoNCE logits.
+        rnn_type: ``"GRU"``, ``"LSTM"``, or ``"RNN"``.
+        supervised_weight: If > 0 and labels are present, adds this multiple of the
+            supervised loss (BCE or CE via :meth:`get_loss_function`) to the
+            contrastive loss.
+        pre_key: Name of the pre-event sequence feature; default ``conditions_pre``
+            if present, else the first input key.
+        post_key: Name of the post-event sequence feature; default ``conditions_post``
+            if present, else the second input key.
+        **kwargs: Passed to :class:`~pyhealth.models.rnn.RNNLayer` (e.g.
+            ``num_layers``, ``dropout``, ``bidirectional``).
+
+    """
+
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        embedding_dim: int = 128,
+        hidden_dim: int = 128,
+        projection_dim: int = 64,
+        temperature: float = 0.1,
+        rnn_type: str = "GRU",
+        supervised_weight: float = 0.0,
+        pre_key: Optional[str] = None,
+        post_key: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(dataset=dataset)
+        if len(self.feature_keys) != 2:
+            raise ValueError(
+                "EBCL requires exactly two sequence input features (pre/post windows)."
+            )
+
+        keys = list(self.feature_keys)
+        if pre_key is None:
+            if "conditions_pre" in keys and "conditions_post" in keys:
+                self.pre_key = "conditions_pre"
+                self.post_key = "conditions_post"
+            else:
+                self.pre_key, self.post_key = keys[0], keys[1]
+        else:
+            self.pre_key = pre_key
+            self.post_key = post_key or keys[1 - keys.index(pre_key)]
+
+        if self.pre_key not in keys or self.post_key not in keys:
+            raise ValueError("pre_key and post_key must match dataset input_schema keys.")
+        if self.pre_key == self.post_key:
+            raise ValueError("pre_key and post_key must differ.")
+
+        self.embedding_dim = embedding_dim
+        self.hidden_dim = hidden_dim
+        self.projection_dim = projection_dim
+        self.temperature = temperature
+        self.supervised_weight = supervised_weight
+
+        if "input_size" in kwargs:
+            raise ValueError("input_size is determined by embedding_dim")
+        if "hidden_size" in kwargs:
+            raise ValueError("hidden_size is determined by hidden_dim")
+
+        self.embedding_model = EmbeddingModel(dataset, embedding_dim)
+        self._maybe_tie_sequence_embeddings()
+
+        self.rnn = RNNLayer(
+            input_size=embedding_dim,
+            hidden_size=hidden_dim,
+            rnn_type=rnn_type,
+            **kwargs,
+        )
+        self.proj = nn.Linear(hidden_dim, projection_dim)
+
+        self.label_key: Optional[str] = None
+        self.fc_probe: Optional[nn.Linear] = None
+        if len(self.label_keys) == 1:
+            self.label_key = self.label_keys[0]
+            out_dim = self.get_output_size()
+            self.fc_probe = nn.Linear(hidden_dim * 2, out_dim)
+
+    def _maybe_tie_sequence_embeddings(self) -> None:
+        """Share pre/post embeddings when both fields use identical code vocabularies."""
+        pre_p = self.dataset.input_processors[self.pre_key]
+        post_p = self.dataset.input_processors[self.post_key]
+        if not isinstance(pre_p, SequenceProcessor) or not isinstance(
+            post_p, SequenceProcessor
+        ):
+            return
+        if pre_p.code_vocab != post_p.code_vocab:
+            return
+        layers = self.embedding_model.embedding_layers
+        if self.pre_key in layers and self.post_key in layers:
+            layers[self.post_key].weight = layers[self.pre_key].weight
+
+    def _embed_branch(
+        self,
+        feature_key: str,
+        kwargs: Dict[str, torch.Tensor | Tuple[torch.Tensor, ...]],
+    ) -> torch.Tensor:
+        """Return last RNN hidden state for one branch (same layout as :class:`RNN`)."""
+        feature = kwargs[feature_key]
+        if isinstance(feature, torch.Tensor):
+            feature = (feature,)
+
+        schema = self.dataset.input_processors[feature_key].schema()
+        value = feature[schema.index("value")] if "value" in schema else None
+        mask = feature[schema.index("mask")] if "mask" in schema else None
+
+        if value is None:
+            raise ValueError(f"Feature '{feature_key}' must contain 'value' in the schema.")
+
+        inputs = {feature_key: value}
+        masks: Dict[str, torch.Tensor] = {}
+        if mask is not None:
+            masks[feature_key] = mask
+
+        embedded = self.embedding_model(inputs, masks=masks or None)
+        x = embedded[feature_key]
+
+        x_dim_orig = x.dim()
+        if x_dim_orig == 4:
+            x = x.sum(dim=2)
+            if feature_key in masks:
+                m = (masks[feature_key].to(self.device).sum(dim=-1) > 0).int()
+            else:
+                m = (torch.abs(x).sum(dim=-1) != 0).int()
+        elif x_dim_orig == 2:
+            x = x.unsqueeze(1)
+            m = None
+        else:
+            if feature_key in masks:
+                m = masks[feature_key].to(self.device).int()
+                if m.dim() == 3:
+                    m = (m.sum(dim=-1) > 0).int()
+            else:
+                m = (torch.abs(x).sum(dim=-1) != 0).int()
+
+        _, last = self.rnn(x, m)
+        return last
+
+    @staticmethod
+    def _info_nce(z_pre: torch.Tensor, z_post: torch.Tensor, temperature: float) -> torch.Tensor:
+        z_pre = F.normalize(z_pre, dim=-1)
+        z_post = F.normalize(z_post, dim=-1)
+        logits = torch.matmul(z_pre, z_post.transpose(0, 1)) / temperature
+        targets = torch.arange(logits.size(0), device=logits.device)
+        loss_pre = F.cross_entropy(logits, targets)
+        loss_post = F.cross_entropy(logits.transpose(0, 1), targets)
+        return (loss_pre + loss_post) * 0.5
+
+    def forward(
+        self,
+        **kwargs: torch.Tensor | Tuple[torch.Tensor, ...],
+    ) -> Dict[str, torch.Tensor]:
+        """Compute CLIP-style contrastive loss on pre/post embeddings.
+
+        Args:
+            **kwargs: Batch tensors keyed by ``input_schema`` and ``output_schema``
+                field names (including the label key when present).
+
+        Returns:
+            Dictionary with at least ``loss``, ``embed_pre``, ``embed_post``,
+            ``z_pre``, and ``z_post``. May include ``logit``, ``y_prob``,
+            ``y_true`` when a label is provided. Optional key ``embed`` if
+            ``kwargs['embed'] is True``.
+        """
+        h_pre = self._embed_branch(self.pre_key, kwargs)
+        h_post = self._embed_branch(self.post_key, kwargs)
+
+        z_pre = self.proj(h_pre)
+        z_post = self.proj(h_post)
+        contrastive_loss = self._info_nce(z_pre, z_post, self.temperature)
+
+        results: Dict[str, torch.Tensor] = {
+            "loss": contrastive_loss,
+            "embed_pre": h_pre,
+            "embed_post": h_post,
+            "z_pre": z_pre,
+            "z_post": z_post,
+        }
+
+        if (
+            self.supervised_weight > 0
+            and self.label_key is not None
+            and self.fc_probe is not None
+            and self.label_key in kwargs
+        ):
+            h_cat = torch.cat([h_pre, h_post], dim=-1)
+            logits = self.fc_probe(h_cat)
+            y_true = kwargs[self.label_key].to(self.device)
+            sup_loss = self.get_loss_function()(logits, y_true)
+            results["loss"] = contrastive_loss + self.supervised_weight * sup_loss
+            results["logit"] = logits
+            results["y_true"] = y_true
+            results["y_prob"] = self.prepare_y_prob(logits)
+        elif self.label_key is not None and self.label_key in kwargs and self.fc_probe is not None:
+            # Eval / logging: still return predictions without adding to loss
+            h_cat = torch.cat([h_pre, h_post], dim=-1)
+            logits = self.fc_probe(h_cat)
+            y_true = kwargs[self.label_key].to(self.device)
+            results["logit"] = logits
+            results["y_true"] = y_true
+            results["y_prob"] = self.prepare_y_prob(logits)
+
+        if kwargs.get("embed", False):
+            results["embed"] = torch.cat([h_pre, h_post], dim=-1)
+
+        return results

--- a/tests/core/test_ebcl.py
+++ b/tests/core/test_ebcl.py
@@ -1,0 +1,143 @@
+"""Unit tests for :class:`~pyhealth.models.EBCL`.
+
+Uses synthetic in-memory samples only (no MIMIC demo or real EHR files).
+"""
+
+import unittest
+
+import torch
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models import EBCL
+
+
+def _make_synthetic_samples(n_patients: int = 4):
+    """Build minimal paired pre/post code sequences for EBCL."""
+    pool = ["A", "B", "C", "D", "E"]
+    samples = []
+    for i in range(n_patients):
+        samples.append(
+            {
+                "patient_id": f"p{i}",
+                "visit_id": f"v{i}",
+                "conditions_pre": [pool[i % 5], pool[(i + 1) % 5]],
+                "conditions_post": [pool[(i + 2) % 5], pool[(i + 3) % 5]],
+                "label": i % 2,
+            }
+        )
+    return samples
+
+
+class TestEBCL(unittest.TestCase):
+    """Tests for Event-Based Contrastive Learning model."""
+
+    def setUp(self):
+        samples = _make_synthetic_samples(4)
+        self.dataset = create_sample_dataset(
+            samples=samples,
+            input_schema={
+                "conditions_pre": "sequence",
+                "conditions_post": "sequence",
+            },
+            output_schema={"label": "binary"},
+            dataset_name="ebcl_test",
+        )
+        self.model = EBCL(
+            self.dataset,
+            embedding_dim=32,
+            hidden_dim=32,
+            projection_dim=16,
+            temperature=0.2,
+            supervised_weight=0.0,
+        )
+
+    def test_initialization(self):
+        self.assertIsInstance(self.model, EBCL)
+        self.assertEqual(self.model.pre_key, "conditions_pre")
+        self.assertEqual(self.model.post_key, "conditions_post")
+        self.assertEqual(self.model.embedding_dim, 32)
+        self.assertEqual(self.model.hidden_dim, 32)
+        self.assertEqual(self.model.projection_dim, 16)
+
+    def test_forward_contrastive_loss_and_shapes(self):
+        loader = get_dataloader(self.dataset, batch_size=4, shuffle=False)
+        batch = next(iter(loader))
+        with torch.no_grad():
+            out = self.model(**batch)
+        self.assertIn("loss", out)
+        self.assertEqual(out["loss"].dim(), 0)
+        self.assertEqual(out["embed_pre"].shape, (4, 32))
+        self.assertEqual(out["embed_post"].shape, (4, 32))
+        self.assertEqual(out["z_pre"].shape, (4, 16))
+        self.assertEqual(out["z_post"].shape, (4, 16))
+
+    def test_backward(self):
+        loader = get_dataloader(self.dataset, batch_size=4, shuffle=False)
+        batch = next(iter(loader))
+        out = self.model(**batch)
+        out["loss"].backward()
+        self.assertIsNotNone(self.model.proj.weight.grad)
+
+    def test_supervised_weight_combines_losses(self):
+        model_sup = EBCL(
+            self.dataset,
+            embedding_dim=32,
+            hidden_dim=32,
+            projection_dim=16,
+            supervised_weight=0.5,
+        )
+        loader = get_dataloader(self.dataset, batch_size=4, shuffle=False)
+        batch = next(iter(loader))
+        with torch.no_grad():
+            out_sup = model_sup(**batch)
+            out_unsup = self.model(**batch)
+        self.assertGreater(out_sup["loss"].item(), 0.0)
+        # Combined loss should differ from contrastive-only when probe is trained
+        self.assertIn("logit", out_sup)
+
+    def test_embed_flag(self):
+        loader = get_dataloader(self.dataset, batch_size=4, shuffle=False)
+        batch = next(iter(loader))
+        batch["embed"] = True
+        with torch.no_grad():
+            out = self.model(**batch)
+        self.assertIn("embed", out)
+        self.assertEqual(out["embed"].shape, (4, 64))
+
+    def test_requires_two_sequence_features(self):
+        samples = [
+            {
+                "patient_id": "p0",
+                "visit_id": "v0",
+                "conditions": ["x"],
+                "label": 0,
+            },
+            {
+                "patient_id": "p1",
+                "visit_id": "v1",
+                "conditions": ["y"],
+                "label": 1,
+            },
+        ]
+        ds = create_sample_dataset(
+            samples=samples,
+            input_schema={"conditions": "sequence"},
+            output_schema={"label": "binary"},
+            dataset_name="ebcl_bad",
+        )
+        with self.assertRaises(ValueError) as ctx:
+            EBCL(ds)
+        self.assertIn("exactly two", str(ctx.exception).lower())
+
+    def test_info_nce_symmetric(self):
+        """Gradient flows through both projection directions."""
+        loader = get_dataloader(self.dataset, batch_size=4, shuffle=False)
+        batch = next(iter(loader))
+        self.model.train()
+        out = self.model(**batch)
+        out["loss"].backward()
+        self.assertIsNotNone(self.model.proj.weight.grad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull request description (PyHealth — EBCL model)

**Authors:** Shashank Mahesh (smahesh3@illinois.edu), Harsha Gajja (hgajja2@illinois.edu)

**Paper (method reproduced):** [Event-Based Contrastive Learning for Medical Time Series](https://arxiv.org/abs/2312.10308) (Oufattole et al., MLHC 2024) — [PDF](https://arxiv.org/pdf/2312.10308.pdf)

**Reference implementation (read-only):** [mit-ccrg/EBCL](https://github.com/mit-ccrg/EBCL)

---

## Overview

This PR adds **`EBCL`** (`EventBasedContrastiveLearning`), a **`BaseModel`** for **event-centered contrastive pretraining** on paired clinical sequences: a **pre–index-event** window and a **post–index-event** window. The training objective is **CLIP-style symmetric InfoNCE** (cross-entropy on the pre–post similarity matrix) so that matched pre/post pairs from the same patient-event align and mismatched batch pairs separate. The implementation uses a **shared RNN encoder** (default GRU) over PyHealth `SequenceProcessor` embeddings; an optional **linear probe** on concatenated pooled states is available when `supervised_weight > 0`. This matches the *conceptual* setup of the paper (pre/post views around an index event); the published backbone is a **transformer + fusion pooling** — see model docstrings and course notes for differences.

**Contribution type:** **Model** (no new dataset or standalone task in this PR).

---

## Model (`pyhealth/models/ebcl.py`)

- Expects exactly **two** sequence inputs (e.g. `conditions_pre`, `conditions_post`) from a `SampleDataset`.
- Shared `EmbeddingModel` + shared `RNNLayer`; ties pre/post code embeddings when both `SequenceProcessor` vocabs are identical.
- Projects pooled states and applies L2-normalized **InfoNCE** with temperature `temperature`.
- `forward` returns `loss`, `embed_pre`, `embed_post`, `z_pre`, `z_post`; optional `logit` / `y_prob` / `y_true` when labels are present and/or `supervised_weight > 0`.

**Export:** `EBCL` added in `pyhealth/models/__init__.py`.

---

## Documentation

- `docs/api/models/pyhealth.models.EBCL.rst` — Sphinx `autoclass` API page.
- `docs/api/models.rst` — toctree entry + short row in the “Choosing a Model” table.

---

## Example / ablations (`examples/mimic4_ebcl_pretrain_ebcl.py`)

- **Synthetic** paired sequences only (no PhysioNet/MIMIC credentials required).
- Ablation loop over **temperature**, **hidden_dim**, **dropout**; reports mean contrastive loss.
- **Shuffled-post baseline:** permutes post sequences along the batch axis to break correct pre/post pairing (loss should increase vs. matched pairing when the batch carries signal).

---

## Unit tests (`tests/core/test_ebcl.py`)

- Uses **fabricated** in-memory samples (no real MIMIC or demo dumps).
- Covers: initialization, forward shapes and scalar `loss`, backward/gradients, `embed` flag, `supervised_weight` path, error when fewer than two sequence features, training-mode gradients.
- Fast to run: `pytest tests/core/test_ebcl.py` or `python -m unittest tests.core.test_ebcl`.

---

## Review note (scope and fidelity)

- **Data pipeline:** Index-event extraction and MIMIC-IV table wiring are **out of scope** for this PR; the example builds **synthetic** pre/post code lists. A future task/dataset PR could emit real pre/post tensors for MIMIC-IV ICU events as in the paper.
- **Architecture:** The paper uses a **transformer** encoder with fusion self-attention; this PR uses an **RNN** last-hidden pooling for a smaller, PyHealth-native baseline. The **contrastive pairing** objective (CLIP on pre vs. post) follows the paper’s Figure 1 / §3.2 description.
