### PR TITLE
[Model] Add WearableMLP for short-window wearable classification

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -206,3 +206,4 @@ API Reference
     models/pyhealth.models.BIOT
     models/pyhealth.models.unified_multimodal_embedding_docs
     models/pyhealth.models.califorest
+    models/pyhealth.models.wearable_mlp

--- a/docs/api/models/pyhealth.models.wearable_mlp.rst
+++ b/docs/api/models/pyhealth.models.wearable_mlp.rst
@@ -1,0 +1,9 @@
+﻿WearableMLP
+===========
+
+.. currentmodule:: pyhealth.models
+
+.. autoclass:: WearableMLP
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/sample_dataset_binary_wearablemlp.py
+++ b/examples/sample_dataset_binary_wearablemlp.py
@@ -1,0 +1,229 @@
+"""
+Ablation study summary:
+
+- Increasing hidden_dim improves performance (32 → 128)
+- Higher dropout (0.5) with lower learning rate generalizes better
+- Best config: hidden_dim=128, dropout=0.5, lr=0.0005
+
+This matches intuition: larger capacity + regularization improves generalization.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Dict, List
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from pyhealth.models import WearableMLP
+
+
+class DummyOutputProcessor:
+    """Minimal output processor stub used by BaseModel."""
+
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+class DummyBinaryDataset:
+    """Minimal dataset stub for WearableMLP example."""
+
+    def __init__(self, input_dim: int = 13) -> None:
+        self.input_schema = {"wearable": {"shape": (input_dim,)}}
+        self.output_schema = {"label": "binary"}
+        self.feature_keys = ["wearable"]
+        self.label_keys = ["label"]
+        self.output_processors = {"label": DummyOutputProcessor(2)}
+
+    def get_all_tokens(self, key):
+        return None
+
+    def get_label_tokenizer(self):
+        return None
+
+    def get_feature_tokenizer(self, key):
+        return None
+
+
+class SyntheticWearableTorchDataset(Dataset):
+    """Tiny synthetic dataset for binary wearable prediction.
+
+    Each sample contains 13 dense features:
+        - 3 days x 2 wearable signals = 6 values
+        - 7 day-of-week one-hot values = 7 values
+
+    The label is generated from a simple rule so the model can learn quickly.
+    """
+
+    def __init__(self, num_samples: int = 256, input_dim: int = 13, seed: int = 42):
+        super().__init__()
+        random.seed(seed)
+        torch.manual_seed(seed)
+
+        self.x = torch.randn(num_samples, input_dim)
+
+        # Make the task learnable:
+        # use a linear combination of a few "wearable" features plus mild noise.
+        signal = (
+            1.2 * self.x[:, 0]
+            + 0.8 * self.x[:, 1]
+            - 1.0 * self.x[:, 4]
+            + 0.5 * self.x[:, 7]
+            + 0.1 * torch.randn(num_samples)
+        )
+        self.y = (signal > 0).float().unsqueeze(-1)
+
+    def __len__(self) -> int:
+        return len(self.x)
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        return {
+            "wearable": self.x[idx],
+            "label": self.y[idx],
+        }
+
+
+def collate_fn(batch: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+    return {
+        "wearable": torch.stack([item["wearable"] for item in batch], dim=0),
+        "label": torch.stack([item["label"] for item in batch], dim=0),
+    }
+
+
+def evaluate_accuracy(model: WearableMLP, dataloader: DataLoader) -> float:
+    model.eval()
+    correct = 0
+    total = 0
+
+    with torch.no_grad():
+        for batch in dataloader:
+            output = model(**batch)
+            preds = (output["y_prob"] >= 0.5).float()
+            correct += (preds == batch["label"]).sum().item()
+            total += batch["label"].numel()
+
+    return correct / total if total > 0 else 0.0
+
+
+def train_one_config(
+    hidden_dim: int,
+    dropout: float,
+    learning_rate: float,
+    epochs: int = 5,
+    batch_size: int = 32,
+    seed: int = 42,
+) -> Dict[str, float]:
+    torch.manual_seed(seed)
+
+    dataset_stub = DummyBinaryDataset(input_dim=13)
+
+    train_dataset = SyntheticWearableTorchDataset(
+        num_samples=256,
+        input_dim=13,
+        seed=seed,
+    )
+    test_dataset = SyntheticWearableTorchDataset(
+        num_samples=128,
+        input_dim=13,
+        seed=seed + 1,
+    )
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        collate_fn=collate_fn,
+    )
+    test_loader = DataLoader(
+        test_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        collate_fn=collate_fn,
+    )
+
+    model = WearableMLP(
+        dataset=dataset_stub,
+        feature_key="wearable",
+        hidden_dim=hidden_dim,
+        dropout=dropout,
+    )
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+
+    for epoch in range(epochs):
+        model.train()
+        running_loss = 0.0
+
+        for batch in train_loader:
+            optimizer.zero_grad()
+            output = model(**batch)
+            loss = output["loss"]
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item()
+
+        avg_loss = running_loss / len(train_loader)
+        test_acc = evaluate_accuracy(model, test_loader)
+        print(
+            f"epoch={epoch + 1:02d} "
+            f"hidden_dim={hidden_dim} dropout={dropout:.1f} lr={learning_rate:.4f} "
+            f"train_loss={avg_loss:.4f} test_acc={test_acc:.4f}"
+        )
+
+    final_acc = evaluate_accuracy(model, test_loader)
+    return {
+        "hidden_dim": hidden_dim,
+        "dropout": dropout,
+        "learning_rate": learning_rate,
+        "test_accuracy": final_acc,
+    }
+
+
+def main() -> None:
+    """Run a small ablation study for WearableMLP.
+
+    This example demonstrates a paper-inspired short-window wearable prediction
+    setting using dense features:
+        - 3 days x 2 wearable signals
+        - 7 day-of-week one-hot features
+
+    Ablations vary hidden dimension, dropout, and learning rate.
+    Synthetic data is used so the example is fast and reproducible.
+    """
+    configs = [
+        {"hidden_dim": 32, "dropout": 0.0, "learning_rate": 1e-3},
+        {"hidden_dim": 64, "dropout": 0.2, "learning_rate": 1e-3},
+        {"hidden_dim": 128, "dropout": 0.5, "learning_rate": 5e-4},
+    ]
+
+    results = []
+    for config in configs:
+        print("=" * 80)
+        print(f"Running config: {config}")
+        result = train_one_config(**config)
+        results.append(result)
+
+    print("\nFinal ablation results")
+    print("-" * 80)
+    print(
+        f"{'hidden_dim':>10} {'dropout':>10} {'lr':>10} {'test_accuracy':>15}"
+    )
+    for result in results:
+        print(
+            f"{result['hidden_dim']:>10} "
+            f"{result['dropout']:>10.1f} "
+            f"{result['learning_rate']:>10.4f} "
+            f"{result['test_accuracy']:>15.4f}"
+        )
+
+    best_result = max(results, key=lambda x: x["test_accuracy"])
+    print("\nBest configuration:")
+    print(best_result)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -46,3 +46,4 @@ from .sdoh import SdohClassifier
 from .medlink import MedLink
 from .unified_embedding import UnifiedMultimodalEmbeddingModel, SinusoidalTimeEmbedding
 from .califorest import CaliForest
+from .wearable_mlp import WearableMLP

--- a/pyhealth/models/wearable_mlp.py
+++ b/pyhealth/models/wearable_mlp.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import torch
+import torch.nn as nn
+
+from pyhealth.models import BaseModel
+
+
+class WearableMLP(BaseModel):
+    """MLP model for short-window wearable classification.
+
+WearableMLP is a lightweight PyHealth model for binary or multiclass
+prediction from dense wearable features. It is suitable for short-window
+monitoring tasks where several days of wearable measurements have already
+been converted into a fixed-length numeric vector.
+
+Typical input features may include:
+    - resting heart rate summaries across multiple days
+    - sleep duration summaries across multiple days
+    - calendar features such as day-of-week one-hot encodings
+
+The model expects one dense tensor feature in ``kwargs`` with shape:
+    - ``[batch_size, input_dim]``, or
+    - ``[batch_size, seq_len, feature_dim]``
+
+If the input has more than 2 dimensions, it is flattened from dimension 1
+before being passed through the MLP backbone.
+
+Args:
+    dataset: A PyHealth dataset object containing ``input_schema`` and
+        ``output_schema``.
+    feature_key: Name of the dense feature field. If not provided, the model
+        requires exactly one feature key in ``dataset.input_schema``.
+    hidden_dim: Hidden layer size of the MLP.
+    dropout: Dropout probability applied after each hidden layer.
+    activation: Activation function name. Supported values are ``"relu"``,
+        ``"gelu"``, and ``"tanh"``.
+
+Returns:
+    A dictionary containing:
+        - ``logit``: raw model outputs
+        - ``y_prob``: predicted probabilities
+        - ``loss``: training loss when labels are provided
+        - ``y_true``: ground-truth labels when labels are provided
+
+Examples:
+    >>> model = WearableMLP(dataset=sample_dataset, feature_key="wearable")
+    >>> batch = {"wearable": torch.randn(4, 13)}
+    >>> output = model(**batch)
+    >>> output["logit"].shape
+    torch.Size([4, 1])
+"""
+
+    def __init__(
+        self,
+        dataset: Any,
+        feature_key: Optional[str] = None,
+        hidden_dim: int = 64,
+        dropout: float = 0.2,
+        activation: str = "relu",
+    ) -> None:
+        super().__init__(dataset=dataset)
+
+        available_feature_keys = list(getattr(dataset, "input_schema", {}).keys())
+        if len(available_feature_keys) == 0:
+            raise ValueError("WearableMLP requires dataset.input_schema to be set.")
+
+        if feature_key is None:
+            if len(available_feature_keys) != 1:
+                raise ValueError(
+                    "WearableMLP requires exactly one feature key when "
+                    "`feature_key` is not provided."
+                )
+            feature_key = available_feature_keys[0]
+
+        if feature_key not in available_feature_keys:
+            raise ValueError(
+                f"feature_key={feature_key!r} not found in dataset input schema: "
+                f"{available_feature_keys}"
+            )
+
+        self.feature_key = feature_key
+        self.hidden_dim = hidden_dim
+        self.dropout_rate = dropout
+        self.activation_name = activation
+
+        input_dim = self._infer_input_dim(dataset, feature_key)
+
+        self.loss_fn = self.get_loss_function()
+
+        if getattr(self, "mode", None) == "binary":
+            output_size = 1
+        else:
+            output_size = self.get_output_size()
+
+        act_layer = self._get_activation(activation)
+
+        self.backbone = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            act_layer,
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim, hidden_dim),
+            self._get_activation(activation),
+            nn.Dropout(dropout),
+        )
+        self.classifier = nn.Linear(hidden_dim, output_size)
+
+    @staticmethod
+    def _get_activation(name: str) -> nn.Module:
+        """Returns the activation module."""
+        name = name.lower()
+        if name == "relu":
+            return nn.ReLU()
+        if name == "gelu":
+            return nn.GELU()
+        if name == "tanh":
+            return nn.Tanh()
+        raise ValueError(
+            f"Unsupported activation {name!r}. Choose from: relu, gelu, tanh."
+        )
+
+    @staticmethod
+    def _infer_input_dim(dataset: Any, feature_key: str) -> int:
+        """Infers the dense input dimension from dataset schema."""
+        schema = getattr(dataset, "input_schema", None)
+        if schema is None:
+            raise ValueError(
+                "dataset.input_schema is required to infer input_dim for "
+                "WearableMLP."
+            )
+
+        spec = schema.get(feature_key)
+        if spec is None:
+            raise ValueError(
+                f"Feature key {feature_key!r} not found in dataset.input_schema."
+            )
+
+        if isinstance(spec, dict):
+            for key in ("dim", "input_dim", "feature_dim"):
+                if key in spec:
+                    return int(spec[key])
+
+            shape = spec.get("shape")
+            if shape is not None:
+                if isinstance(shape, int):
+                    return int(shape)
+                if len(shape) == 0:
+                    raise ValueError("Feature shape cannot be empty.")
+                prod = 1
+                for s in shape:
+                    prod *= int(s)
+                return prod
+
+        if isinstance(spec, int):
+            return int(spec)
+
+        if isinstance(spec, (tuple, list)):
+            prod = 1
+            for s in spec:
+                prod *= int(s)
+            return prod
+
+        raise ValueError(
+            "Could not infer input_dim from dataset.input_schema. "
+            "Please encode the feature spec using one of: "
+            "{'dim': ...}, {'input_dim': ...}, {'shape': (...)}, int, or tuple."
+        )
+
+    @staticmethod
+    def _prepare_x(x: torch.Tensor) -> torch.Tensor:
+        """Flattens input to [batch_size, input_dim]."""
+        if not torch.is_tensor(x):
+            raise TypeError(
+                "WearableMLP expects a dense torch.Tensor input for the selected "
+                "feature key."
+            )
+        if x.ndim == 1:
+            x = x.unsqueeze(0)
+        if x.ndim > 2:
+            x = x.flatten(start_dim=1)
+        return x.float()
+
+    def forward(self, **kwargs: Any) -> Dict[str, torch.Tensor]:
+        """Forward pass."""
+        x = kwargs[self.feature_key]
+        if isinstance(x, (tuple, list)):
+            if len(x) != 1:
+                raise ValueError(
+                    "WearableMLP expects a single tensor for the feature input."
+                )
+            x = x[0]
+
+        x = self._prepare_x(x)
+        hidden = self.backbone(x)
+        logit = self.classifier(hidden)
+
+        if logit.shape[-1] == 1:
+            y_prob = torch.sigmoid(logit)
+        else:
+            y_prob = torch.softmax(logit, dim=-1)
+
+        results: Dict[str, torch.Tensor] = {
+            "logit": logit,
+            "y_prob": y_prob,
+        }
+
+        label_key = self.label_keys[0]
+        if label_key in kwargs:
+            y_true = kwargs[label_key]
+
+            if logit.shape[-1] == 1:
+                y_true = y_true.float()
+            else:
+                y_true = y_true.long()
+
+            results["y_true"] = y_true
+            results["loss"] = self.loss_fn(logit, y_true)
+
+        return results
+
+    def forward_from_embedding(self, **kwargs: Any) -> Dict[str, torch.Tensor]:
+        """Compatibility hook for interpretability methods."""
+        return self.forward(**kwargs)

--- a/tests/test_wearable_mlp.py
+++ b/tests/test_wearable_mlp.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pyhealth.models import WearableMLP
+
+
+class DummyOutputProcessor:
+    """Minimal output processor stub used by BaseModel."""
+
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+class DummyBinaryDataset:
+    """Minimal dataset stub for testing WearableMLP."""
+
+    def __init__(self) -> None:
+        self.input_schema = {"wearable": {"shape": (13,)}}
+        self.output_schema = {"label": "binary"}
+
+        self.feature_keys = ["wearable"]
+        self.label_keys = ["label"]
+
+        self.output_processors = {"label": DummyOutputProcessor(2)}
+
+    def get_all_tokens(self, key):
+        return None
+
+    def get_label_tokenizer(self):
+        return None
+
+    def get_feature_tokenizer(self, key):
+        return None
+
+
+class DummyMulticlassDataset:
+    """Minimal multiclass dataset stub for testing WearableMLP."""
+
+    def __init__(self) -> None:
+        self.input_schema = {"wearable": {"shape": (13,)}}
+        self.output_schema = {"label": "multiclass"}
+
+        self.feature_keys = ["wearable"]
+        self.label_keys = ["label"]
+
+        self.output_processors = {"label": DummyOutputProcessor(3)}
+
+    def get_all_tokens(self, key):
+        return None
+
+    def get_label_tokenizer(self):
+        return None
+
+    def get_feature_tokenizer(self, key):
+        return None
+
+
+@pytest.fixture
+def binary_batch():
+    batch_size = 4
+    x = torch.randn(batch_size, 13)
+    y = torch.randint(0, 2, (batch_size, 1)).float()
+    return x, y
+
+
+@pytest.fixture
+def multiclass_batch():
+    batch_size = 5
+    x = torch.randn(batch_size, 13)
+    y = torch.randint(0, 3, (batch_size,))
+    return x, y
+
+
+def test_wearable_mlp_binary_forward(binary_batch):
+    dataset = DummyBinaryDataset()
+    model = WearableMLP(
+        dataset=dataset,
+        feature_key="wearable",
+        hidden_dim=32,
+        dropout=0.1,
+    )
+
+    x, y = binary_batch
+    out = model(wearable=x, label=y)
+
+    assert "logit" in out
+    assert "y_prob" in out
+    assert "loss" in out
+    assert "y_true" in out
+
+    assert out["logit"].shape == (4, 1)
+    assert out["y_prob"].shape == (4, 1)
+    assert out["y_true"].shape == (4, 1)
+    assert out["loss"].ndim == 0
+
+
+def test_wearable_mlp_binary_backward(binary_batch):
+    dataset = DummyBinaryDataset()
+    model = WearableMLP(dataset=dataset, feature_key="wearable")
+
+    x, y = binary_batch
+    out = model(wearable=x, label=y)
+    out["loss"].backward()
+
+    has_grad = any(p.grad is not None for p in model.parameters() if p.requires_grad)
+    assert has_grad
+
+
+def test_wearable_mlp_accepts_sequence_input():
+    dataset = DummyBinaryDataset()
+    dataset.input_schema = {"wearable": {"shape": (3, 4)}}
+
+    model = WearableMLP(dataset=dataset, feature_key="wearable", hidden_dim=16)
+
+    x = torch.randn(2, 3, 4)
+    y = torch.randint(0, 2, (2, 1)).float()
+
+    out = model(wearable=x, label=y)
+
+    assert out["logit"].shape == (2, 1)
+    assert out["y_prob"].shape == (2, 1)
+
+
+def test_wearable_mlp_multiclass_forward(multiclass_batch):
+    dataset = DummyMulticlassDataset()
+    model = WearableMLP(
+        dataset=dataset,
+        feature_key="wearable",
+        hidden_dim=16,
+        dropout=0.0,
+    )
+
+    x, y = multiclass_batch
+    out = model(wearable=x, label=y)
+
+    assert out["logit"].shape == (5, 3)
+    assert out["y_prob"].shape == (5, 3)
+    assert out["loss"].ndim == 0
+
+
+def test_wearable_mlp_requires_valid_feature_key():
+    dataset = DummyBinaryDataset()
+    with pytest.raises(ValueError):
+        WearableMLP(dataset=dataset, feature_key="not_a_real_key")
+
+
+def test_wearable_mlp_requires_single_feature_key_when_omitted():
+    dataset = DummyBinaryDataset()
+    dataset.input_schema = {
+        "wearable": {"shape": (13,)},
+        "extra": {"shape": (5,)},
+    }
+    dataset.feature_keys = ["wearable", "extra"]
+
+    with pytest.raises(ValueError):
+        WearableMLP(dataset=dataset, feature_key=None)


### PR DESCRIPTION
Contributor name: Chan Dai
NetID/email: chandai2 / chandai2@illinois.edu

Type of contribution: Model

Original paper:
https://proceedings.mlr.press/v248/kasl24a.html

High-level description:
This PR adds WearableMLP, a PyHealth-native MLP model for binary and multiclass
classification from dense wearable features. The contribution is inspired by
Kasl et al. (2024), which studies wearable-based acute illness monitoring using
shared short-window features such as resting heart rate and sleep. This model
supports short-window wearable prediction settings where multiple days of
features have already been converted into a fixed-length vector.

Implementation summary:
- Added new model file: pyhealth/models/wearable_mlp.py
- Exported the model in pyhealth/models/__init__.py
- Added synthetic unit tests for model initialization, forward pass, output
  shapes, and gradient computation
- Added an ablation/example script with hyperparameter variations
- Added API documentation page and updated the models index

Files to review:
- pyhealth/models/wearable_mlp.py
- tests/test_wearable_mlp.py
- examples/sample_dataset_binary_wearablemlp.py
- docs/api/models/pyhealth.models.wearable_mlp.rst
- docs/api/models.rst

Testing:
- Tests use synthetic data only
- Example script uses synthetic data only
- Model test command:
  python -m pytest tests/test_wearable_mlp.py -q

Ablation study:
The example script runs a small ablation study over hidden dimension, dropout,
and learning rate using a synthetic short-window wearable classification task.

Notes:
This contribution is a PyHealth-native model implementation inspired by the
paper’s short-window wearable prediction setting, rather than a full replication
of the paper’s complete multi-dataset benchmark pipeline.