### PR TITLE
Add melanoma artifact classification task

### DIFF
--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -230,3 +230,4 @@ Available Tasks
     Mutation Pathogenicity (COSMIC) <tasks/pyhealth.tasks.MutationPathogenicityPrediction>
     Cancer Survival Prediction (TCGA) <tasks/pyhealth.tasks.CancerSurvivalPrediction>
     Cancer Mutation Burden (TCGA) <tasks/pyhealth.tasks.CancerMutationBurden>
+    Melanoma Artifact Classification <tasks/pyhealth.tasks.melanoma_artifact_classification>

--- a/docs/api/tasks/pyhealth.tasks.melanoma_artifact_classification.rst
+++ b/docs/api/tasks/pyhealth.tasks.melanoma_artifact_classification.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.melanoma_artifact_classification
+===============================================
+
+.. autoclass:: pyhealth.tasks.MelanomaArtifactClassification
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/isic_melanoma_artifact_classification_resnet.py
+++ b/examples/isic_melanoma_artifact_classification_resnet.py
@@ -1,0 +1,45 @@
+import torch
+import torch.nn as nn
+import torchvision.models as models
+
+from pyhealth.tasks import MelanomaArtifactClassification
+
+
+class FakePatient:
+    def __init__(self, patient_id, image, label):
+        self.patient_id = patient_id
+        self.image = image
+        self.label = label
+
+
+def run_example(mode):
+    print(f"\nRunning mode: {mode}")
+
+    task = MelanomaArtifactClassification(mode=mode)
+
+    patients = [
+        FakePatient("p1", torch.randn(3, 224, 224), 1),
+        FakePatient("p2", torch.randn(3, 224, 224), 0),
+    ]
+
+    samples = []
+    for p in patients:
+        samples.extend(task(p))
+
+    X = torch.stack([s["image"] for s in samples])
+    y = torch.tensor([s["label"] for s in samples])
+
+    model = models.resnet50(weights=None)
+    model.fc = nn.Linear(model.fc.in_features, 1)
+
+    outputs = model(X).squeeze()
+    loss_fn = nn.BCEWithLogitsLoss()
+    loss = loss_fn(outputs, y.float())
+
+    print("Output shape:", outputs.shape)
+    print("Loss:", loss.item())
+
+
+if __name__ == "__main__":
+    run_example("whole")
+    run_example("background")

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -67,3 +67,4 @@ from .variant_classification import (
     VariantClassificationClinVar,
 )
 from .patient_linkage_mimic3 import PatientLinkageMIMIC3Task
+from .melanoma_artifact_classification import MelanomaArtifactClassification

--- a/pyhealth/tasks/melanoma_artifact_classification.py
+++ b/pyhealth/tasks/melanoma_artifact_classification.py
@@ -1,0 +1,73 @@
+from typing import Any, Dict, List
+
+import torch
+import torch.nn.functional as F
+
+from .base_task import BaseTask
+
+
+class MelanomaArtifactClassification(BaseTask):
+    """Task for binary melanoma classification with simple image perturbations.
+
+    Supports different modes to simulate the paper's idea of testing model
+    robustness under different image conditions.
+
+    Modes:
+        - "whole": original image
+        - "background": zero out center (simulate removing lesion)
+        - "low_freq": apply blur (simulate low-frequency emphasis)
+    """
+
+    task_name: str = "MelanomaArtifactClassification"
+    input_schema: Dict[str, str] = {
+        "image": "image",
+        "mode": "string",
+    }
+    output_schema: Dict[str, str] = {
+        "label": "binary",
+    }
+
+    def __init__(self, mode: str = "whole"):
+        self.mode = mode
+
+    def _apply_mode(self, image: torch.Tensor) -> torch.Tensor:
+        """Apply simple transformation based on mode."""
+
+        if self.mode == "whole":
+            return image
+
+        if self.mode == "background":
+            """Zero out center region (simulate removing lesion)"""
+            img = image.clone()
+            _, H, W = img.shape
+            h_start, h_end = H // 4, 3 * H // 4
+            w_start, w_end = W // 4, 3 * W // 4
+            img[:, h_start:h_end, w_start:w_end] = 0
+            return img
+
+        if self.mode == "low_freq":
+            """Apply simple blur using average pooling"""
+            return F.avg_pool2d(image.unsqueeze(0), kernel_size=5, stride=1, padding=2).squeeze(0)
+
+        return image
+
+    def __call__(self, patient: Any) -> List[Dict[str, Any]]:
+        image = getattr(patient, "image", None)
+        label = getattr(patient, "label", None)
+        patient_id = getattr(patient, "patient_id", None)
+
+        if image is None or label is None or patient_id is None:
+            return []
+
+        """Apply transformation"""
+        if isinstance(image, torch.Tensor):
+            image = self._apply_mode(image)
+
+        return [
+            {
+                "patient_id": patient_id,
+                "image": image,
+                "mode": self.mode,
+                "label": int(label),
+            }
+        ]

--- a/tests/core/test_melanoma_artifact_classification.py
+++ b/tests/core/test_melanoma_artifact_classification.py
@@ -1,0 +1,92 @@
+import unittest
+from typing import Any
+
+from pyhealth.tasks import MelanomaArtifactClassification
+
+
+class FakePatient:
+    def __init__(self, patient_id: str, image: Any = None, label: Any = None):
+        self.patient_id = patient_id
+        self.image = image
+        self.label = label
+
+
+class TestMelanomaArtifactClassification(unittest.TestCase):
+
+    def setUp(self):
+        self.task = MelanomaArtifactClassification(mode="whole")
+
+    def test_valid_patient(self):
+        patient = FakePatient(
+            patient_id="p1",
+            image="fake_image_path.jpg",
+            label=1
+        )
+
+        output = self.task(patient)
+
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0]["patient_id"], "p1")
+        self.assertEqual(output[0]["image"], "fake_image_path.jpg")
+        self.assertEqual(output[0]["label"], 1)
+        self.assertEqual(output[0]["mode"], "whole")
+
+    def test_missing_image(self):
+        patient = FakePatient(
+            patient_id="p2",
+            image=None,
+            label=1
+        )
+
+        output = self.task(patient)
+        self.assertEqual(output, [])
+
+    def test_missing_label(self):
+        patient = FakePatient(
+            patient_id="p3",
+            image="fake.jpg",
+            label=None
+        )
+
+        output = self.task(patient)
+        self.assertEqual(output, [])
+
+    def test_missing_patient_id(self):
+        patient = FakePatient(
+            patient_id=None,
+            image="fake.jpg",
+            label=1
+        )
+
+        output = self.task(patient)
+        self.assertEqual(output, [])
+
+    def test_different_mode(self):
+        task = MelanomaArtifactClassification(mode="background")
+
+        patient = FakePatient(
+            patient_id="p4",
+            image="fake.jpg",
+            label=0
+        )
+
+        output = task(patient)
+
+        self.assertEqual(output[0]["mode"], "background")
+
+    def test_mode_changes_image(self):
+        import torch
+
+        patient = FakePatient(
+            patient_id="p5",
+            image=torch.ones(3, 10, 10),
+            label=1
+        )
+
+        task = MelanomaArtifactClassification(mode="background")
+        output = task(patient)
+        img = output[0]["image"]
+        self.assertTrue((img[:, 3:7, 3:7] == 0).all())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Contributor:** Sunny Chen, sunnyc3, sunnyc3@illinois.edu, sunnychen0509@gmail.com (github)

**Contribution Type:** Standalone Task

**Paper:** A Study of Artifacts on Melanoma Classification under Diffusion-Based Perturbations (Jin et al., 2025), https://proceedings.mlr.press/v287/jin25b.html

**Description:**
This PR introduces a new task, `MelanomaArtifactClassification`, for binary melanoma classification using dermoscopic images. The task is designed to study model robustness under different image perturbation modes inspired by the paper.

The task supports multiple modes:
- "whole": original image
- "background": center region removed (simulates lesion removal)
- "low_freq": blurred image (simulates low-frequency filtering)

This allows simple ablation studies to analyze how different image conditions affect classification performance.

**Files to Review:**
- `pyhealth/tasks/melanoma_artifact_classification.py` – core task implementation
- `tests/core/test_melanoma_artifact_classification.py` – unit tests using synthetic data
- `examples/isic_melanoma_artifact_classification_resnet.py` – example usage and ablation study
- `docs/api/tasks/pyhealth.tasks.melanoma_artifact_classification.rst` – documentation

**Notes:**
- Uses lightweight transformations instead of full diffusion models for simplicity
- Focuses on task-level reproducibility and robustness analysis