### PR TITLE
Add WESAD Dataset and Stress Classification Task

### DIFF
--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -244,5 +244,6 @@ Available Datasets
     datasets/pyhealth.datasets.ClinVarDataset
     datasets/pyhealth.datasets.COSMICDataset
     datasets/pyhealth.datasets.TCGAPRADDataset
+    datasets/pyhealth.datasets.WESADDataset
     datasets/pyhealth.datasets.splitter
     datasets/pyhealth.datasets.utils

--- a/docs/api/datasets/pyhealth.datasets.WESADDataset.rst
+++ b/docs/api/datasets/pyhealth.datasets.WESADDataset.rst
@@ -5,7 +5,13 @@ The WESAD (Wearable Stress and Affect Detection) dataset contains
 physiological data from 15 subjects for stress detection using
 wrist-worn EDA signals.
 
-Refer to `doc <https://ubicomp.eti.uni-siegen.de/home/datasets/icmi18/>`_ for more information.
+University of Siegen dataset page:
+`https://www.eti.uni-siegen.de/ubicomp/home/datasets/icmi18/index.html.en
+<https://www.eti.uni-siegen.de/ubicomp/home/datasets/icmi18/index.html.en>`_.
+
+UCI ML Repository mirror:
+`WESAD (Wearable Stress and Affect Detection)
+<https://archive.ics.uci.edu/dataset/465/wesad+wearable+stress+and+affect+detection>`_.
 
 .. autoclass:: pyhealth.datasets.WESADDataset
     :members:

--- a/docs/api/datasets/pyhealth.datasets.WESADDataset.rst
+++ b/docs/api/datasets/pyhealth.datasets.WESADDataset.rst
@@ -1,0 +1,13 @@
+pyhealth.datasets.WESADDataset
+===================================
+
+The WESAD (Wearable Stress and Affect Detection) dataset contains
+physiological data from 15 subjects for stress detection using
+wrist-worn EDA signals.
+
+Refer to `doc <https://ubicomp.eti.uni-siegen.de/home/datasets/icmi18/>`_ for more information.
+
+.. autoclass:: pyhealth.datasets.WESADDataset
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -230,3 +230,4 @@ Available Tasks
     Mutation Pathogenicity (COSMIC) <tasks/pyhealth.tasks.MutationPathogenicityPrediction>
     Cancer Survival Prediction (TCGA) <tasks/pyhealth.tasks.CancerSurvivalPrediction>
     Cancer Mutation Burden (TCGA) <tasks/pyhealth.tasks.CancerMutationBurden>
+    Stress Classification (WESAD) <tasks/pyhealth.tasks.StressClassificationWESAD>

--- a/docs/api/tasks/pyhealth.tasks.StressClassificationWESAD.rst
+++ b/docs/api/tasks/pyhealth.tasks.StressClassificationWESAD.rst
@@ -1,0 +1,10 @@
+pyhealth.tasks.StressClassificationWESAD
+=========================================
+
+Binary stress classification task on the WESAD dataset using wrist
+electrodermal activity (EDA) signals.
+
+.. autoclass:: pyhealth.tasks.stress_classification_wesad.StressClassificationWESAD
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/wesad_stress_classification_mlp.py
+++ b/examples/wesad_stress_classification_mlp.py
@@ -1,0 +1,218 @@
+"""WESAD Stress Classification Example and Ablation Study.
+
+This script demonstrates the WESADDataset + StressClassificationWESAD
+pipeline and runs an ablation study over different window sizes and
+model configurations.
+
+Paper:
+    Toye, Gomez, Kleinberg, "Simulation of Health Time Series with
+    Nonstationarity", CHIL 2024.
+
+Ablation Study
+--------------
+We investigate how two factors affect stress classification performance:
+
+1. **Window size** (task configuration):
+   - 5 seconds, 10 seconds, 20 seconds
+   - Smaller windows yield more samples but less context per sample.
+   - Larger windows capture more temporal patterns but reduce data size.
+
+2. **Model architecture** (PyHealth models):
+   - MLP with different hidden dimensions (32, 64, 128)
+   - Demonstrates how model capacity interacts with feature granularity.
+
+Results are printed as a summary table at the end.
+
+Usage:
+    python examples/wesad_stress_classification_mlp.py
+
+    To use the real WESAD dataset, set ROOT below to the path
+    containing S2/, S3/, ..., S17/ directories.
+"""
+
+import os
+import pickle
+import shutil
+import tempfile
+import warnings
+
+import numpy as np
+
+warnings.filterwarnings("ignore")
+
+
+def create_synthetic_wesad(root: str, n_subjects: int = 3) -> str:
+    """Create a minimal synthetic WESAD dataset for testing.
+
+    Args:
+        root: Directory to create synthetic data in.
+        n_subjects: Number of synthetic subjects.
+
+    Returns:
+        Path to the synthetic dataset root.
+    """
+    subject_ids = [f"S{i}" for i in range(2, 2 + n_subjects)]
+
+    for sid in subject_ids:
+        subject_dir = os.path.join(root, sid)
+        os.makedirs(subject_dir, exist_ok=True)
+
+        n_eda = 4800  # 20 minutes at 4 Hz
+        n_labels = int(n_eda * 175)  # ~700 Hz / 4 Hz ratio
+
+        eda = np.random.rand(n_eda, 1).astype(np.float64)
+        # Add realistic structure: stress periods have higher EDA
+        stress_start = int(n_eda * 0.4)
+        stress_end = int(n_eda * 0.7)
+        eda[stress_start:stress_end] += 2.0
+
+        labels = np.ones(n_labels, dtype=np.int32)
+        labels_stress_start = int(n_labels * 0.4)
+        labels_stress_end = int(n_labels * 0.7)
+        labels_amuse_start = int(n_labels * 0.85)
+        labels[labels_stress_start:labels_stress_end] = 2
+        labels[labels_amuse_start:] = 3
+
+        data = {
+            "signal": {
+                "wrist": {
+                    "EDA": eda,
+                    "BVP": np.random.rand(n_eda * 16, 1),
+                    "ACC": np.random.rand(n_eda * 8, 3),
+                    "TEMP": np.random.rand(n_eda, 1),
+                },
+                "chest": {
+                    "ECG": np.random.rand(n_labels, 1),
+                    "EDA": np.random.rand(n_labels, 1),
+                    "EMG": np.random.rand(n_labels, 1),
+                    "Temp": np.random.rand(n_labels, 1),
+                    "ACC": np.random.rand(n_labels, 3),
+                    "Resp": np.random.rand(n_labels, 1),
+                },
+            },
+            "label": labels,
+            "subject": sid,
+        }
+
+        pkl_path = os.path.join(subject_dir, f"{sid}.pkl")
+        with open(pkl_path, "wb") as f:
+            pickle.dump(data, f)
+
+    return root
+
+
+def run_ablation():
+    """Run the ablation study over window sizes and hidden dims."""
+    from pyhealth.datasets import WESADDataset, split_by_patient, get_dataloader
+    from pyhealth.tasks import StressClassificationWESAD
+    from pyhealth.models import MLP
+    from pyhealth.trainer import Trainer
+
+    # -- Configuration --
+    # To use the REAL WESAD dataset, change ROOT to the actual path:
+    #   ROOT = "/path/to/WESAD/"
+    # For this demo, we create synthetic data.
+    use_synthetic = True
+
+    if use_synthetic:
+        tmp_dir = tempfile.mkdtemp(prefix="wesad_ablation_")
+        ROOT = create_synthetic_wesad(tmp_dir, n_subjects=4)
+    else:
+        ROOT = "/path/to/WESAD/"  # <-- UPDATE THIS
+        tmp_dir = None
+
+    window_sizes = [5.0, 10.0, 20.0]
+    hidden_dims = [32, 64, 128]
+
+    results = []
+
+    try:
+        for window_sec in window_sizes:
+            # Load dataset for this window size
+            dataset = WESADDataset(root=ROOT)
+
+            task = StressClassificationWESAD(
+                window_size_sec=window_sec,
+                use_features=True,
+            )
+
+            sample_dataset = dataset.set_task(task)
+
+            train_ds, val_ds, test_ds = split_by_patient(
+                sample_dataset, [0.6, 0.2, 0.2]
+            )
+
+            if len(train_ds) == 0 or len(test_ds) == 0:
+                print(
+                    f"  Skipping window={window_sec}s: "
+                    f"train={len(train_ds)}, test={len(test_ds)}"
+                )
+                continue
+
+            train_loader = get_dataloader(
+                train_ds, batch_size=32, shuffle=True
+            )
+            val_loader = get_dataloader(
+                val_ds, batch_size=32, shuffle=False
+            )
+            test_loader = get_dataloader(
+                test_ds, batch_size=32, shuffle=False
+            )
+
+            for hidden_dim in hidden_dims:
+                print(
+                    f"\n--- Window: {window_sec}s | "
+                    f"Hidden dim: {hidden_dim} ---"
+                )
+
+                model = MLP(
+                    dataset=sample_dataset,
+                    feature_keys=["signal"],
+                    label_key="label",
+                    mode="binary",
+                    embedding_dim=hidden_dim,
+                    hidden_dim=hidden_dim,
+                )
+
+                trainer = Trainer(model=model)
+                trainer.train(
+                    train_dataloader=train_loader,
+                    val_dataloader=val_loader,
+                    epochs=5,
+                    monitor="pr_auc",
+                )
+
+                metrics = trainer.evaluate(test_loader)
+                print(f"  Results: {metrics}")
+
+                results.append({
+                    "window_sec": window_sec,
+                    "hidden_dim": hidden_dim,
+                    **metrics,
+                })
+
+        # -- Print summary --
+        print("\n" + "=" * 70)
+        print("ABLATION STUDY RESULTS")
+        print("=" * 70)
+        print(
+            f"{'Window (s)':<12} {'Hidden dim':<12} "
+            f"{'Accuracy':<12} {'F1':<12} {'PR-AUC':<12}"
+        )
+        print("-" * 70)
+        for r in results:
+            print(
+                f"{r['window_sec']:<12.0f} {r['hidden_dim']:<12} "
+                f"{r.get('accuracy', 'N/A'):<12} "
+                f"{r.get('f1', 'N/A'):<12} "
+                f"{r.get('pr_auc', 'N/A'):<12}"
+            )
+        print("=" * 70)
+
+    finally:
+        if tmp_dir and os.path.exists(tmp_dir):
+            shutil.rmtree(tmp_dir)
+
+
+if __name__ == "__main__":
+    run_ablation()

--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -83,6 +83,7 @@ from .splitter import (
 )
 from .tuab import TUABDataset
 from .tuev import TUEVDataset
+from .wesad import WESADDataset
 from .utils import (
     collate_fn_dict,
     collate_fn_dict_with_padding,

--- a/pyhealth/datasets/configs/wesad.yaml
+++ b/pyhealth/datasets/configs/wesad.yaml
@@ -1,0 +1,9 @@
+version: "1.0.0"
+tables:
+  wrist:
+    file_path: "wesad-pyhealth.csv"
+    patient_id: "subject_id"
+    timestamp: null
+    attributes:
+    - "signal_file"
+    - "sampling_rate"

--- a/pyhealth/datasets/wesad.py
+++ b/pyhealth/datasets/wesad.py
@@ -10,7 +10,10 @@ Paper:
     Wearable Stress and Affect Detection", ICMI 2018.
 
 Dataset URL:
-    https://ubicomp.eti.uni-siegen.de/home/datasets/icmi18/
+    https://www.eti.uni-siegen.de/ubicomp/home/datasets/icmi18/index.html.en
+
+    Mirror (UCI ML Repository):
+    https://archive.ics.uci.edu/dataset/465/wesad+wearable+stress+and+affect+detection
 """
 
 import logging
@@ -49,7 +52,10 @@ class WESADDataset(BaseDataset):
         - Labels: 0=not defined, 1=baseline, 2=stress, 3=amusement
 
     Dataset is available at:
-        https://ubicomp.eti.uni-siegen.de/home/datasets/icmi18/
+        https://www.eti.uni-siegen.de/ubicomp/home/datasets/icmi18/index.html.en
+
+        UCI mirror:
+        https://archive.ics.uci.edu/dataset/465/wesad+wearable+stress+and+affect+detection
 
     Args:
         root: Root directory of the extracted WESAD dataset. Should

--- a/pyhealth/datasets/wesad.py
+++ b/pyhealth/datasets/wesad.py
@@ -1,0 +1,146 @@
+"""WESAD (Wearable Stress and Affect Detection) dataset for PyHealth.
+
+This module implements the WESAD dataset for stress detection from
+electrodermal activity (EDA) signals. The dataset was collected from
+15 subjects wearing chest- and wrist-mounted devices during baseline,
+stress, and amusement conditions.
+
+Paper:
+    Schmidt et al., "Introducing WESAD, a Multimodal Dataset for
+    Wearable Stress and Affect Detection", ICMI 2018.
+
+Dataset URL:
+    https://ubicomp.eti.uni-siegen.de/home/datasets/icmi18/
+"""
+
+import logging
+import os
+from typing import Optional
+
+import pandas as pd
+
+from pyhealth.datasets import BaseDataset
+from pyhealth.tasks.stress_classification_wesad import (
+    StressClassificationWESAD,
+)
+
+logger = logging.getLogger(__name__)
+
+WESAD_SUBJECT_IDS = [
+    "S2", "S3", "S4", "S5", "S6", "S7", "S8", "S9", "S10",
+    "S11", "S13", "S14", "S15", "S16", "S17",
+]
+
+
+class WESADDataset(BaseDataset):
+    """Wearable Stress and Affect Detection (WESAD) dataset.
+
+    The WESAD dataset contains physiological and motion data from
+    15 subjects collected during a lab study. Data was recorded using
+    both a chest-worn device (RespiBAN) and a wrist-worn device
+    (Empatica E4).
+
+    This implementation focuses on the **wrist EDA signal** sampled
+    at 4 Hz, which is used for stress detection tasks.
+
+    Each subject's data is stored as a Python pickle file containing:
+        - Wrist signals: EDA, BVP, ACC, TEMP (from Empatica E4)
+        - Chest signals: ECG, EDA, EMG, TEMP, ACC, Resp (from RespiBAN)
+        - Labels: 0=not defined, 1=baseline, 2=stress, 3=amusement
+
+    Dataset is available at:
+        https://ubicomp.eti.uni-siegen.de/home/datasets/icmi18/
+
+    Args:
+        root: Root directory of the extracted WESAD dataset. Should
+            contain subject folders (S2/, S3/, ..., S17/).
+        dataset_name: Name of the dataset. Default is ``"wesad"``.
+        config_path: Path to the YAML config file. If ``None``, the
+            built-in config is used.
+
+    Attributes:
+        task: Name of the task. Default is ``None``.
+        samples: List of sample dicts after calling ``set_task()``.
+
+    Examples:
+        >>> from pyhealth.datasets import WESADDataset
+        >>> dataset = WESADDataset(
+        ...     root="/path/to/WESAD/",
+        ... )
+        >>> dataset.stats()
+        >>> sample_dataset = dataset.set_task()
+    """
+
+    def __init__(
+        self,
+        root: str,
+        dataset_name: Optional[str] = None,
+        config_path: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        if config_path is None:
+            config_path = os.path.join(
+                os.path.dirname(__file__), "configs", "wesad.yaml"
+            )
+
+        metadata_path = os.path.join(root, "wesad-pyhealth.csv")
+        if not os.path.exists(metadata_path):
+            self.prepare_metadata(root)
+
+        super().__init__(
+            root=root,
+            tables=["wrist"],
+            dataset_name=dataset_name or "wesad",
+            config_path=config_path,
+            **kwargs,
+        )
+
+    def prepare_metadata(self, root: str) -> None:
+        """Prepare metadata CSV for the WESAD dataset.
+
+        Scans the root directory for subject folders and verifies that
+        each contains a valid pickle file with wrist EDA data.
+
+        Args:
+            root: Root directory containing subject folders (S2/, ...).
+
+        Raises:
+            FileNotFoundError: If no valid subject directories are found.
+        """
+        records = []
+        for sid in WESAD_SUBJECT_IDS:
+            pkl_path = os.path.join(root, sid, f"{sid}.pkl")
+            if not os.path.exists(pkl_path):
+                logger.warning("Subject file not found: %s", pkl_path)
+                continue
+            records.append({
+                "subject_id": sid,
+                "signal_file": pkl_path,
+                "sampling_rate": 4,
+            })
+
+        if not records:
+            raise FileNotFoundError(
+                f"No valid WESAD subject files found in {root}. "
+                "Expected directories S2/, S3/, ..., S17/ each containing "
+                "a .pkl file."
+            )
+
+        metadata = pd.DataFrame(records)
+        out_path = os.path.join(root, "wesad-pyhealth.csv")
+        metadata.to_csv(out_path, index=False)
+        logger.info(
+            "Prepared WESAD metadata with %d subjects at %s",
+            len(records),
+            out_path,
+        )
+
+    @property
+    def default_task(self) -> StressClassificationWESAD:
+        """Returns the default task for this dataset.
+
+        Returns:
+            StressClassificationWESAD: Binary stress vs baseline
+                classification task.
+        """
+        return StressClassificationWESAD()

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -67,3 +67,4 @@ from .variant_classification import (
     VariantClassificationClinVar,
 )
 from .patient_linkage_mimic3 import PatientLinkageMIMIC3Task
+from .stress_classification_wesad import StressClassificationWESAD

--- a/pyhealth/tasks/stress_classification_wesad.py
+++ b/pyhealth/tasks/stress_classification_wesad.py
@@ -1,0 +1,228 @@
+"""Stress classification task for the WESAD dataset.
+
+This task implements stress detection from wrist-worn physiological
+signals collected in the WESAD study. It supports binary (baseline
+vs stress) and multi-class (baseline vs stress vs amusement) modes.
+
+Reference:
+    Toye, Gomez, Kleinberg, "Simulation of Health Time Series with
+    Nonstationarity", CHIL 2024.
+
+    Schmidt et al., "Introducing WESAD, a Multimodal Dataset for
+    Wearable Stress and Affect Detection", ICMI 2018.
+
+The signal is segmented into fixed-length non-overlapping windows,
+and optional statistical features (mean, std, min, max) are extracted.
+"""
+
+import logging
+import os
+import pickle
+from typing import Any, Dict, List
+
+import numpy as np
+
+from pyhealth.tasks import BaseTask
+
+logger = logging.getLogger(__name__)
+
+WESAD_LABEL_MAP = {
+    0: "not_defined",
+    1: "baseline",
+    2: "stress",
+    3: "amusement",
+    4: "meditation",
+}
+
+WESAD_DEVICE_RATES = {
+    "wrist": 4,    # Empatica E4: EDA at 4 Hz
+    "chest": 700,  # RespiBAN: all signals at 700 Hz
+}
+
+
+class StressClassificationWESAD(BaseTask):
+    """Stress classification from physiological signals on WESAD.
+
+    Segments each subject's continuous signal into non-overlapping
+    windows of ``window_size_sec`` seconds, optionally extracts
+    statistical features, and assigns labels based on the majority
+    condition label within each window.
+
+    Supports both binary classification (baseline=0, stress=1) and
+    multi-class classification (baseline=0, stress=1, amusement=2)
+    via the ``include_amusement`` parameter.
+
+    Attributes:
+        task_name: ``"StressClassification"``
+        input_schema: ``{"signal": "tensor"}``
+        output_schema: ``{"label": "binary"}`` or
+            ``{"label": "multiclass"}``
+
+    Args:
+        window_size_sec: Duration of each signal window in seconds.
+            Default is 10.0 (matching Toye et al. CHIL 2024).
+        use_features: If ``True``, extract statistical features
+            (mean, std, min, max) per window. If ``False``, use raw
+            signal values. Default is ``True``.
+        signal_key: Which wrist signal to use. One of ``"EDA"``,
+            ``"BVP"``, ``"ACC"``, ``"TEMP"``. Default is ``"EDA"``.
+        device: Which device to use: ``"wrist"`` (Empatica E4) or
+            ``"chest"`` (RespiBAN). Default is ``"wrist"``.
+        include_amusement: If ``True``, include the amusement
+            condition as a third class (label=2). Default is
+            ``False`` (binary: baseline vs stress only).
+
+    Examples:
+        >>> from pyhealth.datasets import WESADDataset
+        >>> from pyhealth.tasks import StressClassificationWESAD
+        >>> dataset = WESADDataset(root="/path/to/WESAD/")
+        >>> # Binary stress classification (default)
+        >>> task = StressClassificationWESAD(window_size_sec=10.0)
+        >>> sample_dataset = dataset.set_task(task)
+        >>> sample_dataset[0]
+        {'patient_id': 'S2', 'signal': tensor([...]), 'label': 0}
+        >>> # Multi-class with amusement
+        >>> task3 = StressClassificationWESAD(
+        ...     include_amusement=True)
+        >>> # Use BVP signal instead of EDA
+        >>> task_bvp = StressClassificationWESAD(signal_key="BVP")
+    """
+
+    task_name: str = "StressClassification"
+    input_schema: Dict[str, str] = {"signal": "tensor"}
+    output_schema: Dict[str, str] = {"label": "binary"}
+
+    def __init__(
+        self,
+        window_size_sec: float = 10.0,
+        use_features: bool = True,
+        signal_key: str = "EDA",
+        device: str = "wrist",
+        include_amusement: bool = False,
+    ) -> None:
+        self.window_size_sec = window_size_sec
+        self.use_features = use_features
+        self.signal_key = signal_key
+        self.device = device
+        self.include_amusement = include_amusement
+
+        if include_amusement:
+            self.output_schema = {"label": "multiclass"}
+
+        if device not in WESAD_DEVICE_RATES:
+            raise ValueError(
+                f"Unknown device '{device}'. "
+                f"Expected one of {list(WESAD_DEVICE_RATES.keys())}."
+            )
+
+        super().__init__()
+
+    def __call__(self, patient: Any) -> List[Dict[str, Any]]:
+        """Process a single patient's data for stress classification.
+
+        Loads the subject's pickle file, extracts the specified signal
+        and condition labels, segments into windows, and returns
+        samples.
+
+        WESAD label mapping:
+            0 = not defined / transient (skipped)
+            1 = baseline  -> label 0
+            2 = stress    -> label 1
+            3 = amusement -> label 2 (if include_amusement=True)
+
+        Args:
+            patient: A PyHealth Patient object. Must have events with
+                a ``signal_file`` attribute pointing to the WESAD
+                pickle file.
+
+        Returns:
+            List of sample dicts, each containing ``patient_id``,
+            ``signal`` (feature vector or raw window), and ``label``.
+        """
+        pid = patient.patient_id
+        events = patient.get_events()
+
+        samples: List[Dict[str, Any]] = []
+        valid_labels = {1, 2}
+        if self.include_amusement:
+            valid_labels.add(3)
+
+        label_remap = {1: 0, 2: 1, 3: 2}
+        sampling_rate = WESAD_DEVICE_RATES[self.device]
+
+        for event in events:
+            signal_file = event.signal_file
+
+            if not os.path.exists(signal_file):
+                logger.warning(
+                    "Signal file %s not found for patient %s, skipping.",
+                    signal_file, pid,
+                )
+                continue
+
+            with open(signal_file, "rb") as f:
+                data = pickle.load(f, encoding="latin1")
+
+            try:
+                signal = data["signal"][self.device][
+                    self.signal_key
+                ].flatten()
+            except KeyError:
+                available = list(data["signal"][self.device].keys())
+                logger.warning(
+                    "Signal key '%s' not found for patient %s. "
+                    "Available keys: %s",
+                    self.signal_key, pid, available,
+                )
+                continue
+
+            raw_labels = data["label"].flatten()
+
+            # Align labels to signal sampling rate
+            if len(raw_labels) != len(signal):
+                label_ratio = len(raw_labels) / len(signal)
+                indices = np.round(
+                    np.arange(len(signal)) * label_ratio
+                ).astype(int)
+                indices = np.clip(indices, 0, len(raw_labels) - 1)
+                aligned_labels = raw_labels[indices]
+            else:
+                aligned_labels = raw_labels
+
+            window_length = int(self.window_size_sec * sampling_rate)
+
+            for start in range(
+                0, len(signal) - window_length + 1, window_length
+            ):
+                window = signal[start : start + window_length]
+                window_labels = aligned_labels[
+                    start : start + window_length
+                ]
+
+                unique, counts = np.unique(
+                    window_labels.astype(int), return_counts=True
+                )
+                majority_label = int(unique[np.argmax(counts)])
+
+                if majority_label not in valid_labels:
+                    continue
+
+                binary_label = label_remap[majority_label]
+
+                if self.use_features:
+                    signal_out = np.array([
+                        np.mean(window),
+                        np.std(window),
+                        np.min(window),
+                        np.max(window),
+                    ], dtype=np.float32)
+                else:
+                    signal_out = window.astype(np.float32)
+
+                samples.append({
+                    "patient_id": pid,
+                    "signal": signal_out,
+                    "label": binary_label,
+                })
+
+        return samples

--- a/tests/core/test_wesad.py
+++ b/tests/core/test_wesad.py
@@ -1,0 +1,267 @@
+"""Tests for WESADDataset and StressClassificationWESAD.
+
+Uses synthetic pickle files to test dataset loading, metadata
+preparation, and task processing without requiring the real
+WESAD dataset.
+"""
+
+import os
+import pickle
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pandas as pd
+
+from pyhealth.datasets.wesad import WESADDataset, WESAD_SUBJECT_IDS
+from pyhealth.tasks.stress_classification_wesad import (
+    StressClassificationWESAD,
+)
+
+
+def _create_synthetic_subject(root: str, subject_id: str) -> str:
+    """Create a minimal synthetic WESAD pickle file for testing.
+
+    Generates 200 samples of wrist EDA at 4 Hz (50 seconds) and
+    700*50 = 35000 chest-rate labels to match the ratio.
+
+    Returns:
+        Path to the created pickle file.
+    """
+    subject_dir = os.path.join(root, subject_id)
+    os.makedirs(subject_dir, exist_ok=True)
+
+    n_eda_samples = 200  # 50 seconds at 4 Hz
+    n_label_samples = 35000  # ~700 Hz chest rate
+
+    eda = np.random.rand(n_eda_samples, 1).astype(np.float64)
+
+    # First 60% baseline (1), next 30% stress (2), last 10% amusement (3)
+    labels = np.ones(n_label_samples, dtype=np.int32)
+    stress_start = int(n_label_samples * 0.6)
+    amusement_start = int(n_label_samples * 0.9)
+    labels[stress_start:amusement_start] = 2
+    labels[amusement_start:] = 3
+
+    data = {
+        "signal": {
+            "wrist": {
+                "EDA": eda,
+                "BVP": np.random.rand(n_eda_samples * 16, 1),
+                "ACC": np.random.rand(n_eda_samples * 8, 3),
+                "TEMP": np.random.rand(n_eda_samples, 1),
+            },
+            "chest": {
+                "ECG": np.random.rand(n_label_samples, 1),
+                "EDA": np.random.rand(n_label_samples, 1),
+                "EMG": np.random.rand(n_label_samples, 1),
+                "Temp": np.random.rand(n_label_samples, 1),
+                "ACC": np.random.rand(n_label_samples, 3),
+                "Resp": np.random.rand(n_label_samples, 1),
+            },
+        },
+        "label": labels,
+        "subject": subject_id,
+    }
+
+    pkl_path = os.path.join(subject_dir, f"{subject_id}.pkl")
+    with open(pkl_path, "wb") as f:
+        pickle.dump(data, f)
+
+    return pkl_path
+
+
+class TestWESADMetadata(unittest.TestCase):
+    """Test metadata preparation for WESADDataset."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.subject_ids = ["S2", "S3"]
+        for sid in self.subject_ids:
+            _create_synthetic_subject(self.temp_dir, sid)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_prepare_metadata_creates_csv(self):
+        """Metadata CSV is created with correct columns."""
+        dataset = WESADDataset(root=self.temp_dir)
+        csv_path = os.path.join(self.temp_dir, "wesad-pyhealth.csv")
+        self.assertTrue(os.path.exists(csv_path))
+
+        df = pd.read_csv(csv_path)
+        self.assertIn("subject_id", df.columns)
+        self.assertIn("signal_file", df.columns)
+        self.assertIn("sampling_rate", df.columns)
+        self.assertEqual(len(df), len(self.subject_ids))
+
+    def test_prepare_metadata_subject_ids(self):
+        """Metadata contains the correct subject IDs."""
+        dataset = WESADDataset(root=self.temp_dir)
+        csv_path = os.path.join(self.temp_dir, "wesad-pyhealth.csv")
+        df = pd.read_csv(csv_path)
+        self.assertEqual(
+            sorted(df["subject_id"].tolist()),
+            sorted(self.subject_ids),
+        )
+
+    def test_no_subjects_raises_error(self):
+        """FileNotFoundError raised when no valid subjects exist."""
+        empty_dir = tempfile.mkdtemp()
+        try:
+            with self.assertRaises(FileNotFoundError):
+                WESADDataset(root=empty_dir)
+        finally:
+            shutil.rmtree(empty_dir)
+
+
+class TestWESADDataset(unittest.TestCase):
+    """Test WESADDataset initialization and patient access."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.subject_ids = ["S2", "S3", "S4"]
+        for sid in self.subject_ids:
+            _create_synthetic_subject(self.temp_dir, sid)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_dataset_initialization(self):
+        """Dataset initializes with correct name and root."""
+        dataset = WESADDataset(root=self.temp_dir)
+        self.assertEqual(dataset.dataset_name, "wesad")
+        self.assertEqual(dataset.root, self.temp_dir)
+
+    def test_patient_count(self):
+        """All synthetic subjects are loaded."""
+        dataset = WESADDataset(root=self.temp_dir)
+        self.assertEqual(
+            len(dataset.unique_patient_ids),
+            len(self.subject_ids),
+        )
+
+    def test_get_patient(self):
+        """Individual patient records are accessible."""
+        dataset = WESADDataset(root=self.temp_dir)
+        patient = dataset.get_patient("S2")
+        self.assertIsNotNone(patient)
+        self.assertEqual(patient.patient_id, "S2")
+
+    def test_get_patient_not_found(self):
+        """Accessing a nonexistent patient raises an error."""
+        dataset = WESADDataset(root=self.temp_dir)
+        with self.assertRaises(AssertionError):
+            dataset.get_patient("S99")
+
+    def test_stats(self):
+        """stats() runs without error."""
+        dataset = WESADDataset(root=self.temp_dir)
+        dataset.stats()
+
+    def test_default_task(self):
+        """default_task returns StressClassificationWESAD."""
+        dataset = WESADDataset(root=self.temp_dir)
+        task = dataset.default_task
+        self.assertIsInstance(task, StressClassificationWESAD)
+
+
+class TestStressClassificationWESADTask(unittest.TestCase):
+    """Test StressClassificationWESAD task processing."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.pkl_path = _create_synthetic_subject(self.temp_dir, "S2")
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def _make_dummy_patient(self):
+        """Create a mock patient with one event pointing to our pickle."""
+        event = MagicMock()
+        event.signal_file = self.pkl_path
+
+        patient = MagicMock()
+        patient.patient_id = "S2"
+        patient.get_events.return_value = [event]
+        return patient
+
+    def test_task_schema(self):
+        """Task has correct schemas and name."""
+        task = StressClassificationWESAD()
+        self.assertEqual(task.task_name, "StressClassification")
+        self.assertEqual(task.input_schema, {"signal": "tensor"})
+        self.assertEqual(task.output_schema, {"label": "binary"})
+
+    def test_call_produces_samples(self):
+        """Task __call__ produces non-empty sample list."""
+        task = StressClassificationWESAD(window_size_sec=10.0)
+        patient = self._make_dummy_patient()
+        samples = task(patient)
+        self.assertIsInstance(samples, list)
+        self.assertGreater(len(samples), 0)
+
+    def test_sample_keys(self):
+        """Each sample has required keys."""
+        task = StressClassificationWESAD(window_size_sec=10.0)
+        patient = self._make_dummy_patient()
+        samples = task(patient)
+        for sample in samples:
+            self.assertIn("patient_id", sample)
+            self.assertIn("signal", sample)
+            self.assertIn("label", sample)
+
+    def test_binary_labels(self):
+        """Labels are binary (0 or 1)."""
+        task = StressClassificationWESAD(window_size_sec=10.0)
+        patient = self._make_dummy_patient()
+        samples = task(patient)
+        labels = {s["label"] for s in samples}
+        self.assertTrue(labels.issubset({0, 1}))
+
+    def test_feature_shape_with_features(self):
+        """When use_features=True, signal has shape (4,)."""
+        task = StressClassificationWESAD(
+            window_size_sec=10.0, use_features=True
+        )
+        patient = self._make_dummy_patient()
+        samples = task(patient)
+        for sample in samples:
+            self.assertEqual(sample["signal"].shape, (4,))
+
+    def test_raw_signal_shape(self):
+        """When use_features=False, signal has shape (window_length,)."""
+        task = StressClassificationWESAD(
+            window_size_sec=10.0, use_features=False
+        )
+        patient = self._make_dummy_patient()
+        samples = task(patient)
+        expected_length = int(10.0 * 4)  # 4 Hz * 10 sec = 40
+        for sample in samples:
+            self.assertEqual(sample["signal"].shape, (expected_length,))
+
+    def test_different_window_sizes(self):
+        """Varying window_size_sec changes sample count."""
+        patient = self._make_dummy_patient()
+
+        task_10 = StressClassificationWESAD(window_size_sec=10.0)
+        task_25 = StressClassificationWESAD(window_size_sec=25.0)
+
+        samples_10 = task_10(patient)
+        samples_25 = task_25(patient)
+
+        self.assertGreater(len(samples_10), len(samples_25))
+
+    def test_patient_id_preserved(self):
+        """Patient ID is correctly propagated to samples."""
+        task = StressClassificationWESAD(window_size_sec=10.0)
+        patient = self._make_dummy_patient()
+        samples = task(patient)
+        for sample in samples:
+            self.assertEqual(sample["patient_id"], "S2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Author**: Dylan Dunham (dylanad2@illinois.edu)

**Contribution type**: Dataset + Task

**Paper**: Toye, Gomez & Kleinberg, "Simulation of Health Time Series with Nonstationarity", CHIL 2024

Links:
- Paper: https://proceedings.mlr.press/v248/toye24a.html
- Dataset paper (Schmidt et al., ICMI 2018): https://dl.acm.org/doi/10.1145/3242969.3242985
- **WESAD dataset** (University of Siegen): https://www.eti.uni-siegen.de/ubicomp/home/datasets/icmi18/index.html.en
- **UCI ML Repository mirror**: https://archive.ics.uci.edu/dataset/465/wesad+wearable+stress+and+affect+detection

*(The old `ubicomp.eti.uni-siegen.de` hostname redirects/breaks; the Siegen site now uses `www.eti.uni-siegen.de/ubicomp/...`.)*

## Overview

This PR adds support for the **WESAD (Wearable Stress and Affect Detection)** dataset to PyHealth, enabling binary and multi-class stress classification from wrist-worn physiological signals.

### Dataset (`WESADDataset`)

- Loads the WESAD dataset (15 subjects, `.pkl` format) via `BaseDataset`
- Auto-generates metadata CSV from subject directories
- YAML config following existing PyHealth patterns (SleepEDF, TUAB)

### Task (`StressClassificationWESAD`)

- Segments continuous physiological signals into fixed-length windows
- Supports configurable signal type (`EDA`, `BVP`, `ACC`, `TEMP`), device (`wrist`, `chest`), and window size
- Two modes: statistical features (mean/std/min/max) or raw signal
- Binary (baseline vs stress) and multi-class (+ amusement) classification
- Label assignment via majority vote within each window

### Ablation Study

The example script (`examples/wesad_stress_classification_mlp.py`) demonstrates:

- Window size ablation: 5s, 10s, 20s windows with varying temporal context
- Model architecture ablation: MLP with hidden dimensions 32, 64, 128
- Runs on synthetic data by default; easily configurable for the real dataset

## File Guide

| File | Description |
|------|-------------|
| `pyhealth/datasets/wesad.py` | `WESADDataset` implementation |
| `pyhealth/datasets/configs/wesad.yaml` | Dataset YAML config |
| `pyhealth/tasks/stress_classification_wesad.py` | `StressClassificationWESAD` task |
| `pyhealth/datasets/__init__.py` | Added `WESADDataset` import |
| `pyhealth/tasks/__init__.py` | Added `StressClassificationWESAD` import |
| `docs/api/datasets/pyhealth.datasets.WESADDataset.rst` | Dataset RST docs |
| `docs/api/tasks/pyhealth.tasks.StressClassificationWESAD.rst` | Task RST docs |
| `docs/api/datasets.rst` | Added to table of contents |
| `docs/api/tasks.rst` | Added to table of contents |
| `examples/wesad_stress_classification_mlp.py` | Example + ablation script |
| `tests/core/test_wesad.py` | Unit tests (synthetic data) |

## Test Plan

- [x] Unit tests passing (`pytest tests/core/test_wesad.py -v`)
- [x] All tests use synthetic data (no real dataset required)
- [x] Tests complete quickly (~7 seconds)
- [x] Full pipeline: Dataset → Task → split_by_patient → DataLoader → MLP training → evaluation
- [x] Verified import from `pyhealth.datasets` and `pyhealth.tasks`
