### PR TITLE
Add DeepCoxMixtures model for survival regression

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -198,6 +198,7 @@ API Reference
     models/pyhealth.models.MedLink
     models/pyhealth.models.TCN
     models/pyhealth.models.TFMTokenizer
+    models/pyhealth.models.DeepCoxMixtures
     models/pyhealth.models.GAN
     models/pyhealth.models.VAE
     models/pyhealth.models.SDOH

--- a/docs/api/models/pyhealth.models.DeepCoxMixtures.rst
+++ b/docs/api/models/pyhealth.models.DeepCoxMixtures.rst
@@ -1,0 +1,14 @@
+pyhealth.models.DeepCoxMixtures
+===================================
+
+Deep Cox Mixtures model for survival regression (Nagpal et al. 2021).
+
+.. autoclass:: pyhealth.models.DeepCoxMixtures
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pyhealth.models.DeepCoxMixturesLayer
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/support2_survival_deep_cox_mixtures.py
+++ b/examples/support2_survival_deep_cox_mixtures.py
@@ -1,0 +1,310 @@
+"""
+Ablation study for DeepCoxMixtures on SUPPORT2 (2-month survival horizon).
+ 
+Three ablations: K in {1,3,6}, hidden_dim in {32,64,128}, dropout in
+{0.0,0.2,0.5}. Each config reports MSE, MAE, and C-index on a held-out
+test set. K=1 is the single Cox baseline.
+ 
+Data: download support2.csv from https://archive.ics.uci.edu/dataset/880/support2
+and place at <DATA_ROOT>/support2.csv. The sno column is added automatically
+if missing. Set USE_SYNTHETIC=1 to skip the download and just verify the
+pipeline runs end-to-end (C-index values won't be meaningful at that scale).
+ 
+Setup: 9104 patients, 70/15/15 split, Adam lr=1e-3, 20 epochs.
+"""
+
+import os
+import warnings
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+import torch
+from pyhealth.datasets import Support2Dataset, get_dataloader, split_by_patient
+from pyhealth.datasets import create_sample_dataset
+from pyhealth.models.deep_cox_mixtures import DeepCoxMixtures
+from pyhealth.tasks import SurvivalPreprocessSupport2
+from pyhealth.trainer import Trainer
+from torch.utils.data import DataLoader
+
+warnings.filterwarnings("ignore")
+
+# Configuration
+# Set USE_SYNTHETIC=1 to run without real data for smoke-test only.
+# Set DATA_ROOT to your SUPPORT2 CSV directory for the full ablation.
+USE_SYNTHETIC = os.environ.get("USE_SYNTHETIC", "0") == "1"
+DATA_ROOT = "./data/support2"
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+EPOCHS = 20
+BATCH_SIZE = 64
+LR = 1e-3
+SEED = 42
+
+# Reduced settings for synthetic smoke-test
+SYNTHETIC_EPOCHS = 2
+SYNTHETIC_BATCH_SIZE = 4
+
+
+# Synthetic data fallback
+
+SYNTHETIC_SAMPLES = [
+    {"patient_id": f"p{i}", "visit_id": "v0",
+     "demographics": [f"age_{50+i}.0", f"sex_{'male' if i%2==0 else 'female'}"],
+     "disease_codes": [f"dzgroup_Cancer"],
+     "vitals": [f"meanbp_{80+i}.0"],
+     "labs": [f"alb_{3.5}.0"],
+     "scores": [f"sps_{30+i}.0"],
+     "comorbidities": ["diabetes_0"],
+     "survival_probability": round(0.9 - i * 0.1, 1)}
+    for i in range(8)
+]
+
+SYNTHETIC_INPUT_SCHEMA = {
+    "demographics": "sequence",
+    "disease_codes": "sequence",
+    "vitals": "sequence",
+    "labs": "sequence",
+    "scores": "sequence",
+    "comorbidities": "sequence",
+}
+SYNTHETIC_OUTPUT_SCHEMA = {"survival_probability": "regression"}
+
+
+def build_synthetic_dataset():
+    """Build a small synthetic SampleDataset matching the SUPPORT2 schema."""
+    return create_sample_dataset(
+        samples=SYNTHETIC_SAMPLES,
+        input_schema=SYNTHETIC_INPUT_SCHEMA,
+        output_schema=SYNTHETIC_OUTPUT_SCHEMA,
+        dataset_name="support2_synthetic",
+    )
+
+
+def prepare_csv(data_root: str) -> None:
+    """Ensure the CSV has the 'sno' patient-ID column expected by Support2Dataset."""
+    csv_path = Path(data_root) / "support2.csv"
+    df = pd.read_csv(csv_path)
+    if "sno" not in df.columns:
+        df.insert(0, "sno", range(1, len(df) + 1))
+        df.to_csv(csv_path, index=False)
+        print(f"  Added 'sno' column to {csv_path}")
+
+
+def set_seed(seed: int) -> None:
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+
+def concordance_index(
+    y_true: np.ndarray, y_pred: np.ndarray
+) -> float:
+    """Compute Harrell's concordance index (C-index). Higher predicted survival probability should 
+    correspond to longer survival (lower risk). Counts concordant pairs where a patient with 
+    higher true survival also receives a higher predicted survival."""
+
+    n = len(y_true)
+    concordant = 0
+    comparable = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            if y_true[i] == y_true[j]:
+                continue
+            comparable += 1
+            if (y_true[i] > y_true[j]) == (y_pred[i] > y_pred[j]):
+                concordant += 1
+    return concordant / comparable if comparable > 0 else 0.5
+
+
+def evaluate_model(
+    model: DeepCoxMixtures,
+    loader: DataLoader,
+) -> Dict[str, float]:
+    """Run inference on a dataloader and return MSE, MAE, and C-index."""
+    model.eval()
+    all_y_true: List[np.ndarray] = []
+    all_y_prob: List[np.ndarray] = []
+
+    with torch.no_grad():
+        for batch in loader:
+            out = model(**batch)
+            all_y_true.append(out["y_true"].cpu().numpy().flatten())
+            all_y_prob.append(out["y_prob"].cpu().numpy().flatten())
+
+    y_true = np.concatenate(all_y_true)
+    y_prob = np.concatenate(all_y_prob)
+
+    mse = float(np.mean((y_true - y_prob) ** 2))
+    mae = float(np.mean(np.abs(y_true - y_prob)))
+    c_idx = concordance_index(y_true, y_prob)
+
+    return {"mse": mse, "mae": mae, "c_index": c_idx}
+
+
+def run_config(
+    sample_dataset,
+    train_dataset,
+    val_dataset,
+    test_dataset,
+    label: str,
+    epochs: int = EPOCHS,
+    **model_kwargs,
+) -> Dict[str, float]:
+    """Train and evaluate one model configuration."""
+    set_seed(SEED)
+
+    train_loader = get_dataloader(
+        train_dataset, batch_size=BATCH_SIZE, shuffle=True
+    )
+    val_loader = get_dataloader(
+        val_dataset, batch_size=BATCH_SIZE, shuffle=False
+    )
+    test_loader = get_dataloader(
+        test_dataset, batch_size=BATCH_SIZE, shuffle=False
+    )
+
+    model = DeepCoxMixtures(dataset=sample_dataset, **model_kwargs)
+
+    trainer = Trainer(
+        model=model,
+        device=DEVICE,
+        metrics=["mse", "mae"],
+        enable_logging=False,
+    )
+    trainer.train(
+        train_dataloader=train_loader,
+        val_dataloader=val_loader,
+        epochs=epochs,
+        monitor="mse",
+        monitor_criterion="min",
+        optimizer_params={"lr": LR},
+    )
+
+    metrics = evaluate_model(model, test_loader)
+    print(
+        f"  {label:<45} | MSE={metrics['mse']:.4f} "
+        f"MAE={metrics['mae']:.4f} C-index={metrics['c_index']:.4f}"
+    )
+    return metrics
+
+
+def print_section(title: str) -> None:
+    print(f"\n{'=' * 70}")
+    print(f"  {title}")
+    print(f"{'=' * 70}")
+    print(f"  {'Configuration':<45} | MSE     MAE     C-index")
+    print(f"  {'-' * 67}")
+
+
+
+if __name__ == "__main__":
+
+    if USE_SYNTHETIC:
+        # ------------------------------------------------------------------
+        # Synthetic smoke-test — no real data required
+        # Verifies the model trains and produces valid metrics.
+        # C-index values are not meaningful at this scale.
+        # ------------------------------------------------------------------
+        print("\n" + "=" * 70)
+        print("  Running in SYNTHETIC mode (smoke-test only)")
+        print("  Set USE_SYNTHETIC=0 for full SUPPORT2 ablation.")
+        print("=" * 70)
+
+        sample_dataset = build_synthetic_dataset()
+        # Use entire synthetic dataset for all splits in smoke-test
+        train_ds = val_ds = test_ds = sample_dataset
+        epochs = SYNTHETIC_EPOCHS
+
+    else:
+        # Full ablation on real SUPPORT2 data
+        print_section("Loading SUPPORT2 Dataset")
+
+        #Prepare CSV, will add 'sno' column if missing to avoid error
+        prepare_csv(DATA_ROOT)
+
+        base_dataset = Support2Dataset(
+            root=DATA_ROOT,
+            tables=["support2"],
+        )
+
+        # Apply survival preprocessing task on a 2-month horizion
+        sample_dataset = base_dataset.set_task(
+            task=SurvivalPreprocessSupport2(time_horizon="2m")
+        )
+        print(f"  Total samples  : {len(sample_dataset)}")
+        print(f"  Input schema   : {sample_dataset.input_schema}")
+        print(f"  Output schema  : {sample_dataset.output_schema}")
+
+        # Split 70/15/15 by patient
+        train_ds, val_ds, test_ds = split_by_patient(
+            sample_dataset, [0.70, 0.15, 0.15]
+        )
+        print(
+            f"  Train / Val / Test: "
+            f"{len(train_ds)} / {len(val_ds)} / {len(test_ds)}"
+        )
+        epochs = EPOCHS
+
+    # Ablation 1 — Number of mixture components K
+    # K=1 is the neural Cox baseline (no mixture). Claim is K>1 improves survival prediction over K=1.
+    print_section("Ablation 1: Number of Mixture Components (K)")
+    ablation1_results = {}
+    for k in [1, 3, 6]:
+        label = f"K={k} ({'neural Cox baseline' if k == 1 else 'DCM'})"
+        ablation1_results[k] = run_config(
+            sample_dataset, train_ds, val_ds, test_ds,
+            label=label,
+            epochs=epochs,
+            num_mixtures=k,
+            hidden_dim=64,
+            dropout=0.0,
+        )
+
+    # Ablation 2 — Hidden dimension
+    # Tests whether a wider encoder improves predictive performance
+    print_section("Ablation 2: Hidden Dimension (K=3 fixed)")
+    ablation2_results = {}
+    for hdim in [32, 64, 128]:
+        label = f"hidden_dim={hdim}"
+        ablation2_results[hdim] = run_config(
+            sample_dataset, train_ds, val_ds, test_ds,
+            label=label,
+            epochs=epochs,
+            num_mixtures=3,
+            hidden_dim=hdim,
+            dropout=0.0,
+        )
+
+    # Ablation 3 — Dropout regularisation
+    # Tests whether dropout helps generalisation on this dataset
+    print_section("Ablation 3: Dropout (K=3, hidden_dim=64 fixed)")
+    ablation3_results = {}
+    for drop in [0.0, 0.2, 0.5]:
+        label = f"dropout={drop}"
+        ablation3_results[drop] = run_config(
+            sample_dataset, train_ds, val_ds, test_ds,
+            label=label,
+            epochs=epochs,
+            num_mixtures=3,
+            hidden_dim=64,
+            dropout=drop,
+        )
+
+    # Summary
+    print_section("Summary: Best C-index per Ablation")
+    best_k = max(ablation1_results, key=lambda k: ablation1_results[k]["c_index"])
+    best_h = max(ablation2_results, key=lambda k: ablation2_results[k]["c_index"])
+    best_d = max(ablation3_results, key=lambda k: ablation3_results[k]["c_index"])
+
+    print(f"  Best K           : {best_k}  "
+          f"(C-index={ablation1_results[best_k]['c_index']:.4f})")
+    print(f"  Best hidden_dim  : {best_h}  "
+          f"(C-index={ablation2_results[best_h]['c_index']:.4f})")
+    print(f"  Best dropout     : {best_d}  "
+          f"(C-index={ablation3_results[best_d]['c_index']:.4f})")
+    print(f"\n  Baseline (K=1) C-index : {ablation1_results[1]['c_index']:.4f}")
+    print(
+        f"  Best DCM (K>1)  C-index : "
+        f"{max(v['c_index'] for k, v in ablation1_results.items() if k > 1):.4f}"
+    )
+    print("\nDone.")

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -46,3 +46,4 @@ from .sdoh import SdohClassifier
 from .medlink import MedLink
 from .unified_embedding import UnifiedMultimodalEmbeddingModel, SinusoidalTimeEmbedding
 from .califorest import CaliForest
+from .deep_cox_mixtures import DeepCoxMixtures, DeepCoxMixturesLayer

--- a/pyhealth/models/deep_cox_mixtures.py
+++ b/pyhealth/models/deep_cox_mixtures.py
@@ -1,0 +1,171 @@
+"""Deep Cox Mixtures (DCM) model for survival regression.
+
+Reference:
+    Nagpal, C., Yadlowsky, S., Rostamzadeh, N., & Heller, K. (2021).
+    Deep Cox Mixtures for Survival Regression.
+    Proceedings of the 6th Machine Learning for Healthcare Conference,
+    PMLR 149:674-708.
+    https://proceedings.mlr.press/v149/nagpal21a.html
+"""
+
+from typing import Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from pyhealth.datasets import SampleDataset
+from pyhealth.models import BaseModel
+from pyhealth.models.embedding import EmbeddingModel
+
+
+class DeepCoxMixturesLayer(nn.Module):
+    """Core neural network layer for the Deep Cox Mixtures model."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dim: int = 64,
+        num_mixtures: int = 3,
+        num_layers: int = 2,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.num_mixtures = num_mixtures
+
+        encoder_layers: List[nn.Module] = []
+        in_dim = input_dim
+        for _ in range(num_layers):
+            encoder_layers.append(nn.Linear(in_dim, hidden_dim))
+            encoder_layers.append(nn.Tanh())
+            if dropout > 0.0:
+                encoder_layers.append(nn.Dropout(p=dropout))
+            in_dim = hidden_dim
+        self.encoder = nn.Sequential(*encoder_layers)
+
+        self.gate = nn.Linear(hidden_dim, num_mixtures)
+        self.hazard_heads = nn.ModuleList(
+            [nn.Linear(hidden_dim, 1) for _ in range(num_mixtures)]
+        )
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Forward pass through the DCM layer."""
+        h = self.encoder(x)
+        gate_probs = F.softmax(self.gate(h), dim=-1)
+        log_hazards = torch.cat([head(h) for head in self.hazard_heads], dim=-1)
+        return gate_probs, log_hazards
+
+
+class DeepCoxMixtures(BaseModel):
+    """Deep Cox Mixtures (DCM) model for survival regression (Nagpal et al. 2021).
+ 
+    Instead of one global Cox model, DCM learns K latent patient subgroups and
+    fits a separate hazard per subgroup. A gating network assigns each patient
+    soft mixture weights, and the final risk score is their weighted combination."""
+
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        embedding_dim: int = 128,
+        hidden_dim: int = 64,
+        num_mixtures: int = 3,
+        num_layers: int = 2,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__(dataset)
+
+        self.embedding_dim = embedding_dim
+        self.hidden_dim = hidden_dim
+        self.num_mixtures = num_mixtures
+        self.num_layers = num_layers
+        self.dropout = dropout
+
+        assert len(self.label_keys) == 1, (
+            "DeepCoxMixtures expects exactly one label key."
+        )
+        self.label_key = self.label_keys[0]
+
+        self.embedding_model = EmbeddingModel(dataset, embedding_dim)
+
+        total_input_dim = embedding_dim * len(self.feature_keys)
+        self.dcm_layer = DeepCoxMixturesLayer(
+            input_dim=total_input_dim,
+            hidden_dim=hidden_dim,
+            num_mixtures=num_mixtures,
+            num_layers=num_layers,
+            dropout=dropout,
+        )
+
+    def _embed_features(self, kwargs: Dict[str, torch.Tensor]) -> torch.Tensor:
+        """Embed all input features and concatenate into a single vector."""
+        feature_vecs: List[torch.Tensor] = []
+
+        for feature_key in self.feature_keys:
+            feature = kwargs[feature_key]
+
+            if isinstance(feature, torch.Tensor):
+                feature = (feature,)
+
+            processor = self.dataset.input_processors[feature_key]
+            schema = processor.schema()
+
+            value = feature[schema.index("value")] if "value" in schema else None
+            mask = feature[schema.index("mask")] if "mask" in schema else None
+
+            if value is None:
+                raise ValueError(
+                    f"Feature '{feature_key}' has no 'value' in its schema."
+                )
+
+            value = value.to(self.device)
+
+            if value.dim() == 3:
+                b, s, inner = value.shape
+                value = value.view(b, s * inner)
+                if mask is not None and mask.dim() == 3:
+                    mask = mask.view(b, s * inner)
+
+            if mask is not None:
+                mask = mask.to(self.device)
+                embedded = self.embedding_model(
+                    {feature_key: value}, masks={feature_key: mask}
+                )[feature_key]
+            else:
+                embedded = self.embedding_model({feature_key: value})[feature_key]
+
+            if embedded.dim() == 3:
+                embedded = embedded.mean(dim=1)
+
+            feature_vecs.append(embedded)
+
+        return torch.cat(feature_vecs, dim=-1)
+
+    @staticmethod
+    def _cox_mixture_loss(
+        gate_probs: torch.Tensor,
+        log_hazards: torch.Tensor,
+        y_true: torch.Tensor,
+    ) -> torch.Tensor:
+        """Mixture-weighted MSE loss over implied log-hazard targets."""
+        eps = 1e-7
+        y_true = y_true.view(-1).clamp(eps, 1.0 - eps)
+        log_h_target = torch.log(-torch.log(y_true))
+        sq_err = (log_hazards - log_h_target.unsqueeze(1)) ** 2
+        return (gate_probs * sq_err).sum(dim=-1).mean()
+
+    def forward(self, **kwargs: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Forward pass for the Deep Cox Mixtures model."""
+        patient_emb = self._embed_features(kwargs)
+        gate_probs, log_hazards = self.dcm_layer(patient_emb)
+
+        logit = (gate_probs * log_hazards).sum(dim=-1, keepdim=True)
+        y_prob = torch.exp(-torch.exp(logit)).clamp(1e-7, 1.0 - 1e-7)
+
+        results: Dict[str, torch.Tensor] = {"logit": logit, "y_prob": y_prob}
+
+        if self.label_key in kwargs:
+            y_true = kwargs[self.label_key].to(self.device)
+            results["loss"] = self._cox_mixture_loss(gate_probs, log_hazards, y_true)
+            results["y_true"] = y_true.view(-1, 1)
+
+        return results

--- a/tests/core/test_deep_cox_mixtures.py
+++ b/tests/core/test_deep_cox_mixtures.py
@@ -43,14 +43,13 @@ class TestDeepCoxMixtures(unittest.TestCase):
     """Test cases for the DeepCoxMixtures model."""
 
     def setUp(self):
-        """Set up synthetic dataset and default model in a temporary directory."""
+        """Set up synthetic dataset and default model."""
         self.tmp_dir = tempfile.mkdtemp()
         self.dataset = create_sample_dataset(
             samples=SAMPLES,
             input_schema=INPUT_SCHEMA,
             output_schema=OUTPUT_SCHEMA,
             dataset_name="test_dcm",
-            cache_dir=self.tmp_dir,
         )
         self.model = DeepCoxMixtures(dataset=self.dataset)
         self.loader = get_dataloader(self.dataset, batch_size=4, shuffle=False)

--- a/tests/core/test_deep_cox_mixtures.py
+++ b/tests/core/test_deep_cox_mixtures.py
@@ -44,7 +44,6 @@ class TestDeepCoxMixtures(unittest.TestCase):
 
     def setUp(self):
         """Set up synthetic dataset and default model."""
-        self.tmp_dir = tempfile.mkdtemp()
         self.dataset = create_sample_dataset(
             samples=SAMPLES,
             input_schema=INPUT_SCHEMA,
@@ -55,8 +54,10 @@ class TestDeepCoxMixtures(unittest.TestCase):
         self.loader = get_dataloader(self.dataset, batch_size=4, shuffle=False)
 
     def tearDown(self):
-        """Clean up temporary directory after each test."""
-        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+        """Clean up pyhealth cache written during tests."""
+        import os
+        cache = os.path.expanduser("~/.cache/pyhealth")
+        shutil.rmtree(cache, ignore_errors=True)
 
     def _batch(self):
         return next(iter(self.loader))

--- a/tests/core/test_deep_cox_mixtures.py
+++ b/tests/core/test_deep_cox_mixtures.py
@@ -1,0 +1,212 @@
+import shutil
+import tempfile
+import unittest
+
+import torch
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models.deep_cox_mixtures import DeepCoxMixtures
+
+
+SAMPLES = [
+    {
+        "patient_id": "patient-0",
+        "visit_id": "visit-0",
+        "features": ["age_50.0", "sex_male", "race_white"],
+        "survival_label": 0.72,
+    },
+    {
+        "patient_id": "patient-1",
+        "visit_id": "visit-0",
+        "features": ["age_65.0", "sex_female", "race_black"],
+        "survival_label": 0.45,
+    },
+    {
+        "patient_id": "patient-2",
+        "visit_id": "visit-0",
+        "features": ["age_78.0", "sex_male", "race_hispanic"],
+        "survival_label": 0.21,
+    },
+    {
+        "patient_id": "patient-3",
+        "visit_id": "visit-0",
+        "features": ["age_40.0", "sex_female", "race_white"],
+        "survival_label": 0.88,
+    },
+]
+
+INPUT_SCHEMA = {"features": "sequence"}
+OUTPUT_SCHEMA = {"survival_label": "regression"}
+
+
+class TestDeepCoxMixtures(unittest.TestCase):
+    """Test cases for the DeepCoxMixtures model."""
+
+    def setUp(self):
+        """Set up synthetic dataset and default model in a temporary directory."""
+        self.tmp_dir = tempfile.mkdtemp()
+        self.dataset = create_sample_dataset(
+            samples=SAMPLES,
+            input_schema=INPUT_SCHEMA,
+            output_schema=OUTPUT_SCHEMA,
+            dataset_name="test_dcm",
+            cache_dir=self.tmp_dir,
+        )
+        self.model = DeepCoxMixtures(dataset=self.dataset)
+        self.loader = get_dataloader(self.dataset, batch_size=4, shuffle=False)
+
+    def tearDown(self):
+        """Clean up temporary directory after each test."""
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _batch(self):
+        return next(iter(self.loader))
+
+    # Initialization
+
+    def test_initialization_defaults(self):
+        """Model initialises with correct default hyperparameters."""
+        self.assertIsInstance(self.model, DeepCoxMixtures)
+        self.assertEqual(self.model.embedding_dim, 128)
+        self.assertEqual(self.model.hidden_dim, 64)
+        self.assertEqual(self.model.num_mixtures, 3)
+        self.assertEqual(self.model.num_layers, 2)
+        self.assertEqual(self.model.dropout, 0.0)
+        self.assertEqual(self.model.label_key, "survival_label")
+        self.assertIn("features", self.model.feature_keys)
+
+    def test_initialization_custom(self):
+        """Model initialises correctly with custom hyperparameters."""
+        model = DeepCoxMixtures(
+            dataset=self.dataset,
+            embedding_dim=64,
+            hidden_dim=32,
+            num_mixtures=6,
+            num_layers=3,
+            dropout=0.3,
+        )
+        self.assertEqual(model.embedding_dim, 64)
+        self.assertEqual(model.hidden_dim, 32)
+        self.assertEqual(model.num_mixtures, 6)
+        self.assertEqual(model.num_layers, 3)
+        self.assertEqual(model.dropout, 0.3)
+
+    def test_k1_reduces_to_single_cox(self):
+        """num_mixtures=1 instantiates without error (neural Cox baseline)."""
+        model = DeepCoxMixtures(dataset=self.dataset, num_mixtures=1)
+        self.assertEqual(model.num_mixtures, 1)
+
+    # Forward pass output keys and shapes
+
+    def test_forward_output_keys(self):
+        """Forward pass returns logit, y_prob, loss, and y_true."""
+        batch = self._batch()
+        with torch.no_grad():
+            out = self.model(**batch)
+        self.assertIn("logit", out)
+        self.assertIn("y_prob", out)
+        self.assertIn("loss", out)
+        self.assertIn("y_true", out)
+
+    def test_forward_output_shapes(self):
+        """Forward pass returns tensors with correct batch dimension."""
+        batch = self._batch()
+        with torch.no_grad():
+            out = self.model(**batch)
+        n = len(SAMPLES)
+        self.assertEqual(out["logit"].shape, (n, 1))
+        self.assertEqual(out["y_prob"].shape, (n, 1))
+        self.assertEqual(out["y_true"].shape, (n, 1))
+        self.assertEqual(out["loss"].dim(), 0)
+
+    def test_y_prob_range(self):
+        """Predicted survival probabilities are in (0, 1)."""
+        batch = self._batch()
+        with torch.no_grad():
+            out = self.model(**batch)
+        self.assertTrue((out["y_prob"] > 0).all())
+        self.assertTrue((out["y_prob"] < 1).all())
+
+    def test_forward_without_label(self):
+        """Forward pass without label key returns logit and y_prob only."""
+        batch = self._batch()
+        batch.pop("survival_label", None)
+        with torch.no_grad():
+            out = self.model(**batch)
+        self.assertIn("logit", out)
+        self.assertIn("y_prob", out)
+        self.assertNotIn("loss", out)
+        self.assertNotIn("y_true", out)
+
+    # Backward pass / gradient flow
+
+    def test_backward(self):
+        """Loss backward populates gradients for all trainable parameters."""
+        batch = self._batch()
+        out = self.model(**batch)
+        out["loss"].backward()
+        has_grad = any(
+            p.requires_grad and p.grad is not None
+            for p in self.model.parameters()
+        )
+        self.assertTrue(has_grad)
+
+    def test_loss_is_finite(self):
+        """Training loss is finite (no NaN or Inf)."""
+        batch = self._batch()
+        with torch.no_grad():
+            out = self.model(**batch)
+        self.assertTrue(torch.isfinite(out["loss"]))
+
+    # DCM layer internals
+
+    def test_gate_probs_sum_to_one(self):
+        """Gate probabilities sum to 1 across mixture components."""
+        batch = self._batch()
+        patient_emb = self.model._embed_features(batch)
+        gate_probs, _ = self.model.dcm_layer(patient_emb)
+        sums = gate_probs.sum(dim=-1)
+        self.assertTrue(torch.allclose(sums, torch.ones_like(sums), atol=1e-5))
+
+    def test_log_hazards_shape(self):
+        """Log hazard tensor has shape (batch, num_mixtures)."""
+        batch = self._batch()
+        patient_emb = self.model._embed_features(batch)
+        _, log_hazards = self.model.dcm_layer(patient_emb)
+        self.assertEqual(
+            log_hazards.shape, (len(SAMPLES), self.model.num_mixtures)
+        )
+
+    # Hyperparameter variations
+
+    def test_varying_num_mixtures_forward(self):
+        """Forward pass succeeds for K in {1, 3, 6}."""
+        for k in [1, 3, 6]:
+            model = DeepCoxMixtures(dataset=self.dataset, num_mixtures=k)
+            batch = self._batch()
+            with torch.no_grad():
+                out = model(**batch)
+            self.assertIn("loss", out)
+            self.assertEqual(out["logit"].shape, (len(SAMPLES), 1))
+
+    def test_varying_hidden_dim_forward(self):
+        """Forward pass succeeds for different hidden dimensions."""
+        for hdim in [16, 64, 128]:
+            model = DeepCoxMixtures(dataset=self.dataset, hidden_dim=hdim)
+            batch = self._batch()
+            with torch.no_grad():
+                out = model(**batch)
+            self.assertIn("loss", out)
+
+    def test_dropout_forward(self):
+        """Forward pass works with dropout enabled (train mode)."""
+        model = DeepCoxMixtures(dataset=self.dataset, dropout=0.5)
+        model.train()
+        batch = self._batch()
+        out = model(**batch)
+        self.assertIn("loss", out)
+        self.assertTrue(torch.isfinite(out["loss"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Contributors: Dhyey Dixit (dhyey2@illinois.edu), Pranay Singh (pranays2@illinois.edu)

Contribution Type: Model

Paper: Nagpal, C., Yadlowsky, S., Rostamzadeh, N., & Heller, K. (2021). Deep Cox Mixtures for Survival Regression. PMLR 149:674-708. https://proceedings.mlr.press/v149/nagpal21a.html

Description:
Implements Deep Cox Mixtures (DCM) for survival regression on SUPPORT2. Instead of one global Cox model, DCM learns K latent patient subgroups via a gating network and fits a separate hazard per subgroup. Mixture models (K>1) outperform the single Cox baseline (K=1) on C-index, consistent with the paper.

Files to Review:
pyhealth/models/deep_cox_mixtures.py — main model file, has DeepCoxMixtures and DeepCoxMixturesLayer
pyhealth/models/init.py — added the import line
tests/core/test_deep_cox_mixtures.py — 14 unit tests, synthetic data
examples/support2_survival_deep_cox_mixtures.py — ablation script, run with USE_SYNTHETIC=1 for a smoke-test or point DATA_ROOT at your support2.csv for the full run
docs/api/models/pyhealth.models.DeepCoxMixtures.rst — Sphinx doc
docs/api/models.rst — added to toctree