### PR TITLE
First commit

### DIFF
--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -206,6 +206,7 @@ Available Tasks
     :maxdepth: 3
 
     Base Task <tasks/pyhealth.tasks.BaseTask>
+    Left AMA Prediction (MIMIC-III) <tasks/pyhealth.tasks.against_medical_advice_prediction>
     In-Hospital Mortality (MIMIC-IV) <tasks/pyhealth.tasks.InHospitalMortalityMIMIC4>
     MIMIC-III ICD-9 Coding <tasks/pyhealth.tasks.MIMIC3ICD9Coding>
     Cardiology Detection <tasks/pyhealth.tasks.cardiology_detect>

--- a/docs/api/tasks/pyhealth.tasks.against_medical_advice_prediction.rst
+++ b/docs/api/tasks/pyhealth.tasks.against_medical_advice_prediction.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.against_medical_advice_prediction
+================================================
+
+.. autoclass:: pyhealth.tasks.AgainstMedicalAdvicePredictionMIMIC3
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/mimic3_against_medical_advice_prediction_logistic_regression.py
+++ b/examples/mimic3_against_medical_advice_prediction_logistic_regression.py
@@ -1,0 +1,279 @@
+"""Ablation example for MIMIC-III left-AMA prediction on CPU.
+
+This script demonstrates Option 3 (standalone task) usage with multiple
+feature-group configurations and a lightweight PyHealth model.
+
+Notes:
+    Configs prefixed with ``baseline`` mirror the paper-style reproduction
+    feature groups.
+
+    Configs prefixed with ``novel_`` are the intended extension/ablation
+    study for coursework credit because they are not reported in the original
+    paper table:
+    - restricting note-derived features to nursing notes
+    - tightening the ICU cohort to 24 hours
+
+    The MIMIC-III demo subset can be extremely label-sparse. When a requested
+    configuration produces a split with only one label class, the script will
+    skip that configuration instead of failing the whole run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+from pyhealth.datasets import MIMIC3Dataset
+from pyhealth.datasets import get_dataloader, split_by_patient
+from pyhealth.models import LogisticRegression
+from pyhealth.tasks import AgainstMedicalAdvicePredictionMIMIC3
+from pyhealth.trainer import Trainer
+
+
+CONFIG_DEFAULTS: Dict[str, Dict[str, object]] = {
+    "baseline": {
+        "include_baseline": True,
+        "include_race": False,
+        "include_mistrust": False,
+        "include_codes": False,
+    },
+    "baseline_race": {
+        "include_baseline": True,
+        "include_race": True,
+        "include_mistrust": False,
+        "include_codes": False,
+    },
+    "baseline_noncompliance": {
+        "include_baseline": True,
+        "include_race": False,
+        "include_mistrust": True,
+        "mistrust_feature_set": "noncompliance",
+        "include_codes": False,
+    },
+    "baseline_all": {
+        "include_baseline": True,
+        "include_race": True,
+        "include_mistrust": True,
+        "mistrust_feature_set": "all",
+        "include_codes": False,
+    },
+    "novel_nursing_all": {
+        "include_baseline": True,
+        "include_race": True,
+        "include_mistrust": True,
+        "mistrust_feature_set": "all",
+        "include_codes": False,
+        "note_categories": ["nursing"],
+    },
+    "novel_icu24_all": {
+        "include_baseline": True,
+        "include_race": True,
+        "include_mistrust": True,
+        "mistrust_feature_set": "all",
+        "include_codes": False,
+        "min_icu_hours": 24.0,
+    },
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="MIMIC-III left-AMA ablation with LogisticRegression."
+    )
+    parser.add_argument("--root", required=True, help="Path to MIMIC-III root.")
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help="Optional cache directory (default: temp directory).",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+    parser.add_argument("--epochs", type=int, default=3, help="Training epochs.")
+    parser.add_argument("--batch-size", type=int, default=128, help="Batch size.")
+    parser.add_argument("--num-workers", type=int, default=1, help="Task workers.")
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Enable PyHealth dev mode (first 1000 patients).",
+    )
+    parser.add_argument(
+        "--configs",
+        nargs="+",
+        default=[
+            "baseline",
+            "baseline_all",
+            "novel_nursing_all",
+            "novel_icu24_all",
+        ],
+        choices=sorted(CONFIG_DEFAULTS.keys()),
+        help="Configuration names to run.",
+    )
+    parser.add_argument(
+        "--include-codes",
+        action="store_true",
+        help="Force include code features in all selected configs.",
+    )
+    parser.add_argument(
+        "--min-icu-hours",
+        type=float,
+        default=None,
+        help="Optional minimum ICU-hours filter.",
+    )
+    parser.add_argument(
+        "--note-categories",
+        nargs="+",
+        default=None,
+        help="Optional note category filter (case-insensitive).",
+    )
+    return parser.parse_args()
+
+
+def build_tables(config: Dict[str, object]) -> List[str]:
+    tables = ["noteevents"]
+    if config.get("include_codes", False):
+        tables.extend(["diagnoses_icd", "procedures_icd", "prescriptions"])
+    return tables
+
+
+def _extract_binary_label(sample) -> int:
+    label = sample["left_ama"]
+    if hasattr(label, "detach"):
+        return int(label.detach().cpu().numpy().reshape(-1)[0])
+    return int(np.asarray(label).reshape(-1)[0])
+
+
+def _count_classes(dataset) -> Dict[int, int]:
+    counts = {0: 0, 1: 0}
+    for idx in range(len(dataset)):
+        counts[_extract_binary_label(dataset[idx])] += 1
+    return counts
+
+
+def run_one_config(args: argparse.Namespace, config_name: str) -> Dict[str, object]:
+    config = dict(CONFIG_DEFAULTS[config_name])
+    if args.include_codes:
+        config["include_codes"] = True
+    task_note_categories = config.pop("note_categories", None)
+    task_min_icu_hours = config.pop("min_icu_hours", None)
+    if args.note_categories is not None:
+        task_note_categories = args.note_categories
+    if args.min_icu_hours is not None and task_min_icu_hours is None:
+        task_min_icu_hours = args.min_icu_hours
+
+    print(f"\n=== Running config: {config_name} ===")
+    print(f"Config args: {config}")
+
+    cache_dir = args.cache_dir or tempfile.mkdtemp(prefix="mimic3_ama_cache_")
+    sample_dataset = None
+    dataset = MIMIC3Dataset(
+        root=args.root,
+        tables=build_tables(config),
+        cache_dir=cache_dir,
+        dev=args.dev,
+    )
+    task = AgainstMedicalAdvicePredictionMIMIC3(
+        exclude_minors=True,
+        min_icu_hours=task_min_icu_hours,
+        note_categories=task_note_categories,
+        **config,
+    )
+    try:
+        try:
+            sample_dataset = dataset.set_task(task, num_workers=args.num_workers)
+        except Exception as exc:
+            if "Expected 2 unique labels, got 1" in str(exc):
+                return {
+                    "status": "skipped",
+                    "reason": (
+                        "Dataset/task combination only contains one label class "
+                        "for this run."
+                    ),
+                }
+            raise
+        if len(sample_dataset) < 10:
+            return {
+                "status": "skipped",
+                "reason": (
+                    f"Too few samples ({len(sample_dataset)}) for config "
+                    f"'{config_name}'."
+                ),
+            }
+
+        train_ds, val_ds, test_ds = split_by_patient(
+            sample_dataset,
+            ratios=[0.8, 0.1, 0.1],
+            seed=args.seed,
+        )
+        split_counts = {
+            "train": _count_classes(train_ds),
+            "val": _count_classes(val_ds),
+            "test": _count_classes(test_ds),
+        }
+        if any(min(counts.values()) == 0 for counts in split_counts.values()):
+            return {
+                "status": "skipped",
+                "reason": (
+                    "One or more splits have only a single label class. "
+                    f"Split counts: {split_counts}"
+                ),
+            }
+
+        train_loader = get_dataloader(
+            train_ds,
+            batch_size=args.batch_size,
+            shuffle=True,
+        )
+        val_loader = get_dataloader(val_ds, batch_size=args.batch_size, shuffle=False)
+        test_loader = get_dataloader(test_ds, batch_size=args.batch_size, shuffle=False)
+
+        model = LogisticRegression(dataset=sample_dataset, embedding_dim=64)
+        trainer = Trainer(
+            model=model,
+            metrics=[
+                "roc_auc",
+                "pr_auc",
+                "balanced_accuracy",
+                "f1",
+                "precision",
+                "recall",
+            ],
+            enable_logging=False,
+        )
+        trainer.train(
+            train_dataloader=train_loader,
+            val_dataloader=val_loader,
+            epochs=args.epochs,
+            monitor="roc_auc",
+        )
+        test_scores = trainer.evaluate(test_loader)
+        test_scores["status"] = "ok"
+        test_scores["split_counts"] = split_counts
+        return test_scores
+    finally:
+        if sample_dataset is not None:
+            sample_dataset.close()
+
+
+def main():
+    args = parse_args()
+    root = Path(args.root)
+    if not root.exists():
+        raise FileNotFoundError(f"Dataset root does not exist: {root}")
+
+    results: Dict[str, Dict[str, object]] = {}
+    for config_name in args.configs:
+        try:
+            results[config_name] = run_one_config(args, config_name)
+            print(f"Result ({config_name}): {results[config_name]}")
+        except Exception as exc:
+            print(f"Config '{config_name}' failed: {exc}")
+
+    print("\n=== Summary ===")
+    for name, scores in results.items():
+        print(f"{name}: {scores}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -1,4 +1,5 @@
 from .base_task import BaseTask
+from .against_medical_advice_prediction import AgainstMedicalAdvicePredictionMIMIC3
 from .benchmark_ehrshot import BenchmarkEHRShot
 from .cancer_survival import CancerMutationBurden, CancerSurvivalPrediction
 from .bmd_hs_disease_classification import BMDHSDiseaseClassification

--- a/pyhealth/tasks/against_medical_advice_prediction.py
+++ b/pyhealth/tasks/against_medical_advice_prediction.py
@@ -1,0 +1,428 @@
+"""Standalone MIMIC-III task for left-against-medical-advice prediction.
+
+This task is designed for reproducibility-oriented experiments inspired by:
+"Racial Disparities and Mistrust in End-of-Life Care" (Boag et al.).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+from .base_task import BaseTask
+
+
+class AgainstMedicalAdvicePredictionMIMIC3(BaseTask):
+    """Predict whether an admission ends with left against medical advice.
+
+    The task emits configurable feature groups so users can run focused
+    ablations:
+    1. Baseline demographics and numeric features.
+    2. Race-only additions.
+    3. Lightweight note-derived mistrust proxies.
+    4. Optional diagnosis/procedure/drug code features.
+
+    Notes:
+        - The MIMIC-III discharge value is stored as
+          ``LEFT AGAINST MEDICAL ADVI`` (truncated in source table).
+        - Mistrust features are heuristic and intentionally lightweight.
+
+    Examples:
+        >>> from pyhealth.datasets import MIMIC3Dataset
+        >>> from pyhealth.tasks import AgainstMedicalAdvicePredictionMIMIC3
+        >>> dataset = MIMIC3Dataset(
+        ...     root="/path/to/mimic-iii/1.4",
+        ...     tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
+        ... )
+        >>> task = AgainstMedicalAdvicePredictionMIMIC3(
+        ...     include_race=True,
+        ...     include_mistrust=True,
+        ... )
+        >>> sample_dataset = dataset.set_task(task)
+    """
+
+    task_name: str = "AgainstMedicalAdvicePredictionMIMIC3"
+    input_schema: Dict[str, str] = {}
+    output_schema: Dict[str, str] = {"left_ama": "binary"}
+
+    NONCOMPLIANCE_PATTERNS = [
+        r"\bnon[\s\-]?compliant\b",
+        r"\brefus(?:e|ed|ing|al)\b",
+        r"\bdeclin(?:e|ed|ing)\b",
+        r"\bagainst\s+medical\s+advice\b",
+        r"\bleft\s+ama\b",
+        r"\buncooperative\b",
+        r"\bhostile\b",
+        r"\bcombative\b",
+    ]
+    NEGATIVE_LEXICON = {
+        "angry",
+        "argumentative",
+        "belligerent",
+        "combative",
+        "confrontational",
+        "declined",
+        "delirious",
+        "distrustful",
+        "hostile",
+        "noncompliant",
+        "refused",
+        "refusing",
+        "uncooperative",
+        "upset",
+        "verbally",
+        "violent",
+    }
+    EMPTY_CODE_TOKENS = {
+        "conditions": "NO_CONDITION",
+        "procedures": "NO_PROCEDURE",
+        "drugs": "NO_DRUG",
+    }
+
+    def __init__(
+        self,
+        exclude_minors: bool = True,
+        min_icu_hours: Optional[float] = None,
+        include_baseline: bool = True,
+        include_race: bool = False,
+        include_mistrust: bool = False,
+        mistrust_feature_set: str = "all",
+        note_categories: Optional[List[str]] = None,
+        include_codes: bool = False,
+        code_mapping: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Initialize the task.
+
+        Args:
+            exclude_minors: Whether to exclude admissions where age is under 18.
+            min_icu_hours: Optional minimum ICU overlap duration in hours.
+            include_baseline: Include baseline numeric and demographic features.
+            include_race: Include normalized race token feature.
+            include_mistrust: Include note-derived mistrust proxy tensor.
+            mistrust_feature_set: One of ``"noncompliance"``,
+                ``"negative_sentiment"``, or ``"all"``.
+            note_categories: Optional note category whitelist (case-insensitive).
+            include_codes: Include diagnosis/procedure/drug sequence features.
+            code_mapping: Optional PyHealth code mapping config.
+        """
+        if mistrust_feature_set not in {"noncompliance", "negative_sentiment", "all"}:
+            raise ValueError(
+                "mistrust_feature_set must be one of "
+                "{'noncompliance', 'negative_sentiment', 'all'}"
+            )
+
+        self.exclude_minors = exclude_minors
+        self.min_icu_hours = min_icu_hours
+        self.include_baseline = include_baseline
+        self.include_race = include_race
+        self.include_mistrust = include_mistrust
+        self.mistrust_feature_set = mistrust_feature_set
+        self.note_categories = (
+            {self._normalize_text(c) for c in note_categories}
+            if note_categories
+            else None
+        )
+        self.include_codes = include_codes
+        self._noncompliance_regex = [
+            re.compile(pattern, flags=re.IGNORECASE)
+            for pattern in self.NONCOMPLIANCE_PATTERNS
+        ]
+
+        schema: Dict[str, str] = {}
+        if self.include_baseline:
+            schema["baseline_numeric"] = "tensor"
+            schema["baseline_demographics"] = "multi_hot"
+        if self.include_race:
+            schema["race_tokens"] = "multi_hot"
+        if self.include_mistrust:
+            schema["mistrust_features"] = "tensor"
+        if self.include_codes:
+            schema["conditions"] = "sequence"
+            schema["procedures"] = "sequence"
+            schema["drugs"] = "sequence"
+        self.input_schema = schema
+
+        super().__init__(code_mapping=code_mapping)
+
+    @staticmethod
+    def _normalize_text(value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip().lower()
+
+    @staticmethod
+    def _parse_datetime(value: Any) -> Optional[datetime]:
+        """Parse timestamp-like values into ``datetime``."""
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        as_str = str(value).strip()
+        if not as_str or as_str.lower() == "none":
+            return None
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+            try:
+                return datetime.strptime(as_str, fmt)
+            except ValueError:
+                continue
+        try:
+            return datetime.fromisoformat(as_str)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _normalize_insurance(value: Any) -> str:
+        """Map raw insurance to coarse buckets."""
+        v = str(value or "").strip().upper()
+        if not v:
+            return "unknown"
+        if v == "PRIVATE":
+            return "private"
+        if v in {"MEDICARE", "MEDICAID", "GOVERNMENT"}:
+            return "public"
+        if v == "SELF PAY":
+            return "self_pay"
+        return "other"
+
+    @staticmethod
+    def _normalize_race(value: Any) -> str:
+        """Collapse ethnicity text into broad race groups."""
+        v = str(value or "").strip().upper()
+        if "BLACK" in v:
+            return "black"
+        if "WHITE" in v:
+            return "white"
+        if "HISPANIC" in v or "LATINO" in v:
+            return "hispanic"
+        if "ASIAN" in v:
+            return "asian"
+        return "other"
+
+    def _count_noncompliance_hits(self, text: str) -> int:
+        return sum(len(regex.findall(text)) for regex in self._noncompliance_regex)
+
+    def _negative_sentiment_proxy(self, text: str) -> float:
+        tokens = re.findall(r"\b[a-z]+\b", text.lower())
+        if not tokens:
+            return 0.0
+        negative_hits = sum(token in self.NEGATIVE_LEXICON for token in tokens)
+        return float(negative_hits / len(tokens))
+
+    def _compute_age_years(
+        self,
+        patient: Any,
+        admission_time: datetime,
+    ) -> Optional[float]:
+        patient_events = patient.get_events(event_type="patients")
+        if not patient_events:
+            return None
+        dob = self._parse_datetime(getattr(patient_events[0], "dob", None))
+        if dob is None:
+            return None
+        age_years = admission_time.year - dob.year
+        if (admission_time.month, admission_time.day) < (dob.month, dob.day):
+            age_years -= 1
+        if age_years < 0:
+            return None
+        if age_years > 89:
+            age_years = 89
+        return float(age_years)
+
+    def _compute_icu_overlap_hours(
+        self,
+        patient: Any,
+        admission_time: datetime,
+        discharge_time: datetime,
+    ) -> float:
+        icu_events = patient.get_events(event_type="icustays")
+        overlap_hours = 0.0
+        for icu_event in icu_events:
+            intime = self._parse_datetime(getattr(icu_event, "intime", None))
+            if intime is None:
+                intime = self._parse_datetime(getattr(icu_event, "timestamp", None))
+            outtime = self._parse_datetime(getattr(icu_event, "outtime", None))
+            if intime is None or outtime is None:
+                continue
+            if outtime <= intime:
+                continue
+            overlap_start = max(intime, admission_time)
+            overlap_end = min(outtime, discharge_time)
+            if overlap_end <= overlap_start:
+                continue
+            overlap_hours += (overlap_end - overlap_start).total_seconds() / 3600.0
+        return overlap_hours
+
+    def _collect_note_text(self, patient: Any, hadm_id: Any) -> tuple[str, int]:
+        note_events = patient.get_events(
+            event_type="noteevents",
+            filters=[("hadm_id", "==", hadm_id)],
+        )
+        filtered_text_parts: List[str] = []
+        retained_notes = 0
+        for event in note_events:
+            category = self._normalize_text(getattr(event, "category", ""))
+            if (
+                self.note_categories is not None
+                and category not in self.note_categories
+            ):
+                continue
+            text = str(getattr(event, "text", "") or "").strip()
+            if not text:
+                continue
+            retained_notes += 1
+            filtered_text_parts.append(text)
+        return " ".join(filtered_text_parts), retained_notes
+
+    @classmethod
+    def _extract_code_sequence(
+        cls,
+        events: Iterable[Any],
+        attribute: str,
+        placeholder_key: str,
+    ) -> List[str]:
+        """Extract a non-empty code sequence for categorical features.
+
+        Some admissions legitimately have no diagnosis, procedure, or
+        prescription code rows in the subset of tables loaded for the task.
+        Returning an explicit placeholder token keeps these sequence features
+        well-defined for simple baseline models that do not handle empty
+        categorical sequences robustly.
+        """
+        values = [
+            str(getattr(event, attribute, "")).strip()
+            for event in events
+            if str(getattr(event, attribute, "")).strip()
+        ]
+        if values:
+            return values
+        return [cls.EMPTY_CODE_TOKENS[placeholder_key]]
+
+    @staticmethod
+    def _is_left_ama(discharge_location: Any) -> int:
+        value = str(discharge_location or "").strip().upper()
+        if value == "LEFT AGAINST MEDICAL ADVI":
+            return 1
+        if value.startswith("LEFT AGAINST MEDICAL ADVI"):
+            return 1
+        return 0
+
+    def __call__(self, patient: Any) -> List[Dict[str, Any]]:
+        """Generate admission-level samples for one patient."""
+        admissions = patient.get_events(event_type="admissions")
+        patient_events = patient.get_events(event_type="patients")
+        patient_gender = self._normalize_text(
+            getattr(patient_events[0], "gender", "unknown")
+            if patient_events
+            else "unknown"
+        )
+        if not patient_gender:
+            patient_gender = "unknown"
+        samples: List[Dict[str, Any]] = []
+
+        for admission in admissions:
+            hadm_id = getattr(admission, "hadm_id", None)
+            admission_time = self._parse_datetime(getattr(admission, "timestamp", None))
+            discharge_time = self._parse_datetime(getattr(admission, "dischtime", None))
+            if hadm_id is None or admission_time is None or discharge_time is None:
+                continue
+            if discharge_time <= admission_time:
+                continue
+
+            los_days = (discharge_time - admission_time).total_seconds() / 86400.0
+            if los_days < 0:
+                continue
+
+            age_years = self._compute_age_years(patient, admission_time)
+            if self.exclude_minors:
+                if age_years is None or age_years < 18:
+                    continue
+
+            if self.min_icu_hours is not None:
+                icu_hours = self._compute_icu_overlap_hours(
+                    patient=patient,
+                    admission_time=admission_time,
+                    discharge_time=discharge_time,
+                )
+                if icu_hours < self.min_icu_hours:
+                    continue
+
+            left_ama = self._is_left_ama(getattr(admission, "discharge_location", None))
+            sample: Dict[str, Any] = {
+                "visit_id": str(hadm_id),
+                "hadm_id": str(hadm_id),
+                "patient_id": str(patient.patient_id),
+                "left_ama": left_ama,
+            }
+
+            if self.include_baseline:
+                sample["baseline_numeric"] = [float(age_years or 0.0), float(los_days)]
+                insurance = self._normalize_insurance(
+                    getattr(admission, "insurance", None)
+                )
+                sample["baseline_demographics"] = [
+                    f"gender:{patient_gender}",
+                    f"insurance:{insurance}",
+                ]
+
+            if self.include_race:
+                race = self._normalize_race(getattr(admission, "ethnicity", None))
+                sample["race_tokens"] = [f"race:{race}"]
+
+            if self.include_mistrust:
+                note_text, note_count = self._collect_note_text(patient, hadm_id)
+                noncompliance_count = float(self._count_noncompliance_hits(note_text))
+                noncompliance_any = float(noncompliance_count > 0.0)
+                negative_proxy = float(self._negative_sentiment_proxy(note_text))
+                note_present = float(note_count > 0)
+
+                if self.mistrust_feature_set == "noncompliance":
+                    mistrust_features = [
+                        noncompliance_any,
+                        noncompliance_count,
+                        0.0,
+                        note_present,
+                    ]
+                elif self.mistrust_feature_set == "negative_sentiment":
+                    mistrust_features = [0.0, 0.0, negative_proxy, note_present]
+                else:
+                    mistrust_features = [
+                        noncompliance_any,
+                        noncompliance_count,
+                        negative_proxy,
+                        note_present,
+                    ]
+                sample["mistrust_features"] = mistrust_features
+
+            if self.include_codes:
+                diagnoses = patient.get_events(
+                    event_type="diagnoses_icd",
+                    filters=[("hadm_id", "==", hadm_id)],
+                )
+                procedures = patient.get_events(
+                    event_type="procedures_icd",
+                    filters=[("hadm_id", "==", hadm_id)],
+                )
+                prescriptions = patient.get_events(
+                    event_type="prescriptions",
+                    filters=[("hadm_id", "==", hadm_id)],
+                )
+                sample["conditions"] = self._extract_code_sequence(
+                    diagnoses,
+                    attribute="icd9_code",
+                    placeholder_key="conditions",
+                )
+                sample["procedures"] = self._extract_code_sequence(
+                    procedures,
+                    attribute="icd9_code",
+                    placeholder_key="procedures",
+                )
+                sample["drugs"] = self._extract_code_sequence(
+                    prescriptions,
+                    attribute="ndc",
+                    placeholder_key="drugs",
+                )
+
+            samples.append(sample)
+
+        return samples

--- a/tests/core/test_against_medical_advice_prediction.py
+++ b/tests/core/test_against_medical_advice_prediction.py
@@ -1,0 +1,513 @@
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+from pyhealth.datasets import MIMIC3Dataset
+from pyhealth.tasks import AgainstMedicalAdvicePredictionMIMIC3
+
+
+def _write_csv(path: Path, header, rows):
+    with path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+class TestAgainstMedicalAdvicePredictionMIMIC3(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.TemporaryDirectory()
+        cls.root = Path(cls.tmpdir.name)
+        cls.cache_dir = tempfile.TemporaryDirectory()
+        cls._build_synthetic_mimic3(cls.root)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmpdir.cleanup()
+        cls.cache_dir.cleanup()
+
+    @classmethod
+    def _build_synthetic_mimic3(cls, root: Path):
+        _write_csv(
+            root / "PATIENTS.csv",
+            [
+                "ROW_ID",
+                "SUBJECT_ID",
+                "GENDER",
+                "DOB",
+                "DOD",
+                "DOD_HOSP",
+                "DOD_SSN",
+                "EXPIRE_FLAG",
+            ],
+            [
+                [1, 1, "M", "2080-01-01", "", "", "", 0],
+                [2, 2, "F", "2069-02-02", "", "", "", 0],
+                [3, 3, "M", "2109-03-03", "", "", "", 0],
+                [4, 4, "F", "1800-04-04", "", "", "", 0],
+            ],
+        )
+
+        _write_csv(
+            root / "ADMISSIONS.csv",
+            [
+                "ROW_ID",
+                "SUBJECT_ID",
+                "HADM_ID",
+                "ADMITTIME",
+                "DISCHTIME",
+                "DEATHTIME",
+                "ADMISSION_TYPE",
+                "ADMISSION_LOCATION",
+                "DISCHARGE_LOCATION",
+                "INSURANCE",
+                "LANGUAGE",
+                "RELIGION",
+                "MARITAL_STATUS",
+                "ETHNICITY",
+                "EDREGTIME",
+                "EDOUTTIME",
+                "DIAGNOSIS",
+                "HOSPITAL_EXPIRE_FLAG",
+                "HAS_CHARTEVENTS_DATA",
+            ],
+            [
+                [
+                    10,
+                    1,
+                    1001,
+                    "2120-01-10 08:00:00",
+                    "2120-01-12 10:00:00",
+                    "",
+                    "EMERGENCY",
+                    "EMERGENCY ROOM ADMIT",
+                    "HOME",
+                    "MEDICARE",
+                    "ENGLISH",
+                    "CATHOLIC",
+                    "MARRIED",
+                    "BLACK/AFRICAN AMERICAN",
+                    "",
+                    "",
+                    "DX1",
+                    0,
+                    1,
+                ],
+                [
+                    11,
+                    2,
+                    1002,
+                    "2120-02-10 08:00:00",
+                    "2120-02-11 08:00:00",
+                    "",
+                    "EMERGENCY",
+                    "EMERGENCY ROOM ADMIT",
+                    "LEFT AGAINST MEDICAL ADVI",
+                    "PRIVATE",
+                    "ENGLISH",
+                    "CATHOLIC",
+                    "SINGLE",
+                    "WHITE",
+                    "",
+                    "",
+                    "DX2",
+                    0,
+                    1,
+                ],
+                [
+                    12,
+                    3,
+                    1003,
+                    "2120-03-10 08:00:00",
+                    "2120-03-10 20:00:00",
+                    "",
+                    "EMERGENCY",
+                    "EMERGENCY ROOM ADMIT",
+                    "LEFT AGAINST MEDICAL ADVI",
+                    "SELF PAY",
+                    "ENGLISH",
+                    "OTHER",
+                    "SINGLE",
+                    "HISPANIC OR LATINO",
+                    "",
+                    "",
+                    "DX3",
+                    0,
+                    1,
+                ],
+                [
+                    13,
+                    4,
+                    1004,
+                    "2120-04-10 08:00:00",
+                    "2120-04-11 08:00:00",
+                    "",
+                    "ELECTIVE",
+                    "PHYS REFERRAL/NORMAL DELI",
+                    "HOME HEALTH CARE",
+                    "MEDICAID",
+                    "ENGLISH",
+                    "CATHOLIC",
+                    "MARRIED",
+                    "ASIAN",
+                    "",
+                    "",
+                    "DX4",
+                    0,
+                    1,
+                ],
+            ],
+        )
+
+        _write_csv(
+            root / "ICUSTAYS.csv",
+            [
+                "ROW_ID",
+                "SUBJECT_ID",
+                "HADM_ID",
+                "ICUSTAY_ID",
+                "DBSOURCE",
+                "FIRST_CAREUNIT",
+                "LAST_CAREUNIT",
+                "INTIME",
+                "OUTTIME",
+                "LOS",
+            ],
+            [
+                [
+                    1,
+                    1,
+                    1001,
+                    5001,
+                    "carevue",
+                    "MICU",
+                    "MICU",
+                    "2120-01-10 09:00:00",
+                    "2120-01-11 15:00:00",
+                    1.25,
+                ],
+                [
+                    2,
+                    2,
+                    1002,
+                    5002,
+                    "carevue",
+                    "MICU",
+                    "MICU",
+                    "2120-02-10 09:00:00",
+                    "2120-02-10 11:00:00",
+                    0.08,
+                ],
+                [
+                    3,
+                    3,
+                    1003,
+                    5003,
+                    "carevue",
+                    "MICU",
+                    "MICU",
+                    "2120-03-10 09:00:00",
+                    "2120-03-10 12:00:00",
+                    0.12,
+                ],
+            ],
+        )
+
+        _write_csv(
+            root / "NOTEEVENTS.csv",
+            [
+                "ROW_ID",
+                "SUBJECT_ID",
+                "HADM_ID",
+                "CHARTDATE",
+                "CHARTTIME",
+                "STORETIME",
+                "CATEGORY",
+                "DESCRIPTION",
+                "CGID",
+                "ISERROR",
+                "TEXT",
+            ],
+            [
+                [
+                    1,
+                    1,
+                    1001,
+                    "2120-01-10",
+                    "2120-01-10 12:00:00",
+                    "2120-01-10 12:30:00",
+                    "Nursing",
+                    "Report",
+                    100,
+                    "",
+                    "Patient refused medication and was hostile during counseling.",
+                ],
+                [
+                    2,
+                    2,
+                    1002,
+                    "2120-02-10",
+                    "2120-02-10 12:00:00",
+                    "2120-02-10 12:30:00",
+                    "Physician ",
+                    "Report",
+                    101,
+                    "",
+                    "Patient appears calm and cooperative.",
+                ],
+                [
+                    3,
+                    2,
+                    1002,
+                    "2120-02-10",
+                    "2120-02-10 18:00:00",
+                    "2120-02-10 18:30:00",
+                    "Radiology",
+                    "Report",
+                    102,
+                    "",
+                    "No acute findings.",
+                ],
+            ],
+        )
+
+        _write_csv(
+            root / "DIAGNOSES_ICD.csv",
+            ["ROW_ID", "SUBJECT_ID", "HADM_ID", "SEQ_NUM", "ICD9_CODE"],
+            [
+                [1, 1, 1001, 1, "4019"],
+                [2, 2, 1002, 1, "25000"],
+                [3, 4, 1004, 1, "41401"],
+            ],
+        )
+        _write_csv(
+            root / "PROCEDURES_ICD.csv",
+            ["ROW_ID", "SUBJECT_ID", "HADM_ID", "SEQ_NUM", "ICD9_CODE"],
+            [
+                [1, 1, 1001, 1, "3893"],
+                [2, 2, 1002, 1, "8856"],
+                [3, 4, 1004, 1, "3615"],
+            ],
+        )
+        _write_csv(
+            root / "PRESCRIPTIONS.csv",
+            [
+                "ROW_ID",
+                "SUBJECT_ID",
+                "HADM_ID",
+                "ICUSTAY_ID",
+                "STARTDATE",
+                "ENDDATE",
+                "DRUG_TYPE",
+                "DRUG",
+                "DRUG_NAME_POE",
+                "DRUG_NAME_GENERIC",
+                "FORMULARY_DRUG_CD",
+                "GSN",
+                "NDC",
+                "PROD_STRENGTH",
+                "DOSE_VAL_RX",
+                "DOSE_UNIT_RX",
+                "FORM_VAL_DISP",
+                "FORM_UNIT_DISP",
+                "ROUTE",
+            ],
+            [
+                [
+                    1,
+                    1,
+                    1001,
+                    "",
+                    "2120-01-10",
+                    "2120-01-11",
+                    "MAIN",
+                    "Aspirin",
+                    "Aspirin",
+                    "Aspirin",
+                    "ASP",
+                    "1",
+                    "11111",
+                    "81mg",
+                    "1",
+                    "TAB",
+                    "1",
+                    "TAB",
+                    "PO",
+                ],
+                [
+                    2,
+                    2,
+                    1002,
+                    "",
+                    "2120-02-10",
+                    "2120-02-11",
+                    "MAIN",
+                    "Metformin",
+                    "Metformin",
+                    "Metformin",
+                    "MET",
+                    "2",
+                    "22222",
+                    "500mg",
+                    "1",
+                    "TAB",
+                    "1",
+                    "TAB",
+                    "PO",
+                ],
+            ],
+        )
+
+    def _get_dataset(self, tables):
+        return MIMIC3Dataset(
+            root=str(self.root),
+            tables=tables,
+            cache_dir=self.cache_dir.name,
+        )
+
+    def test_task_schema_default(self):
+        task = AgainstMedicalAdvicePredictionMIMIC3()
+        self.assertEqual(task.task_name, "AgainstMedicalAdvicePredictionMIMIC3")
+        self.assertEqual(task.output_schema, {"left_ama": "binary"})
+        self.assertIn("baseline_numeric", task.input_schema)
+        self.assertIn("baseline_demographics", task.input_schema)
+        self.assertNotIn("race_tokens", task.input_schema)
+        self.assertNotIn("mistrust_features", task.input_schema)
+
+    def test_label_and_baseline_extraction(self):
+        dataset = self._get_dataset(tables=["noteevents"])
+        task = AgainstMedicalAdvicePredictionMIMIC3(exclude_minors=False)
+        patient = dataset.get_patient("2")
+        samples = task(patient)
+        self.assertEqual(len(samples), 1)
+        self.assertEqual(samples[0]["left_ama"], 1)
+        self.assertIn("insurance:private", samples[0]["baseline_demographics"])
+
+    def test_minor_exclusion(self):
+        dataset = self._get_dataset(tables=["noteevents"])
+        task = AgainstMedicalAdvicePredictionMIMIC3(exclude_minors=True)
+        patient = dataset.get_patient("3")
+        samples = task(patient)
+        self.assertEqual(samples, [])
+
+    def test_age_cap_at_89(self):
+        dataset = self._get_dataset(tables=["noteevents"])
+        task = AgainstMedicalAdvicePredictionMIMIC3(exclude_minors=False)
+        patient = dataset.get_patient("4")
+        samples = task(patient)
+        self.assertEqual(len(samples), 1)
+        self.assertEqual(samples[0]["baseline_numeric"][0], 89.0)
+
+    def test_race_and_insurance_normalization(self):
+        dataset = self._get_dataset(tables=["noteevents"])
+        task = AgainstMedicalAdvicePredictionMIMIC3(
+            exclude_minors=False,
+            include_race=True,
+        )
+        p1 = task(dataset.get_patient("1"))[0]
+        p4 = task(dataset.get_patient("4"))[0]
+        self.assertIn("insurance:public", p1["baseline_demographics"])
+        self.assertEqual(p1["race_tokens"], ["race:black"])
+        self.assertEqual(p4["race_tokens"], ["race:asian"])
+
+    def test_icu_hour_filter(self):
+        dataset = self._get_dataset(tables=["noteevents"])
+        task = AgainstMedicalAdvicePredictionMIMIC3(
+            exclude_minors=False,
+            min_icu_hours=12.0,
+        )
+        self.assertEqual(len(task(dataset.get_patient("1"))), 1)
+        self.assertEqual(len(task(dataset.get_patient("2"))), 0)
+
+    def test_note_category_filter_and_mistrust_features(self):
+        dataset = self._get_dataset(tables=["noteevents"])
+        task = AgainstMedicalAdvicePredictionMIMIC3(
+            exclude_minors=False,
+            include_mistrust=True,
+            mistrust_feature_set="all",
+            note_categories=["NURSING"],
+        )
+        sample_1 = task(dataset.get_patient("1"))[0]
+        sample_2 = task(dataset.get_patient("2"))[0]
+        self.assertGreater(sample_1["mistrust_features"][0], 0.0)
+        self.assertGreater(sample_1["mistrust_features"][1], 0.0)
+        self.assertGreater(sample_1["mistrust_features"][2], 0.0)
+        self.assertEqual(sample_2["mistrust_features"][2], 0.0)
+
+    def test_missing_notes_produces_zero_mistrust_proxy(self):
+        dataset = self._get_dataset(tables=["noteevents"])
+        task = AgainstMedicalAdvicePredictionMIMIC3(
+            exclude_minors=False,
+            include_mistrust=True,
+        )
+        sample = task(dataset.get_patient("4"))[0]
+        self.assertEqual(sample["mistrust_features"], [0.0, 0.0, 0.0, 0.0])
+
+    def test_include_codes_feature_group(self):
+        dataset = self._get_dataset(
+            tables=[
+                "noteevents",
+                "diagnoses_icd",
+                "procedures_icd",
+                "prescriptions",
+            ]
+        )
+        task = AgainstMedicalAdvicePredictionMIMIC3(
+            exclude_minors=False,
+            include_codes=True,
+        )
+        sample = task(dataset.get_patient("1"))[0]
+        self.assertIn("conditions", sample)
+        self.assertIn("procedures", sample)
+        self.assertIn("drugs", sample)
+        self.assertGreaterEqual(len(sample["conditions"]), 1)
+        sample_missing_drug = task(dataset.get_patient("4"))[0]
+        self.assertEqual(sample_missing_drug["drugs"], ["NO_DRUG"])
+
+    def test_include_codes_uses_placeholders_for_empty_sequences(self):
+        dataset = self._get_dataset(
+            tables=[
+                "noteevents",
+                "diagnoses_icd",
+                "procedures_icd",
+                "prescriptions",
+            ]
+        )
+        task = AgainstMedicalAdvicePredictionMIMIC3(
+            exclude_minors=False,
+            include_codes=True,
+        )
+        sample = task(dataset.get_patient("3"))[0]
+        self.assertEqual(sample["conditions"], ["NO_CONDITION"])
+        self.assertEqual(sample["procedures"], ["NO_PROCEDURE"])
+        self.assertEqual(sample["drugs"], ["NO_DRUG"])
+
+    def test_dataset_set_task_end_to_end(self):
+        dataset = self._get_dataset(
+            tables=[
+                "noteevents",
+                "diagnoses_icd",
+                "procedures_icd",
+                "prescriptions",
+            ]
+        )
+        task = AgainstMedicalAdvicePredictionMIMIC3(
+            exclude_minors=False,
+            include_race=True,
+            include_mistrust=True,
+            include_codes=True,
+            min_icu_hours=1.0,
+        )
+        sample_dataset = dataset.set_task(task)
+        self.assertGreater(len(sample_dataset), 0)
+        sample = sample_dataset[0]
+        self.assertIn("left_ama", sample)
+        self.assertIn("baseline_numeric", sample)
+        self.assertIn("mistrust_features", sample)
+        self.assertIn("conditions", sample)
+        sample_dataset.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# [PR] Add MIMIC-III Left-AMA Standalone Task with Mistrust-Feature Ablations

## Contributor

- Name: Joshua Wong
- NetID: jjwong4

## Type of Contribution

- Option 3: Standalone Task (task for existing supported PyHealth dataset)

## Original Paper (Reproducibility Link)

https://arxiv.org/abs/1808.03827

## High-Level Description

This PR adds a new MIMIC-III standalone task:
`AgainstMedicalAdvicePredictionMIMIC3`.

The task predicts whether an admission ends in
`LEFT AGAINST MEDICAL ADVI` (Left AMA) and supports configurable ablations:

- Baseline demographic/numeric features (age, LOS, gender, insurance)
- Optional race token features
- Optional lightweight note-derived mistrust features:
  noncompliance proxies and negative-sentiment proxy
- Cohort and note-configuration ablations for extension studies
  (for example, nursing-note-only features or stricter ICU-hour thresholds)

The implementation is reproducibility-oriented,
aligned with the paper’s Left AMA downstream task and ablation framing.

## Novelty Statement

This contribution is novel in two separate ways:

- **Novel in PyHealth:** the local PyHealth codebase did not already contain a
  standalone MIMIC-III Left AMA prediction task before this implementation.
- **Novel relative to the paper:** the paper's published Left AMA table only
  reports `Baseline`, `+Race`, `+Noncompliant`, `+Autopsy`,
  `+Negative-Sentiment`, and `+ALL`.
- **Executed off-paper ablations in this project:** `novel_nursing_all`
  restricts mistrust-note features to nursing notes only, and
  `novel_icu24_all` tightens the cohort from `min_icu_hours=12` to
  `min_icu_hours=24`.

So the PR is not just reformatting an existing PyHealth task, and the claimed
extension is not just repeating an ablation that already appears in the paper.

## File Guide (Suggested Review Order)

1. Core task implementation:
   - `pyhealth/tasks/against_medical_advice_prediction.py`
2. Task registration:
   - `pyhealth/tasks/__init__.py`
3. Task documentation:
   - `docs/api/tasks/pyhealth.tasks.against_medical_advice_prediction.rst`
   - `docs/api/tasks.rst`
4. Example ablation script:
   - `examples/mimic3_against_medical_advice_prediction_logistic_regression.py`
5. Synthetic tests:
   - `tests/core/test_against_medical_advice_prediction.py`

## Tests Run

- `python -m unittest -v tests/core/test_against_medical_advice_prediction.py`

All tests pass locally.

## Notes for Maintainers

- This PR does not add new external runtime dependencies.
- Mistrust note features are heuristic proxies for a lightweight reproducible
  baseline and are documented as such in task docs/docstrings.