### PR TITLE
Add LLMSYN: LLM-based Synthetic EHR Generation (Hao et al., MLHC 2024)

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -206,3 +206,4 @@ API Reference
     models/pyhealth.models.BIOT
     models/pyhealth.models.unified_multimodal_embedding_docs
     models/pyhealth.models.califorest
+    models/pyhealth.models.LLMSYNModel

--- a/docs/api/models/pyhealth.models.LLMSYNModel.rst
+++ b/docs/api/models/pyhealth.models.LLMSYNModel.rst
@@ -1,0 +1,15 @@
+pyhealth.models.LLMSYNModel
+===================================
+
+LLM-based Synthetic EHR Generation (LLMSYN) using a 4-step Markov pipeline.
+Supports three ablation variants from the paper: LLMSYNfull, LLMSYNprior,
+and LLMSYNbase.
+
+Reference:
+    Hao et al., "LLMSYN: Generating Synthetic Electronic Health Records
+    Without Patient-Level Data", MLHC 2024, PMLR 252.
+
+.. autoclass:: pyhealth.models.LLMSYNModel
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -230,3 +230,4 @@ Available Tasks
     Mutation Pathogenicity (COSMIC) <tasks/pyhealth.tasks.MutationPathogenicityPrediction>
     Cancer Survival Prediction (TCGA) <tasks/pyhealth.tasks.CancerSurvivalPrediction>
     Cancer Mutation Burden (TCGA) <tasks/pyhealth.tasks.CancerMutationBurden>
+    Synthetic EHR Generation (LLMSYN) <tasks/pyhealth.tasks.SyntheticEHRGenerationTask>

--- a/docs/api/tasks/pyhealth.tasks.SyntheticEHRGenerationTask.rst
+++ b/docs/api/tasks/pyhealth.tasks.SyntheticEHRGenerationTask.rst
@@ -1,0 +1,11 @@
+pyhealth.tasks.SyntheticEHRGenerationTask
+==========================================
+
+Task for LLMSYN synthetic EHR generation evaluated via TSTR
+(Train-on-Synthetic, Test-on-Real). Converts real MIMIC-III admissions
+into samples for use with :class:`~pyhealth.models.LLMSYNModel`.
+
+.. autoclass:: pyhealth.tasks.SyntheticEHRGenerationTask
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/llmsyn_mimic3_synthetic_ehr.py
+++ b/examples/llmsyn_mimic3_synthetic_ehr.py
@@ -1,0 +1,234 @@
+"""
+LLMSYN: Synthetic EHR Generation on MIMIC-III (Hao et al., MLHC 2024).
+
+Demonstrates all three ablation variants from the paper:
+  - LLMSYNfull  : prior statistics + Mayo Clinic RAG (best performance)
+  - LLMSYNprior : prior statistics only
+  - LLMSYNbase  : minimal prompts, single sampled disease per record
+
+Prerequisites:
+  - MIMIC-III 1.4 access via PhysioNet (ADMISSIONS.csv, DIAGNOSES_ICD.csv,
+    D_ICD_DIAGNOSES.csv, PATIENTS.csv)
+  - For real LLM generation: set OPENAI_API_KEY or ANTHROPIC_API_KEY
+  - For RAG (LLMSYNfull): pip install requests beautifulsoup4
+
+Reference:
+    Hao et al., "LLMSYN: Generating Synthetic Electronic Health Records
+    Without Patient-Level Data", MLHC 2024, PMLR 252.
+    https://proceedings.mlr.press/v252/hao24a.html
+"""
+
+import json
+
+from pyhealth.datasets import MIMIC3Dataset, create_sample_dataset, get_dataloader, split_by_patient
+from pyhealth.models import LLMSYNModel
+from pyhealth.tasks import SyntheticEHRGenerationTask
+from pyhealth.trainer import Trainer
+
+
+# ---------------------------------------------------------------------------
+# Configuration — update these paths for your environment
+# ---------------------------------------------------------------------------
+
+# Path to pre-computed stats JSON (run compute_all_stats() once to generate it,
+# or use the bundled file from test-resources/llmsyn/stats.json)
+STATS_PATH = "test-resources/llmsyn/stats.json"
+
+# Path to MIMIC-III data directory (must contain .csv.gz files incl. ICUSTAYS.csv.gz)
+# Using bundled demo data for quick testing — replace with full MIMIC-III 1.4 for real use
+MIMIC3_ROOT = "test-resources/core/mimic3demo"
+
+
+LLM_PROVIDER = "mock"      # "mock" | "openai" | "claude"
+API_KEY = None             # set if using "openai" or "claude"
+N_GENERATE = 10            # synthetic records to generate per variant
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Compute or load prior statistics from MIMIC-III
+# ---------------------------------------------------------------------------
+
+def get_stats(stats_path: str) -> dict:
+    print(f"Loading stats from {stats_path}")
+    with open(stats_path) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Step 2a: Load MIMIC-III dataset and apply SyntheticEHRGenerationTask
+#           (requires full MIMIC-III 1.4 download with ICUSTAYS.csv.gz)
+# ---------------------------------------------------------------------------
+
+def load_sample_dataset(mimic3_root: str):
+    print("\n=== Step 2a: Loading MIMIC-III and applying task ===")
+    base_dataset = MIMIC3Dataset(
+        root=mimic3_root,
+        tables=["diagnoses_icd"],
+        dev=True,  # remove for full dataset
+    )
+    task = SyntheticEHRGenerationTask()
+    sample_dataset = base_dataset.set_task(task)
+    print(f"Total samples: {len(sample_dataset)}")
+    print(f"Input schema : {task.input_schema}")
+    print(f"Output schema: {task.output_schema}")
+    return sample_dataset
+
+
+# ---------------------------------------------------------------------------
+# Step 2b: Create a small in-memory dataset for quick testing / TSTR demo
+#           (no MIMIC-III download required — uses create_sample_dataset)
+# ---------------------------------------------------------------------------
+
+_ICD9_POOL = [
+    ["250.00", "401.9", "428.0"],   # diabetes + hypertension + heart failure
+    ["410.71", "414.01", "272.4"],  # MI + coronary artery disease + hyperlipidemia
+    ["486", "496", "491.21"],       # pneumonia + COPD + acute exacerbation
+    ["584.9", "585.9", "403.90"],   # AKI + CKD + hypertensive CKD
+    ["038.9", "995.91", "785.52"],  # sepsis + SIRS + septic shock
+]
+
+
+def create_mock_sample_dataset():
+    """Build a 20-patient in-memory dataset using create_sample_dataset.
+
+    Returns a SampleDataset compatible with split_by_patient and LLMSYNModel
+    without requiring any MIMIC-III files.  Each of the 20 mock patients has
+    1–2 admissions drawn from a small pool of common ICD-9 clusters.
+    """
+    print("\n=== Step 2b: Creating mock in-memory dataset ===")
+    task = SyntheticEHRGenerationTask()
+    samples = []
+    for i in range(20):
+        pid = f"P{i:03d}"
+        for j in range(1 + (i % 2)):          # 1 or 2 visits per patient
+            samples.append({
+                "patient_id": pid,
+                "visit_id": f"V{i:03d}_{j}",
+                "conditions": _ICD9_POOL[i % len(_ICD9_POOL)],
+                "mortality": 1 if i % 10 == 0 else 0,
+            })
+    sample_dataset = create_sample_dataset(
+        samples=samples,
+        input_schema=task.input_schema,
+        output_schema=task.output_schema,
+        task_name=task.task_name,
+    )
+    print(f"Mock samples : {len(sample_dataset)}")
+    return sample_dataset
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Run all three ablation variants
+# ---------------------------------------------------------------------------
+
+VARIANTS = {
+    "LLMSYNfull" : {"prior_mode": "full",    "enable_rag": True},
+    "LLMSYNprior": {"prior_mode": "full",    "enable_rag": False},
+    "LLMSYNbase" : {"prior_mode": "sampled", "enable_rag": False},
+}
+
+
+def run_variants(sample_dataset, stats: dict):
+    print(f"\n=== Step 3: Generating {N_GENERATE} records per variant ===")
+    results = {}
+    for name, cfg in VARIANTS.items():
+        print(f"\n--- {name} ---")
+        model = LLMSYNModel(
+            dataset=sample_dataset,
+            llm_provider=LLM_PROVIDER,
+            api_key=API_KEY,
+            stats=stats,
+            prior_mode=cfg["prior_mode"],
+            enable_rag=cfg["enable_rag"],
+            noise_scale=0.05,
+            seed=42,
+        )
+        records = model.generate(n=N_GENERATE)
+        results[name] = records
+
+        # Print first record summary
+        r = records[0]
+        print(f"  Age        : {r['Age']}")
+        print(f"  Gender     : {r['Gender']}")
+        print(f"  Survived   : {r['Survived']}")
+        print(f"  MainDx     : {r['MainDiagnosis']}")
+        print(f"  Comps      : {r['Complications']}")
+        print(f"  Procedures : {r['Procedures']}")
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Step 4: TSTR forward pass (optional — shows PyHealth training integration)
+# ---------------------------------------------------------------------------
+
+def run_tstr(sample_dataset, stats: dict):
+    print("\n=== Step 4: TSTR forward pass (LLMSYNprior) ===")
+    train_ds, val_ds, test_ds = split_by_patient(sample_dataset, [0.7, 0.15, 0.15])
+    train_loader = get_dataloader(train_ds, batch_size=16, shuffle=True)
+    val_loader   = get_dataloader(val_ds,   batch_size=16, shuffle=False)
+    test_loader  = get_dataloader(test_ds,  batch_size=16, shuffle=False)
+
+    model = LLMSYNModel(
+        dataset=sample_dataset,
+        llm_provider=LLM_PROVIDER,
+        api_key=API_KEY,
+        stats=stats,
+        prior_mode="full",
+        enable_rag=False,
+        seed=0,
+    )
+
+    trainer = Trainer(model=model, metrics=["pr_auc", "roc_auc"])
+    trainer.train(
+        train_dataloader=train_loader,
+        val_dataloader=val_loader,
+        epochs=3,
+        monitor="pr_auc",
+    )
+
+    print("\nTest Results (TSTR):")
+    results = trainer.evaluate(test_loader)
+    for metric, value in results.items():
+        print(f"  {metric}: {value:.4f}")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print("=" * 60)
+    print("LLMSYN: SYNTHETIC EHR GENERATION ON MIMIC-III")
+    print("=" * 60)
+
+    # Step 1: stats
+    print("\n=== Step 1: Prior statistics ===")
+    stats = get_stats(STATS_PATH)
+    print(f"Mortality rate : {stats['mortality_rate']:.4f}")
+    print(f"Top disease    : {stats['top_diseases'][0]['icd9_code']} — "
+          f"{stats['top_diseases'][0]['desc']}")
+
+    # Step 2: dataset
+    # Option A — real MIMIC-III (requires download + ICUSTAYS.csv.gz):
+    sample_dataset = load_sample_dataset(MIMIC3_ROOT)
+    # Option B — quick in-memory mock (no download needed):
+    # sample_dataset = create_mock_sample_dataset()
+
+    # Step 3: generate with all 3 variants
+    run_variants(sample_dataset, stats)
+
+    # Step 4: TSTR training loop — uses mock dataset so it always runs
+    # To use real data instead: run_tstr(sample_dataset, stats)
+    run_tstr(sample_dataset, stats)   # real data
+    # mock_ds = create_mock_sample_dataset()
+    # run_tstr(mock_ds, stats)
+
+    print("\n" + "=" * 60)
+    print("DONE")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/llmsyn_validation.py
+++ b/examples/llmsyn_validation.py
@@ -1,0 +1,727 @@
+"""
+LLMSYN Validation: Random Forest TSTR Pipeline for Synthetic EHR Evaluation.
+
+This script implements the validation methodology from:
+  Hao et al., "LLMSYN: Generating Synthetic Electronic Health Records
+  Without Patient-Level Data", MLHC 2024 (PMLR 252).
+  https://proceedings.mlr.press/v252/hao24a.html
+
+Key components:
+  - Synthetic EHR generation via PyHealth's LLMSYNModel (4-step Markov pipeline)
+  - Train-on-Synthetic, Test-on-Real (TSTR) evaluation with Random Forest
+  - Mortality prediction (binary) + Phenotype prediction (multi-label, top-10 ICD-9)
+  - Metrics: Accuracy, AUROC, F1, K-S statistic, MMD, k-anonymity
+
+================================================================================
+PREREQUISITES (full setup, ~10-20 min on a clean machine)
+================================================================================
+
+1) PYTHON VERSION
+   PyHealth requires Python >=3.12, <3.14. Recommended: Python 3.13.
+     macOS:   brew install python@3.13
+     Linux:   sudo apt install python3.13 python3.13-venv
+     Verify:  python3.13 --version   # -> Python 3.13.x
+
+   Common gotcha (macOS): if `python --version` reports 3.14 even after
+   creating a 3.13 venv, you likely have `alias python="..."` in ~/.zshrc.
+   Fix in current shell:  unalias python
+   Permanent fix:         sed -i '' 's/^alias python=/# alias python=/' ~/.zshrc
+
+2) VIRTUAL ENVIRONMENT (use absolute path to avoid PATH conflicts)
+     cd /path/to/PyHealth-master
+     /opt/homebrew/bin/python3.13 -m venv examples/path/to/venv
+     source examples/path/to/venv/bin/activate
+     python --version   # MUST be 3.13.x
+
+3) INSTALL PYHEALTH + ALL DEPENDENCIES (editable install pulls everything)
+     pip install --upgrade pip
+     pip install -e .
+   This installs torch, transformers, polars, pydantic, dask, rdkit, etc.
+   ~5-10 min download. Do NOT install packages individually.
+
+4) MIMIC-III DEMO DATA (already in repo, no download needed)
+   Located at: test-resources/core/mimic3demo/ (gz CSV files, 100 patients).
+   For full MIMIC-III access (paper-quality numbers), credential at PhysioNet:
+     https://physionet.org/content/mimiciii/1.4/   (requires CITI training)
+
+5) LLMSYN STATS FILE (already in repo)
+   Located at: test-resources/llmsyn/stats.json
+   Pre-computed prior statistics from real MIMIC-III (mortality_rate=0.0993,
+   100 top diagnosis codes, demographic distributions).
+
+6) LLM PROVIDER (CHOOSE ONE)
+   This script defaults to LLM_PROVIDER="mock" (no API call, no cost, but
+   produces single-class outputs so AUROC stays at 0.5).
+
+   For real paper-quality numbers, switch to a real LLM:
+
+   Option A - Anthropic Claude (recommended):
+     1. Sign up at https://console.anthropic.com/, add >=$5 credit.
+     2. Create API key (Settings -> API Keys).
+     3. export ANTHROPIC_API_KEY=sk-ant-...
+     4. Set LLM_PROVIDER = "claude" below.
+
+   Option B - OpenAI:
+     1. Sign up at https://platform.openai.com/, add credit.
+     2. Create API key at https://platform.openai.com/api-keys
+     3. export OPENAI_API_KEY=sk-...
+     4. Set LLM_PROVIDER = "openai" below.
+
+   Option C - Mock backend (default, no cost, no API call):
+     Set LLM_PROVIDER = "mock" below. Uses PyHealth's built-in
+     _MockLLMBackend (pyhealth/models/llmsyn.py), which exercises the full
+     4-step pipeline (prompts, parser, RAG hooks, schema validation) but
+     returns deterministic placeholder strings instead of calling an LLM.
+     Useful for: smoke-testing the pipeline, CI, debugging code paths.
+     Caveat: mock outputs are single-class (Survived="Yes" always), so
+     downstream AUROC will be 0.5 by construction. Don't use mock numbers
+     for any paper / report.
+
+   COST ESTIMATE: each synthetic record requires 4 LLM calls (4-step Markov
+   chain: demographics -> main_dx -> complications -> procedures). Plus RAG
+   lookups if enable_rag=True. Rough cost (Claude Haiku):
+       N=5    -> ~$0.10   (smoke test)
+       N=100  -> ~$2-5    (paper-quality experiment)
+
+================================================================================
+USAGE
+================================================================================
+
+   cd examples
+   python llmsyn_validation.py
+
+Outputs to stdout: dataset stats, per-task metrics, final results dict.
+
+================================================================================
+CONFIGURATION (edit constants below)
+================================================================================
+
+   N_SYNTHETIC      # how many synthetic records to generate (5 for smoke test, 100+ for paper)
+   USE_REAL_DATA    # True -> load real MIMIC-III demo; False -> use mock data
+   USE_REAL_LLMSYN  # True -> call LLMSYNModel; False -> use built-in mock generator
+   LLM_PROVIDER     # "mock" | "claude" | "openai"
+
+================================================================================
+GRACEFUL FALLBACKS (script will not crash if any of these fail)
+================================================================================
+
+   - PyHealth import fails              -> use _load_mock_dataset()
+   - MIMIC-III demo files missing       -> use _load_mock_dataset()
+   - LLMSYN imports fail                -> use _generate_mock_synthetic()
+   - API key missing for non-mock LLM   -> use _generate_mock_synthetic()
+   - LLMSYNModel.generate() raises      -> use _generate_mock_synthetic()
+   - Single-class label edge cases      -> AUROC/F1 reported as NaN (no crash)
+
+================================================================================
+FILE LAYOUT
+================================================================================
+
+   load_real_dataset()              # MIMIC-III demo loader (PyHealth API)
+   _load_mock_dataset()             # numpy-only fallback for real data
+   generate_synthetic_data()        # entry point: real LLMSYN or mock fallback
+   _generate_mock_synthetic()       # numpy-only fallback for synthetic data
+   train_random_forest()            # Mortality task: RF on synthetic
+   evaluate_on_real_data()          # Mortality task: TSTR + ACC/AUROC/F1/K-S
+   compute_additional_metrics()     # MMD + k-anonymity
+   train_phenotype_rf()             # Phenotype task: one RF per top-10 ICD-9
+   evaluate_phenotype_on_real()     # Phenotype task: macro ACC/AUROC/F1
+   main()                           # orchestrates the 7-step pipeline
+
+================================================================================
+"""
+
+
+import json
+import os
+import sys
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score, roc_auc_score, f1_score, roc_curve
+
+# Allow running from examples/ directory
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Try to import PyHealth; fall back to mock data if unavailable
+try:
+    from pyhealth.datasets import MIMIC3Dataset
+    PYHEALTH_AVAILABLE = True
+except Exception as _e:
+    print(f"[warn] PyHealth import failed ({_e}); will use mock data.")
+    MIMIC3Dataset = None
+    PYHEALTH_AVAILABLE = False
+
+# from pyhealth.models import LLMSYNModel
+# from pyhealth.tasks import MortalityPredictionTask
+# from pyhealth.metrics import binary_metrics_fn
+
+
+# Configuration
+STATS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test-resources/llmsyn/stats.json"))
+MIMIC3_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test-resources/core/mimic3demo"))
+N_SYNTHETIC = 100  # Number of synthetic records to generate (small for API smoke test; bump to 100+ for paper)
+USE_REAL_DATA = True  # Set False to force mock data even if PyHealth is available
+USE_REAL_LLMSYN = True  # Set False to force mock synthetic generator
+LLM_PROVIDER = "mock"  # "mock" | "openai" | "claude"
+API_KEY = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("OPENAI_API_KEY")
+
+# Top ICD-9 phenotype codes for multi-label prediction (from MIMIC-III stats)
+TOP_PHENOTYPES = ["4019", "4280", "42731", "41401", "5849", "25000", "2724", "51881", "5990", "53081"]
+
+
+def _load_mock_dataset():
+    """Fallback mock real dataset (used when PyHealth or demo files unavailable)."""
+    print("Loading mock real MIMIC-III dataset...")
+    rng = np.random.default_rng(42)
+    base_samples = [
+        {"conditions": ["4019", "41401"], "mortality": 0},
+        {"conditions": ["4280", "42731"], "mortality": 1},
+        {"conditions": ["5849"], "mortality": 1},
+        {"conditions": ["25000", "2724"], "mortality": 0},
+        {"conditions": ["486", "496"], "mortality": 1},
+        {"conditions": ["41071", "41401"], "mortality": 0},
+        {"conditions": ["0389", "99591"], "mortality": 1},
+        {"conditions": ["40390", "5859"], "mortality": 0},
+        {"conditions": ["49121"], "mortality": 1},
+        {"conditions": ["4019", "4280", "42731"], "mortality": 1},
+    ]
+    mock_samples = []
+    for s in base_samples * 10:
+        enriched = dict(s)
+        enriched["age"] = int(rng.integers(40, 90))
+        enriched["gender"] = "Female" if rng.random() > 0.5 else "Male"
+        enriched["ethnicity"] = str(rng.choice(["WHITE", "BLACK", "HISPANIC", "ASIAN"]))
+        enriched["insurance"] = str(rng.choice(["Medicare", "Private", "Medicaid"]))
+        mock_samples.append(enriched)
+    print(f"Mock real dataset: {len(mock_samples)} samples")
+    return mock_samples
+
+
+def load_real_dataset():
+    """Load real MIMIC-III demo dataset via PyHealth's MIMIC3Dataset.
+
+    Returns a list of per-visit dicts with:
+      - conditions: list[str] of ICD-9 diagnosis codes
+      - mortality: 0/1 (HOSPITAL_EXPIRE_FLAG)
+      - age, gender, ethnicity, insurance: demographics
+
+    Falls back to mock data if PyHealth is unavailable, demo files are missing,
+    or USE_REAL_DATA is False.
+    """
+    if not USE_REAL_DATA:
+        print("USE_REAL_DATA=False; using mock dataset.")
+        return _load_mock_dataset()
+    if not PYHEALTH_AVAILABLE:
+        print("PyHealth unavailable; falling back to mock dataset.")
+        return _load_mock_dataset()
+    if not os.path.isdir(MIMIC3_ROOT):
+        print(f"MIMIC-III demo files not found at {MIMIC3_ROOT}; falling back to mock dataset.")
+        return _load_mock_dataset()
+
+    print(f"Loading real MIMIC-III demo dataset from {MIMIC3_ROOT}...")
+    try:
+        dataset = MIMIC3Dataset(
+            root=MIMIC3_ROOT,
+            tables=["diagnoses_icd"],
+            dev=True,
+        )
+    except Exception as e:
+        print(f"[warn] MIMIC3Dataset load failed ({e}); falling back to mock dataset.")
+        return _load_mock_dataset()
+
+    samples = []
+    try:
+        for patient in dataset.iter_patients():
+            # Patient-level demographics
+            gender = "Unknown"
+            dob = None
+            patient_events = patient.get_events(event_type="patients")
+            if patient_events:
+                pe = patient_events[0]
+                gender = pe.attr_dict.get("gender", "Unknown")
+                dob = pe.attr_dict.get("dob", None)
+
+            # One sample per admission
+            for adm in patient.get_events(event_type="admissions"):
+                hadm_id = adm.attr_dict.get("hadm_id")
+                mortality = 1 if int(adm.attr_dict.get("hospital_expire_flag", 0) or 0) == 1 else 0
+                ethnicity = adm.attr_dict.get("ethnicity", "WHITE") or "WHITE"
+                insurance = adm.attr_dict.get("insurance", "Medicare") or "Medicare"
+
+                # Conditions for this admission
+                conditions = []
+                for dx in patient.get_events(event_type="diagnoses_icd"):
+                    if dx.attr_dict.get("hadm_id") == hadm_id:
+                        code = dx.attr_dict.get("icd9_code")
+                        if code:
+                            conditions.append(str(code))
+                if not conditions:
+                    continue
+
+                # Age at admission
+                age = 65
+                if dob is not None and adm.timestamp is not None:
+                    try:
+                        age = max(0, int((adm.timestamp - dob).days / 365.25))
+                        if age > 110:  # MIMIC-III obfuscates ages >89 to ~300
+                            age = 90
+                    except Exception:
+                        age = 65
+
+                samples.append({
+                    "conditions": conditions,
+                    "mortality": mortality,
+                    "age": age,
+                    "gender": "Female" if str(gender).upper().startswith("F") else "Male",
+                    "ethnicity": str(ethnicity).split()[0].upper(),
+                    "insurance": str(insurance),
+                })
+    except Exception as e:
+        print(f"[warn] Failed to iterate MIMIC-III patients ({e}); falling back to mock dataset.")
+        import traceback
+        traceback.print_exc()
+        return _load_mock_dataset()
+
+    if not samples:
+        print("[warn] No usable samples extracted from MIMIC-III demo; falling back to mock.")
+        return _load_mock_dataset()
+
+    print(f"Loaded {len(samples)} real MIMIC-III demo visits")
+    return samples
+
+
+def _generate_mock_synthetic(n_samples):
+    """Mock synthetic generator (used when LLMSYN unavailable / no API key)."""
+    print(f"Generating {n_samples} mock synthetic EHR records...")
+    mock_records = []
+    for i in range(n_samples):
+        age = np.random.randint(40, 90)
+        gender = "Female" if np.random.rand() > 0.5 else "Male"
+        ethnicity = np.random.choice(["WHITE", "BLACK", "HISPANIC", "ASIAN"])
+        insurance = np.random.choice(["Medicare", "Private", "Medicaid"])
+        survived = "Yes" if np.random.rand() > 0.5 else "No"
+        main_dx = np.random.choice(["4019", "4280", "42731", "41401", "5849", "25000"])
+        num_comp = np.random.randint(0, 3)
+        comps = np.random.choice(["4280", "42731", "41401", "5849", "25000"], num_comp, replace=False)
+        has_proc = np.random.rand() > 0.7
+        procs = ["CPT:93000"] if has_proc else []
+        mock_records.append({
+            "Age": str(age),
+            "Gender": gender,
+            "Ethnicity": ethnicity,
+            "Insurance": insurance,
+            "Survived": survived,
+            "MainDiagnosis": f"ICD9:{main_dx}",
+            "Complications": [f"ICD9:{c}" for c in comps],
+            "Procedures": procs,
+        })
+    print(f"Generated {len(mock_records)} mock synthetic records")
+    return mock_records
+
+
+def generate_synthetic_data(n_samples):
+    """Generate synthetic EHR records via real LLMSYN if available, else mock."""
+    if not USE_REAL_LLMSYN:
+        print("USE_REAL_LLMSYN=False; using mock generator.")
+        return _generate_mock_synthetic(n_samples)
+    if not PYHEALTH_AVAILABLE:
+        print("PyHealth unavailable; using mock generator.")
+        return _generate_mock_synthetic(n_samples)
+    if LLM_PROVIDER != "mock" and not API_KEY:
+        print(f"No API key for {LLM_PROVIDER} (set ANTHROPIC_API_KEY or OPENAI_API_KEY); using mock generator.")
+        return _generate_mock_synthetic(n_samples)
+    if not os.path.isfile(STATS_PATH):
+        print(f"Stats file not found at {STATS_PATH}; using mock generator.")
+        return _generate_mock_synthetic(n_samples)
+
+    try:
+        from pyhealth.models import LLMSYNModel
+        from pyhealth.datasets import create_sample_dataset
+        from pyhealth.tasks import SyntheticEHRGenerationTask
+    except Exception as e:
+        print(f"[warn] LLMSYN imports failed ({e}); using mock generator.")
+        return _generate_mock_synthetic(n_samples)
+
+    print(f"Generating {n_samples} synthetic EHR records via LLMSYN ({LLM_PROVIDER})...")
+    try:
+        with open(STATS_PATH) as f:
+            stats = json.load(f)
+
+        # Build a tiny seed sample dataset (LLMSYNModel requires it for schema)
+        task = SyntheticEHRGenerationTask()
+        seed_samples = [
+            {
+                "patient_id": "P000",
+                "visit_id": "V000",
+                "conditions": ["4019", "41401"],
+                "mortality": 0,
+            },
+            {
+                "patient_id": "P001",
+                "visit_id": "V001",
+                "conditions": ["4280", "42731"],
+                "mortality": 1,
+            },
+        ]
+        seed_dataset = create_sample_dataset(
+            samples=seed_samples,
+            input_schema=task.input_schema,
+            output_schema=task.output_schema,
+            task_name=task.task_name,
+        )
+
+        model = LLMSYNModel(
+            dataset=seed_dataset,
+            llm_provider=LLM_PROVIDER,
+            api_key=API_KEY,
+            stats=stats,
+            prior_mode="full",
+            enable_rag=True,
+            noise_scale=0.05,
+            seed=42,
+        )
+        records = model.generate(n=n_samples)
+        print(f"Generated {len(records)} LLMSYN synthetic records")
+        return records
+    except Exception as e:
+        print(f"[warn] LLMSYN generation failed ({e}); falling back to mock generator.")
+        import traceback
+        traceback.print_exc()
+        return _generate_mock_synthetic(n_samples)
+
+
+def preprocess_synthetic_for_training(synthetic_records):
+    """Convert synthetic records to feature vectors for Random Forest.
+    
+    Features (to match real data):
+    - Num_diagnoses (int): total number of diagnosis codes
+    - Has_procedures (0/1): whether procedures are present
+    - Age (float): patient age
+    
+    Label: Mortality (0=deceased, 1=survived)
+    """
+    print("Preprocessing synthetic data for training...")
+    
+    X = []
+    y = []
+    
+    for record in synthetic_records:
+        # Extract diagnosis codes
+        diagnoses = []
+        main_dx = record.get("MainDiagnosis", "")
+        if main_dx:
+            diagnoses.append(main_dx.replace("ICD9:", ""))
+        
+        complications = record.get("Complications", [])
+        if isinstance(complications, str):
+            complications = [c.strip().replace("ICD9:", "") for c in complications.split(",") if c.strip()]
+        diagnoses.extend(complications)
+        
+        num_diagnoses = len(diagnoses)
+        
+        # Procedures
+        procedures = record.get("Procedures", [])
+        if isinstance(procedures, str):
+            procedures = [p.strip() for p in procedures.split(",") if p.strip()]
+        has_procedures = 1 if procedures else 0
+        
+        # Age
+        age = float(record.get("Age", 65))
+        
+        # Feature vector
+        features = [num_diagnoses, has_procedures, age]
+        X.append(features)
+        
+        # Label: Survived (1=Yes/survived, 0=No/deceased)
+        survived = 1 if record.get("Survived") == "Yes" else 0
+        y.append(survived)
+    
+    X = np.array(X)
+    y = np.array(y)
+    print(f"Preprocessed {len(X)} synthetic samples with {X.shape[1]} features")
+    return X, y
+
+
+def train_random_forest(X_train, y_train):
+    """Train Random Forest on synthetic data.
+
+    If only a single class is present in y_train, RandomForest still fits but
+    predict_proba will return shape (n, 1). The downstream evaluator handles this.
+    """
+    print("Training Random Forest on synthetic data...")
+    n_classes = len(np.unique(y_train))
+    if n_classes < 2:
+        print(f"  [warn] Synthetic labels are single-class (only {n_classes}); RF will degenerate.")
+    rf = RandomForestClassifier(n_estimators=100, random_state=42)
+    rf.fit(X_train, y_train)
+    return rf
+
+
+def evaluate_on_real_data(rf_model, real_dataset):
+    """Test trained model on real MIMIC-III data and compute metrics."""
+    print("Evaluating on real data...")
+    
+    X_real = []
+    y_real = []
+    
+    for sample in real_dataset:
+        conditions = sample.get("conditions", [])
+        num_diagnoses = len(conditions)
+        has_procedures = 0  # No procedures in this task
+        age = float(sample.get("age", 65))
+        
+        features = [num_diagnoses, has_procedures, age]
+        X_real.append(features)
+        
+        mortality = sample.get("mortality", 0)
+        y_real.append(mortality)
+    
+    X_real = np.array(X_real)
+    y_real = np.array(y_real)
+    
+    print(f"Real test set: {len(X_real)} samples")
+    
+    # Predict
+    y_pred = rf_model.predict(X_real)
+    proba = rf_model.predict_proba(X_real)
+    if proba.shape[1] >= 2:
+        y_pred_prob = proba[:, 1]
+    else:
+        # Single-class training set: positive-class prob = the only class iff it's 1
+        only_class = int(rf_model.classes_[0])
+        y_pred_prob = np.full(len(X_real), float(only_class))
+    
+    # Compute metrics (guard against single-class real labels)
+    acc = accuracy_score(y_real, y_pred)
+    if len(np.unique(y_real)) < 2:
+        print("  [warn] Real labels are single-class; AUROC/F1/K-S undefined.")
+        auc, f1, ks = float("nan"), float("nan"), float("nan")
+    else:
+        auc = roc_auc_score(y_real, y_pred_prob)
+        f1 = f1_score(y_real, y_pred, zero_division=0)
+        fpr, tpr, _ = roc_curve(y_real, y_pred_prob)
+        ks = float(max(tpr - fpr))
+    
+    print(f"  Accuracy:     {acc:.4f}")
+    print(f"  AUROC:        {auc:.4f}")
+    print(f"  F1 Score:     {f1:.4f}")
+    print(f"  K-S Stat:     {ks:.4f}")
+    
+    return {
+        "accuracy": acc,
+        "auc": auc,
+        "f1": f1,
+        "ks": ks,
+    }
+
+
+def compute_additional_metrics(synthetic_records, real_dataset, X_synth, X_real):
+    """Compute MMD, k-anonymity, and other metrics."""
+    print("Computing additional metrics...")
+    
+    # MMD (Maximum Mean Discrepancy) using RBF kernel
+    def rbf_kernel(X, Y, sigma=1.0):
+        """Compute RBF kernel between two sets."""
+        X = X.reshape(X.shape[0], -1)
+        Y = Y.reshape(Y.shape[0], -1)
+        X_norm = np.sum(X ** 2, axis=1).reshape(-1, 1)
+        Y_norm = np.sum(Y ** 2, axis=1).reshape(1, -1)
+        dist = X_norm + Y_norm - 2 * np.dot(X, Y.T)
+        return np.exp(-dist / (2 * sigma ** 2))
+    
+    K_xx = rbf_kernel(X_synth, X_synth)
+    K_yy = rbf_kernel(X_real, X_real)
+    K_xy = rbf_kernel(X_synth, X_real)
+    
+    mmd = np.mean(K_xx) + np.mean(K_yy) - 2 * np.mean(K_xy)
+    
+    # k-anonymity: simple check - number of unique synthetic records
+    # In reality, k-anonymity checks if quasi-identifiers can identify <k individuals
+    # Here, approximate as uniqueness
+    synth_features = [tuple(x) for x in X_synth]
+    unique_synth = len(set(synth_features))
+    k_anonymity = len(synth_features) / unique_synth if unique_synth > 0 else float('inf')
+    
+    print(f"  MMD:          {mmd:.4f}")
+    print(f"  k-Anonymity:  {k_anonymity:.2f}")
+    
+    return {
+        "mmd": mmd,
+        "k_anonymity": k_anonymity,
+    }
+
+
+def _phenotype_features_from_synth(record):
+    """Extract demographic-only features for phenotype prediction (synthetic)."""
+    age = float(record.get("Age", 65))
+    gender = 1 if record.get("Gender") == "Female" else 0
+    eth = record.get("Ethnicity", "WHITE")
+    eth_idx = ["WHITE", "BLACK", "HISPANIC", "ASIAN"].index(eth) if eth in ["WHITE", "BLACK", "HISPANIC", "ASIAN"] else 0
+    ins = record.get("Insurance", "Medicare")
+    ins_idx = ["Medicare", "Private", "Medicaid"].index(ins) if ins in ["Medicare", "Private", "Medicaid"] else 0
+    return [age, gender, eth_idx, ins_idx]
+
+
+def _phenotype_features_from_real(sample):
+    """Extract demographic-only features for phenotype prediction (real)."""
+    age = float(sample.get("age", 65))
+    gender = 1 if sample.get("gender") == "Female" else 0
+    eth = sample.get("ethnicity", "WHITE")
+    eth_idx = ["WHITE", "BLACK", "HISPANIC", "ASIAN"].index(eth) if eth in ["WHITE", "BLACK", "HISPANIC", "ASIAN"] else 0
+    ins = sample.get("insurance", "Medicare")
+    ins_idx = ["Medicare", "Private", "Medicaid"].index(ins) if ins in ["Medicare", "Private", "Medicaid"] else 0
+    return [age, gender, eth_idx, ins_idx]
+
+
+def _phenotype_labels(diagnoses):
+    """Build multi-hot label vector over TOP_PHENOTYPES."""
+    return [1 if code in diagnoses else 0 for code in TOP_PHENOTYPES]
+
+
+def preprocess_phenotype_synthetic(synthetic_records):
+    """Build (X, Y) for multi-label phenotype prediction from synthetic data."""
+    print("Preprocessing synthetic data for phenotype task...")
+    X, Y = [], []
+    for r in synthetic_records:
+        diagnoses = set()
+        main_dx = r.get("MainDiagnosis", "").replace("ICD9:", "")
+        if main_dx:
+            diagnoses.add(main_dx)
+        for c in r.get("Complications", []):
+            diagnoses.add(c.replace("ICD9:", "") if isinstance(c, str) else c)
+        X.append(_phenotype_features_from_synth(r))
+        Y.append(_phenotype_labels(diagnoses))
+    X, Y = np.array(X), np.array(Y)
+    print(f"  Synthetic phenotype set: {X.shape[0]} samples, {Y.shape[1]} phenotype labels")
+    return X, Y
+
+
+def preprocess_phenotype_real(real_dataset):
+    """Build (X, Y) for multi-label phenotype prediction from real data."""
+    X, Y = [], []
+    for s in real_dataset:
+        diagnoses = set(s.get("conditions", []))
+        X.append(_phenotype_features_from_real(s))
+        Y.append(_phenotype_labels(diagnoses))
+    return np.array(X), np.array(Y)
+
+
+def train_phenotype_rf(X_train, Y_train):
+    """Train one RandomForest per phenotype (multi-label one-vs-rest)."""
+    print("Training Random Forests for phenotype prediction...")
+    models = []
+    for j in range(Y_train.shape[1]):
+        y = Y_train[:, j]
+        if len(np.unique(y)) < 2:
+            models.append(None)  # Not enough class diversity to train
+            continue
+        rf = RandomForestClassifier(n_estimators=100, random_state=42)
+        rf.fit(X_train, y)
+        models.append(rf)
+    n_trained = sum(m is not None for m in models)
+    print(f"  Trained {n_trained}/{len(models)} phenotype classifiers")
+    return models
+
+
+def evaluate_phenotype_on_real(models, X_real, Y_real):
+    """Evaluate per-phenotype RFs on real data; report macro-averaged metrics."""
+    print("Evaluating phenotype models on real data...")
+    accs, aucs, f1s = [], [], []
+    for j, rf in enumerate(models):
+        if rf is None:
+            continue
+        y_true = Y_real[:, j]
+        if len(np.unique(y_true)) < 2:
+            continue  # AUROC undefined
+        y_pred = rf.predict(X_real)
+        proba = rf.predict_proba(X_real)
+        if proba.shape[1] >= 2:
+            y_prob = proba[:, 1]
+        else:
+            only_class = int(rf.classes_[0])
+            y_prob = np.full(len(X_real), float(only_class))
+        accs.append(accuracy_score(y_true, y_pred))
+        try:
+            aucs.append(roc_auc_score(y_true, y_prob))
+        except ValueError:
+            pass
+        f1s.append(f1_score(y_true, y_pred, zero_division=0))
+
+    macro_acc = float(np.mean(accs)) if accs else 0.0
+    macro_auc = float(np.mean(aucs)) if aucs else 0.0
+    macro_f1 = float(np.mean(f1s)) if f1s else 0.0
+
+    print(f"  Phenotype Macro-Accuracy: {macro_acc:.4f}")
+    print(f"  Phenotype Macro-AUROC:    {macro_auc:.4f}")
+    print(f"  Phenotype Macro-F1:       {macro_f1:.4f}")
+    print(f"  Evaluable phenotypes:     {len(accs)}/{len(models)}")
+
+    return {
+        "phenotype_acc": macro_acc,
+        "phenotype_auc": macro_auc,
+        "phenotype_f1": macro_f1,
+    }
+
+
+def main():
+    try:
+        print("=" * 60)
+        print("LLMSYN VALIDATION: RANDOM FOREST TSTR PIPELINE")
+        print("=" * 60)
+
+        # Step 1: Load real dataset
+        real_dataset = load_real_dataset()
+
+        # Step 2: Generate synthetic data
+        synthetic_records = generate_synthetic_data(N_SYNTHETIC)
+
+        # Step 3: Preprocess synthetic data
+        X_synth, y_synth = preprocess_synthetic_for_training(synthetic_records)
+
+        # Step 4: Train Random Forest
+        rf_model = train_random_forest(X_synth, y_synth)
+
+        # Step 5: Evaluate on real data
+        metrics = evaluate_on_real_data(rf_model, real_dataset)
+
+        # Step 6: Compute additional metrics
+        # Get X_real
+        X_real = []
+        for sample in real_dataset:
+            conditions = sample.get("conditions", [])
+            num_diagnoses = len(conditions)
+            has_procedures = 0
+            age = float(sample.get("age", 65))
+            features = [num_diagnoses, has_procedures, age]
+            X_real.append(features)
+        X_real = np.array(X_real)
+        
+        additional_metrics = compute_additional_metrics(synthetic_records, real_dataset, X_synth, X_real)
+
+        # Step 7: Phenotype prediction (multi-label TSTR)
+        print("\n" + "-" * 60)
+        print("PHENOTYPE PREDICTION TASK (multi-label)")
+        print("-" * 60)
+        Xp_synth, Yp_synth = preprocess_phenotype_synthetic(synthetic_records)
+        Xp_real, Yp_real = preprocess_phenotype_real(real_dataset)
+        phenotype_models = train_phenotype_rf(Xp_synth, Yp_synth)
+        phenotype_metrics = evaluate_phenotype_on_real(phenotype_models, Xp_real, Yp_real)
+
+        # Combine results
+        all_metrics = {**metrics, **additional_metrics, **phenotype_metrics}
+        print("\nFinal Results:")
+        for key, value in all_metrics.items():
+            try:
+                print(f"  {key}: {float(value):.4f}")
+            except (TypeError, ValueError):
+                print(f"  {key}: {value}")
+
+    except ImportError as e:
+        print(f"Missing dependency: {e}. Please install numpy and scikit-learn.")
+    except Exception as e:
+        print(f"Error during execution: {e}")
+        import traceback
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -91,3 +91,4 @@ from .utils import (
     save_processors,
 )
 from .collate import collate_temporal
+from .llmsyn_utils import compute_all_stats, get_medical_knowledge

--- a/pyhealth/datasets/llmsyn_utils.py
+++ b/pyhealth/datasets/llmsyn_utils.py
@@ -1,0 +1,317 @@
+"""LLMSYN dataset utilities: MIMIC-III stats ingestion and Mayo Clinic RAG.
+
+Two responsibilities:
+1. Ingest raw MIMIC-III CSV files and produce the stats dict that
+   LLMSYNModel uses as prior knowledge (port of mimic_ingest.py).
+2. Fetch Mayo Clinic medical knowledge for a disease name, used by
+   LLMSYNModel when enable_rag=True (port of mayo_scraper.py).
+
+Usage — generate stats.json from your MIMIC-III files::
+
+    from pyhealth.datasets.llmsyn_utils import compute_all_stats
+    import json
+
+    stats = compute_all_stats("/path/to/mimic-iii/")
+    with open("stats.json", "w") as f:
+        json.dump(stats, f, indent=2)
+"""
+
+from __future__ import annotations
+
+import time
+import urllib.robotparser
+import pandas as pd
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import quote_plus, urlparse
+
+
+try:
+    import requests
+    from bs4 import BeautifulSoup
+    _HAS_REQUESTS = True
+except ImportError:
+    _HAS_REQUESTS = False
+
+
+# ---------------------------------------------------------------------------
+# MIMIC-III ingestion (ported from CS598 mimic_ingest.py)
+# ---------------------------------------------------------------------------
+
+def load_tables(raw_dir: str) -> Dict:
+    """Load required MIMIC-III CSV tables from ``raw_dir``.
+
+    Args:
+        raw_dir: Directory containing MIMIC-III CSV files.
+
+    Returns:
+        Dict with keys ``admissions``, ``diagnoses_icd``, and optionally
+        ``d_icd_diagnoses``, ``patients``.
+
+    Raises:
+        FileNotFoundError: If a required table is missing.
+    """
+    raw_dir = Path(raw_dir)
+    table_names = {
+        "admissions": True,
+        "diagnoses_icd": True,
+        "d_icd_diagnoses": False,
+        "patients": False,
+    }
+    tables = {}
+    for name, required in table_names.items():
+        path = raw_dir / f"{name.upper()}.csv"
+        if path.exists():
+            tables[name] = pd.read_csv(path)
+        elif required:
+            raise FileNotFoundError(f"Required MIMIC-III table not found: {path}")
+    return tables
+
+
+def compute_mortality_rate(admissions) -> float:
+    """Compute overall hospital mortality rate from ADMISSIONS.HOSPITAL_EXPIRE_FLAG.
+
+    Args:
+        admissions: ADMISSIONS DataFrame.
+
+    Returns:
+        Float between 0 and 1 (e.g. 0.099 means 9.9% mortality).
+    """
+    return float(
+        admissions["HOSPITAL_EXPIRE_FLAG"].fillna(0).astype(int).mean()
+    )
+
+
+def compute_top_diseases(tables: Dict, top_n: int = 100) -> List[Dict]:
+    """Compute the top N most frequent ICD-9 diagnoses.
+
+    Joins DIAGNOSES_ICD with ADMISSIONS to compute per-disease admission
+    counts and mortality rates. Merges with D_ICD_DIAGNOSES for descriptions
+    when available.
+
+    Args:
+        tables: Dict from :func:`load_tables`.
+        top_n: Number of top diseases to return (default 100, matching paper).
+
+    Returns:
+        List of dicts with keys: ``icd9_code``, ``admission_count``,
+        ``deaths``, ``mortality_rate``, ``desc``.
+    """
+    admissions = tables["admissions"]
+    diagnoses = tables["diagnoses_icd"]
+
+    hadm_mort = admissions.set_index("HADM_ID")["HOSPITAL_EXPIRE_FLAG"]
+
+    diag = diagnoses[["HADM_ID", "ICD9_CODE"]].dropna()
+    diag = diag.rename(columns={"ICD9_CODE": "icd9_code"}).drop_duplicates()
+
+    counts = (
+        diag.groupby("icd9_code")
+        .agg({"HADM_ID": "nunique"})
+        .rename(columns={"HADM_ID": "admission_count"})
+    )
+
+    merged = (
+        diag.set_index("HADM_ID")
+        .join(hadm_mort.rename("died"), how="left")
+    )
+    merged["died"] = merged["died"].fillna(0).astype(int)
+    mort = (
+        merged.reset_index()
+        .groupby("icd9_code")
+        .agg({"died": "sum"})
+        .rename(columns={"died": "deaths"})
+    )
+
+    stats = counts.join(mort)
+    stats["mortality_rate"] = stats["deaths"] / stats["admission_count"]
+    stats = stats.sort_values("admission_count", ascending=False)
+
+    if "d_icd_diagnoses" in tables:
+        icd_table = (
+            tables["d_icd_diagnoses"][["ICD9_CODE", "LONG_TITLE"]]
+            .rename(columns={"ICD9_CODE": "icd9_code", "LONG_TITLE": "desc"})
+        )
+        stats = (
+            stats.reset_index()
+            .merge(icd_table, on="icd9_code", how="left")
+            .set_index("icd9_code")
+        )
+        stats["desc"] = stats["desc"].fillna("")
+
+    return stats.head(top_n).reset_index().to_dict(orient="records")
+
+
+def compute_demographics(admissions, patients=None) -> Dict:
+    """Compute demographic distributions for Step 0 of the LLMSYN pipeline.
+
+    Args:
+        admissions: ADMISSIONS DataFrame.
+        patients: PATIENTS DataFrame (optional — needed for age and gender).
+
+    Returns:
+        Dict with keys ``ethnicity``, ``insurance``, ``marital_status``,
+        ``language``, and (if patients provided) ``gender``, ``age_mean``,
+        ``age_std``.
+    """
+    demo: Dict = {}
+
+    for col, key in [
+        ("ETHNICITY", "ethnicity"),
+        ("INSURANCE", "insurance"),
+        ("MARITAL_STATUS", "marital_status"),
+        ("LANGUAGE", "language"),
+    ]:
+        dist = admissions[col].fillna("UNKNOWN").value_counts(normalize=True)
+        demo[key] = {str(k): round(float(v), 4) for k, v in dist.items()}
+
+    if patients is not None:
+        dist = patients["GENDER"].fillna("UNKNOWN").value_counts(normalize=True)
+        demo["gender"] = {str(k): round(float(v), 4) for k, v in dist.items()}
+
+        merged = admissions[["SUBJECT_ID", "ADMITTIME"]].merge(
+            patients[["SUBJECT_ID", "DOB"]], on="SUBJECT_ID"
+        )
+        merged["admittime"] = pd.to_datetime(merged["ADMITTIME"], errors="coerce")
+        merged["dob"] = pd.to_datetime(merged["DOB"], errors="coerce")
+        # Use year-level subtraction to avoid int64 overflow from MIMIC-III's
+        # DOB shifting (~300 years back) for patients over 89.
+        # A workaround to generate stats for older patients
+        merged["age"] = (
+            merged["admittime"].dt.year - merged["dob"].dt.year
+        ).clip(0, 89)
+        demo["age_mean"] = round(float(merged["age"].mean()), 1)
+        demo["age_std"] = round(float(merged["age"].std()), 1)
+
+    return demo
+
+
+def compute_all_stats(raw_dir: str, top_n: int = 100) -> Dict:
+    """Compute the full stats dict for LLMSYNModel from raw MIMIC-III files.
+
+    Single entry point for preprocessing. Equivalent to running CS598's
+    ``mimic_ingest.py`` script. Output can be saved as JSON and passed to
+    ``LLMSYNModel(stats_path=...)``.
+
+    Args:
+        raw_dir: Path to directory containing ADMISSIONS.csv,
+            DIAGNOSES_ICD.csv, D_ICD_DIAGNOSES.csv, PATIENTS.csv.
+        top_n: Number of top diseases to include (default 100).
+
+    Returns:
+        Dict with keys ``mortality_rate``, ``top_diseases``, ``demographics``.
+
+    Example::
+
+        stats = compute_all_stats("/data/mimic-iii/")
+        import json
+        with open("stats.json", "w") as f:
+            json.dump(stats, f, indent=2)
+    """
+    tables = load_tables(raw_dir)
+    return {
+        "mortality_rate": compute_mortality_rate(tables["admissions"]),
+        "top_diseases": compute_top_diseases(tables, top_n),
+        "demographics": compute_demographics(
+            tables["admissions"], tables.get("patients")
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mayo Clinic RAG (ported from CS598 mayo_scraper.py)
+# ---------------------------------------------------------------------------
+
+def _robots_allowed(url: str, user_agent: str = "llmsyn-bot") -> bool:
+    parsed = urlparse(url)
+    rp = urllib.robotparser.RobotFileParser()
+    rp.set_url(f"{parsed.scheme}://{parsed.netloc}/robots.txt")
+    try:
+        rp.read()
+    except Exception:
+        return False
+    return rp.can_fetch(user_agent, url)
+
+
+def _fetch_page(url: str, timeout: int = 10, user_agent: str = "llmsyn-bot") -> str:
+    headers = {"User-Agent": user_agent}
+    r = requests.get(url, headers=headers, timeout=timeout)
+    r.raise_for_status()
+    return r.text
+
+
+def _extract_main_text(html: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    article = soup.find("article") or soup.find(attrs={"class": "content"})
+    if article:
+        texts = [p.get_text(separator=" ", strip=True) for p in article.find_all("p")]
+        return "\n\n".join(t for t in texts if t)
+    ps = [p.get_text(separator=" ", strip=True) for p in soup.find_all("p")]
+    return "\n\n".join(ps[:20])
+
+
+def _find_disease_url(search_html: str) -> Optional[str]:
+    soup = BeautifulSoup(search_html, "html.parser")
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if "/diseases-conditions/" in href and "/symptoms-causes/" in href:
+            if href.startswith("http"):
+                return href
+            return "https://www.mayoclinic.org" + href
+    return None
+
+
+def get_medical_knowledge(
+    disease_name: str,
+    cache_dir: str = "data/mayo",
+) -> str:
+    """Fetch Mayo Clinic article text for a disease name (used by RAG step).
+
+    Called by ``LLMSYNModel`` when ``enable_rag=True``. Checks a local disk
+    cache before making network requests. Returns an empty string gracefully
+    if the page cannot be fetched or dependencies are unavailable.
+
+    Args:
+        disease_name: Human-readable disease name from MIMIC-III
+            (e.g. ``"Acute respiratory failure"``).
+        cache_dir: Directory for caching fetched pages.
+
+    Returns:
+        Plain text of the Mayo Clinic article, or ``""`` if unavailable.
+    """
+    if not _HAS_REQUESTS:
+        return ""
+
+    cache_path = Path(cache_dir)
+    slug = disease_name.lower()[:60].replace(" ", "_").replace("/", "_")
+    slug = "".join(c for c in slug if c.isalnum() or c == "_")
+    cached = cache_path / f"{slug}.txt"
+
+    if cached.exists():
+        return cached.read_text(encoding="utf-8")
+
+    if not _robots_allowed("https://www.mayoclinic.org/"):
+        return ""
+
+    try:
+        search_url = (
+            f"https://www.mayoclinic.org/search/search-results"
+            f"?q={quote_plus(disease_name)}"
+        )
+        search_html = _fetch_page(search_url)
+        disease_url = _find_disease_url(search_html)
+        if not disease_url:
+            return ""
+
+        time.sleep(1.0)
+        disease_html = _fetch_page(disease_url)
+        text = _extract_main_text(disease_html)
+
+        if text:
+            cache_path.mkdir(parents=True, exist_ok=True)
+            cached.write_text(text, encoding="utf-8")
+
+        return text
+
+    except Exception:
+        return ""

--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -46,3 +46,4 @@ from .sdoh import SdohClassifier
 from .medlink import MedLink
 from .unified_embedding import UnifiedMultimodalEmbeddingModel, SinusoidalTimeEmbedding
 from .califorest import CaliForest
+from .llmsyn import LLMSYNModel

--- a/pyhealth/models/llmsyn.py
+++ b/pyhealth/models/llmsyn.py
@@ -307,7 +307,7 @@ class _MockLLMBackend(_BaseLLMBackend):
 
 
 class _OpenAILLMBackend(_BaseLLMBackend):
-    """OpenAI ChatCompletion backend.
+    """OpenAI chat backend (openai>=1.0).
 
     Args:
         api_key: OpenAI API key.
@@ -318,17 +318,16 @@ class _OpenAILLMBackend(_BaseLLMBackend):
         try:
             import openai
 
-            self._openai = openai
-            self._openai.api_key = api_key
+            self._client = openai.OpenAI(api_key=api_key)
         except ImportError as exc:
             raise ImportError(
-                "OpenAI backend requires: pip install openai"
+                "OpenAI backend requires: pip install openai>=1.0"
             ) from exc
         self._model = model
 
     def generate(self, prompt: str, max_tokens: int = 256) -> str:
-        """Call OpenAI ChatCompletion and return the response text."""
-        resp = self._openai.ChatCompletion.create(
+        """Call OpenAI chat completions and return the response text."""
+        resp = self._client.chat.completions.create(
             model=self._model,
             messages=[{"role": "user", "content": prompt}],
             max_tokens=max_tokens,

--- a/pyhealth/models/llmsyn.py
+++ b/pyhealth/models/llmsyn.py
@@ -1,0 +1,756 @@
+"""LLMSYN: LLM-based Synthetic EHR Generation model.
+
+Reference:
+    Hao et al., "LLMSYN: Generating Synthetic Electronic Health Records
+    Without Patient-Level Data", MLHC 2024, PMLR 252.
+    https://proceedings.mlr.press/v252/hao24a.html
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+
+from pyhealth.datasets import SampleDataset
+from pyhealth.models.base_model import BaseModel
+
+
+
+# ---------------------------------------------------------------------------
+# Prompt templates (one per Markov step)
+# ---------------------------------------------------------------------------
+
+_STEP_TEMPLATES: Dict[int, str] = {
+    0: """\
+TASK:
+Generate a synthetic EHR patient demographic profile.
+Return ONLY these fields in exactly this format.
+
+EXAMPLE OUTPUT:
+Age: 67
+Gender: Female
+Ethnicity: WHITE
+Insurance: Medicare
+Survived: Yes
+
+PRIOR STATISTICS:
+{stats_summary}
+""",
+    1: """\
+TASK:
+Generate the main ICD-9 diagnosis for a synthetic patient.
+Return ONLY this field in exactly this format.
+
+EXAMPLE OUTPUT:
+MainDiagnosis: ICD9:41401
+
+PREVIOUS OUTPUT:
+{prev_output}
+
+PRIOR STATISTICS:
+{stats_summary}
+""",
+    2: """\
+TASK:
+Generate complication ICD-9 codes for a synthetic patient.
+Return ONLY this field. Use a comma-separated list or "None".
+
+EXAMPLE OUTPUT:
+Complications: ICD9:4280,ICD9:42731
+
+PREVIOUS OUTPUT:
+{prev_output}
+
+MEDICAL KNOWLEDGE:
+{medical_text}
+""",
+    3: """\
+TASK:
+Generate CPT procedure codes for a synthetic patient.
+Return ONLY this field. Use a comma-separated list or "None".
+
+EXAMPLE OUTPUT:
+Procedures: CPT:93000,CPT:36415
+
+PREVIOUS OUTPUT:
+{prev_output}
+
+MEDICAL KNOWLEDGE:
+{medical_text}
+""",
+}
+
+#: Built-in fallback statistics (MIMIC-III approximate values).
+_DEFAULT_STATS: Dict[str, Any] = {
+    "mortality_rate": 0.09926,
+    "top_diseases": [
+        {"icd9_code": "4019",  "desc": "Unspecified essential hypertension", "admission_count": 20696, "mortality_rate": 0.09775},
+        {"icd9_code": "4280",  "desc": "Congestive heart failure, unspecified", "admission_count": 13111, "mortality_rate": 0.14370},
+        {"icd9_code": "42731", "desc": "Atrial fibrillation", "admission_count": 12886, "mortality_rate": 0.14977},
+        {"icd9_code": "41401", "desc": "Coronary atherosclerosis of native coronary artery", "admission_count": 12428, "mortality_rate": 0.07169},
+        {"icd9_code": "5849",  "desc": "Acute kidney failure, unspecified","admission_count":  9118, "mortality_rate": 0.19950},
+        {"icd9_code": "25000", "desc": "Diabetes mellitus without mention of complication, type II", "admission_count":  9057, "mortality_rate": 0.11958},
+        {"icd9_code": "2724",  "desc": "Other and unspecified hyperlipidemia", "admission_count":  8689, "mortality_rate": 0.07481},
+        {"icd9_code": "51881", "desc": "Acute respiratory failure", "admission_count":  7497, "mortality_rate": 0.30439},
+        {"icd9_code": "5990",  "desc": "Urinary tract infection, site not specified", "admission_count":  6555, "mortality_rate": 0.12372},
+        {"icd9_code": "53081", "desc": "Esophageal reflux", "admission_count":  6324, "mortality_rate": 0.07606},
+    ],
+    "demographics": {
+        "age_mean": 55.0,
+        "age_std": 27.2,
+        "gender": {"M": 0.5615, "F": 0.4385},
+        "insurance": {"Medicare": 0.4784, "Private": 0.3829, "Medicaid": 0.0981, "Government": 0.0302, "Self Pay": 0.0104},
+        "ethnicity": {"WHITE": 0.6951, "BLACK/AFRICAN AMERICAN": 0.0922, "HISPANIC OR LATINO": 0.0288, "UNKNOWN/NOT SPECIFIED": 0.0767},
+    },
+}
+
+def _compact_stats(stats: Dict[str, Any]) -> str:
+    """Render a compact text summary of prior statistics for prompting.
+
+    Args:
+        stats: Statistics dict with ``mortality_rate``, ``top_diseases``,
+            and ``demographics`` keys.
+
+    Returns:
+        Multi-line string for inclusion in an LLM prompt.
+    """
+    top = stats.get("top_diseases", [])[:5]
+    lines = [
+        f"Overall mortality rate: {stats.get('mortality_rate', 'unknown')}"
+    ]
+    lines.append("Top diseases:")
+    for d in top:
+        lines.append(
+            f"  - {d.get('icd9_code')}: {d.get('desc', '')} "
+            f"(n={d.get('admission_count')}, "
+            f"mort={d.get('mortality_rate')})"
+        )
+    demo = stats.get("demographics", {})
+    lines.append(
+        f"Age mean/std: {demo.get('age_mean')}/{demo.get('age_std')}"
+    )
+    lines.append(f"Gender: {json.dumps(demo.get('gender', {}))}")
+    lines.append(f"Insurance: {json.dumps(demo.get('insurance', {}))}")
+    return "\n".join(lines)
+
+
+def _build_prompt(
+    step: int,
+    prev_output: Optional[str],
+    stats: Dict[str, Any],
+    medical_text: Optional[str],
+) -> str:
+    """Build a structured prompt for the given Markov generation step.
+
+    Args:
+        step: Step index (0-3).
+        prev_output: Raw LLM output from the previous step.
+        stats: Prior statistics dict.
+        medical_text: Retrieved medical knowledge (steps 2 and 3).
+
+    Returns:
+        Formatted prompt string.
+    """
+    template = _STEP_TEMPLATES.get(step, "Generate structured EHR output.")
+    return template.format(
+        stats_summary=_compact_stats(stats),
+        prev_output=prev_output or "None",
+        medical_text=medical_text or "None",
+    )
+
+
+def _normalize_icd9(code: str) -> str:
+    code = code.strip().upper()
+    if code.startswith("ICD9:"):
+        return code
+    return f"ICD9:{code}"
+
+
+def _normalize_cpt(code: str) -> str:
+    code = code.strip().upper()
+    if code.startswith("CPT:"):
+        return code
+    return f"CPT:{code}"
+
+
+def _parse_codes(text: str, prefix: str) -> List[str]:
+    pattern = rf"{prefix}:[\w]+"
+    matches = re.findall(pattern, text, flags=re.I)
+    if prefix == "ICD9":
+        return [_normalize_icd9(m) for m in matches]
+    return [_normalize_cpt(m) for m in matches]
+
+
+def _parse_output(text: str) -> Dict[str, Any]:
+    """Parse one generation step's LLM output into a structured dict.
+
+    Args:
+        text: Raw LLM response text.
+
+    Returns:
+        Dict with keys: Age, Gender, Ethnicity, Insurance, Survived,
+        MainDiagnosis, Complications, Procedures.
+    """
+    record: Dict[str, Any] = {
+        "Age": None,
+        "Gender": None,
+        "Ethnicity": None,
+        "Insurance": None,
+        "Survived": None,
+        "MainDiagnosis": None,
+        "Complications": [],
+        "Procedures": [],
+    }
+    _scalar_patterns = {
+        "Age": (r"Age:\s*(\d{1,3})", lambda m: int(m.group(1))),
+        "Gender": (
+            r"Gender:\s*(Male|Female|Other)",
+            lambda m: m.group(1).title(),
+        ),
+        "Ethnicity": (r"Ethnicity:\s*(.+)", lambda m: m.group(1).strip()),
+        "Insurance": (r"Insurance:\s*(.+)", lambda m: m.group(1).strip()),
+        "Survived": (
+            r"Survived:\s*(Yes|No)", lambda m: m.group(1).title()
+        ),
+        "MainDiagnosis": (
+            r"MainDiagnosis:\s*((?:ICD9:)?[A-Za-z0-9]+)",
+            lambda m: _normalize_icd9(m.group(1)),
+        ),
+    }
+    for key, (pat, fn) in _scalar_patterns.items():
+        m = re.search(pat, text, flags=re.I)
+        if m:
+            record[key] = fn(m)
+
+    comp_m = re.search(r"Complications:\s*(.+)", text, flags=re.I)
+    if comp_m:
+        val = comp_m.group(1).strip()
+        if val.lower() not in ("none", "n/a", ""):
+            record["Complications"] = _parse_codes(val, "ICD9")
+
+    proc_m = re.search(r"Procedures:\s*(.+)", text, flags=re.I)
+    if proc_m:
+        val = proc_m.group(1).strip()
+        if val.lower() not in ("none", "n/a", ""):
+            record["Procedures"] = _parse_codes(val, "CPT")
+    return record
+
+
+# ---------------------------------------------------------------------------
+# LLM backends
+# ---------------------------------------------------------------------------
+
+
+class _BaseLLMBackend(ABC):
+    """Abstract interface for LLM generation backends."""
+
+    @abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 256) -> str:
+        """Generate a text response for the given prompt.
+
+        Args:
+            prompt: Input prompt string.
+            max_tokens: Maximum tokens to generate.
+
+        Returns:
+            Generated text string.
+        """
+
+
+class _MockLLMBackend(_BaseLLMBackend):
+    """Deterministic mock backend for testing (no API calls required).
+
+    Args:
+        seed: Optional random seed for reproducibility.
+    """
+
+    def __init__(self, seed: Optional[int] = None) -> None:
+        self._rng = random.Random(seed)
+
+    def generate(self, prompt: str, max_tokens: int = 256) -> str:
+        """Return a canned response matched to the prompt step."""
+        rng = self._rng
+        if "patient demographic profile" in prompt:
+            return (
+                f"Age: {rng.randint(18, 90)}\n"
+                f"Gender: {rng.choice(['Male', 'Female'])}\n"
+                f"Ethnicity: "
+                f"{rng.choice(['WHITE', 'BLACK/AFRICAN AMERICAN'])}\n"
+                f"Insurance: {rng.choice(['Medicare', 'Private'])}\n"
+                f"Survived: {rng.choice(['Yes'] * 85 + ['No'] * 15)}"
+            )
+        if "main ICD-9 diagnosis" in prompt:
+            return (
+                f"MainDiagnosis: "
+                f"ICD9:{rng.choice(['4019', '41401', '42731'])}"
+            )
+        if "complication ICD-9 codes" in prompt:
+            k = rng.randint(0, 2)
+            if k == 0:
+                return "Complications: None"
+            opts = ["ICD9:4280", "ICD9:42731", "ICD9:5849"]
+            return f"Complications: {','.join(rng.choices(opts, k=k))}"
+        if "CPT procedure codes" in prompt:
+            k = rng.randint(0, 2)
+            if k == 0:
+                return "Procedures: None"
+            opts = ["CPT:93000", "CPT:36415", "CPT:99232"]
+            return f"Procedures: {','.join(rng.choices(opts, k=k))}"
+        return "MainDiagnosis: ICD9:4019"
+
+
+class _OpenAILLMBackend(_BaseLLMBackend):
+    """OpenAI ChatCompletion backend.
+
+    Args:
+        api_key: OpenAI API key.
+        model: Model identifier (e.g. ``"gpt-3.5-turbo"``).
+    """
+
+    def __init__(self, api_key: str, model: str = "gpt-3.5-turbo") -> None:
+        try:
+            import openai
+
+            self._openai = openai
+            self._openai.api_key = api_key
+        except ImportError as exc:
+            raise ImportError(
+                "OpenAI backend requires: pip install openai"
+            ) from exc
+        self._model = model
+
+    def generate(self, prompt: str, max_tokens: int = 256) -> str:
+        """Call OpenAI ChatCompletion and return the response text."""
+        resp = self._openai.ChatCompletion.create(
+            model=self._model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_tokens,
+            temperature=0.4,
+        )
+        return resp.choices[0].message.content
+
+
+class _AnthropicLLMBackend(_BaseLLMBackend):
+    """Anthropic Claude backend.
+
+    Args:
+        api_key: Anthropic API key.
+        model: Model identifier (e.g. ``"claude-sonnet-4-6"``).
+    """
+
+    def __init__(
+        self, api_key: str, model: str = "claude-sonnet-4-6"
+    ) -> None:
+        try:
+            import anthropic
+
+            self._client = anthropic.Anthropic(api_key=api_key)
+        except ImportError as exc:
+            raise ImportError(
+                "Anthropic backend requires: pip install anthropic"
+            ) from exc
+        self._model = model
+
+    def generate(self, prompt: str, max_tokens: int = 256) -> str:
+        """Call Anthropic Messages API and return the response text."""
+        resp = self._client.messages.create(
+            model=self._model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.content[0].text
+
+
+# ---------------------------------------------------------------------------
+# Internal 4-step Markov generation pipeline
+# ---------------------------------------------------------------------------
+
+
+class _LLMSYNPipeline:
+    """4-step Markov EHR generation pipeline (internal).
+
+    Args:
+        backend: LLM generation backend instance.
+        stats: Prior statistics dict.
+        noise_scale: Noise std for stats perturbation.
+        prior_mode: ``"full"`` or ``"sampled"`` disease sampling.
+        enable_rag: Whether to append retrieved medical knowledge.
+    """
+
+    def __init__(
+        self,
+        backend: _BaseLLMBackend,
+        stats: Dict[str, Any],
+        noise_scale: float = 0.0,
+        prior_mode: str = "full",
+        enable_rag: bool = False,
+    ) -> None:
+        self._backend = backend
+        self._stats = stats
+        self._noise_scale = noise_scale
+        self._prior_mode = prior_mode
+        self._enable_rag = enable_rag
+        self._icd_desc: Dict[str, str] = {
+            str(d["icd9_code"]): d.get("desc", str(d["icd9_code"]))
+            for d in stats.get("top_diseases", [])
+        }
+
+    def _perturb_stats(self) -> Dict[str, Any]:
+        import copy
+        s = copy.deepcopy(self._stats)
+        diseases = s.get("top_diseases", [])
+        if diseases:
+            weights = [max(1, d.get("admission_count", 1)) for d in diseases]
+            sampled = random.choices(diseases, weights=weights, k=1)[0]
+            if self._prior_mode == "sampled":
+                s["top_diseases"] = [sampled]
+            else:
+                rest = [d for d in diseases if d is not sampled]
+                s["top_diseases"] = [sampled] + rest
+
+        # Age jitter is always applied
+        demo = s.get("demographics", {})
+        if "age_mean" in demo:
+            demo["age_mean"] = max(0.0, demo["age_mean"] + random.uniform(-5.0, 5.0))
+        if "age_std" in demo:
+            demo["age_std"] = max(1.0, demo["age_std"] + random.uniform(-2.0, 2.0))
+
+        # Larger noise only when noise_scale > 0
+        if self._noise_scale > 0:
+            ns = self._noise_scale
+            mr = s.get("mortality_rate", 0.0)
+            s["mortality_rate"] = max(0.0, min(1.0, mr + random.uniform(-ns, ns)))
+            for d in s.get("top_diseases", []):
+                if "mortality_rate" in d:
+                    d["mortality_rate"] = max(0.0, min(1.0, d["mortality_rate"] + random.uniform(-ns, ns)))
+                if "admission_count" in d:
+                    d["admission_count"] = max(1, int(d["admission_count"] * (1 + random.uniform(-ns, ns))))
+        return s
+
+    def _get_medical_text(
+        self,
+        parsed: Dict[str, Any],
+        stats: Dict[str, Any],
+    ) -> Optional[str]:
+        """Build medical context for Step-2/3 prompts.
+
+        Args:
+            parsed: Parsed Step-1 output (contains MainDiagnosis).
+            stats: Perturbed stats for this record.
+
+        Returns:
+            Medical context string or ``None``.
+        """
+        main = parsed.get("MainDiagnosis")
+        if not main:
+            return None
+        code = main.replace("ICD9:", "").strip()
+        text: Optional[str] = None
+        for d in stats.get("top_diseases", []):
+            if str(d.get("icd9_code")) == code:
+                text = (
+                    f"Code {code}: {d.get('desc', 'unknown')}. "
+                    f"Observed mortality: {d.get('mortality_rate')}. "
+                    "Generate clinically plausible complications."
+                )
+                break
+        if text is None:
+            text = (
+                f"Code {code}: generate plausible downstream "
+                "clinical details."
+            )
+        if self._enable_rag:
+            desc = self._icd_desc.get(code, code)
+            try:
+                from pyhealth.datasets.llmsyn_utils import (
+                    get_medical_knowledge,
+                )
+
+                retrieved = get_medical_knowledge(desc)
+                if retrieved:
+                    text += f"\nMedical Knowledge: {retrieved}"
+            except Exception:
+                pass
+        return text
+
+    def generate_record(self) -> Dict[str, Any]:
+        """Run the 4-step Markov loop and return one synthetic EHR record.
+
+        Returns:
+            Dict with keys: Age, Gender, Ethnicity, Insurance, Survived,
+            MainDiagnosis, Complications, Procedures, Raw.
+        """
+        stats = self._perturb_stats()
+        prev_output: Optional[str] = None
+        medical_text: Optional[str] = None
+        step_outputs: Dict[str, Any] = {}
+
+        for step_idx in range(4):
+            prompt = _build_prompt(
+                step_idx, prev_output, stats, medical_text
+            )
+            raw = self._backend.generate(prompt)
+            parsed = _parse_output(raw)
+            step_outputs[f"step_{step_idx}_raw"] = raw
+
+            if step_idx == 0:
+                step_outputs["demographics"] = parsed
+            elif step_idx == 1:
+                step_outputs["diagnosis"] = parsed
+                medical_text = self._get_medical_text(parsed, stats)
+            elif step_idx == 2:
+                step_outputs["complications"] = parsed
+            elif step_idx == 3:
+                step_outputs["procedures"] = parsed
+
+            prev_output = raw  # Markov: thread output to next step
+
+        demo = step_outputs.get("demographics", {})
+        diag = step_outputs.get("diagnosis", {})
+        comp = step_outputs.get("complications", {})
+        proc = step_outputs.get("procedures", {})
+
+        return {
+            "Age": demo.get("Age"),
+            "Gender": demo.get("Gender"),
+            "Ethnicity": demo.get("Ethnicity"),
+            "Insurance": demo.get("Insurance"),
+            "Survived": demo.get("Survived"),
+            "MainDiagnosis": diag.get("MainDiagnosis"),
+            "Complications": comp.get("Complications", []),
+            "Procedures": proc.get("Procedures", []),
+            "Raw": step_outputs,
+        }
+
+    def generate_n(self, n: int) -> List[Dict[str, Any]]:
+        """Generate ``n`` synthetic EHR records sequentially.
+
+        Args:
+            n: Number of records to generate.
+
+        Returns:
+            List of EHR record dicts.
+        """
+        return [self.generate_record() for _ in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Public PyHealth model
+# ---------------------------------------------------------------------------
+
+
+class LLMSYNModel(BaseModel):
+    """LLM-based Synthetic EHR Generation (LLMSYN) model.
+
+    Implements the 4-step Markov generation pipeline from:
+
+        Hao et al., "LLMSYN: Generating Synthetic Electronic Health Records
+        Without Patient-Level Data", MLHC 2024, PMLR 252.
+        https://proceedings.mlr.press/v252/hao24a.html
+
+    The pipeline conditions each step on the previous output (Markov
+    property), reducing hallucination:
+
+    - **Step 0** - Demographics: age, gender, ethnicity, insurance, survival.
+    - **Step 1** - Main ICD-9 diagnosis (conditioned on Step 0).
+    - **Step 2** - Complication ICD-9 codes (conditioned on Steps 0-1 + RAG).
+    - **Step 3** - CPT procedure codes (conditioned on Steps 0-2 + RAG).
+
+    Three ablation variants are supported:
+
+    - **LLMSYNfull** (``prior_mode="full"``, ``enable_rag=True``):
+      Prior statistics + RAG from Mayo Clinic.
+    - **LLMSYNprior** (``prior_mode="full"``, ``enable_rag=False``):
+      Prior statistics only.
+    - **LLMSYNbase** (``prior_mode="sampled"``, ``enable_rag=False``):
+      Minimal prompts, single sampled disease per record.
+
+    For PyHealth integration, ``forward()`` frames generation as a TSTR
+    (Train-on-Synthetic, Test-on-Real) mortality prediction task: a synthetic
+    record is generated per batch item, and its predicted survival is compared
+    against the real mortality label via BCE loss.
+    Use :meth:`generate` for standalone synthetic EHR generation.
+
+    Args:
+        dataset: A :class:`~pyhealth.datasets.SampleDataset` providing
+            ``input_schema`` / ``output_schema`` context for BaseModel.
+        llm_provider: Backend for LLM calls. ``"mock"`` (default, no API
+            key needed), ``"openai"``, or ``"claude"``.
+        noise_scale: Gaussian noise std added to prior statistics at each
+            generation call. ``0.0`` disables noise.
+        prior_mode: ``"full"`` (weighted sampling) or ``"sampled"``
+            (single disease per record).
+        enable_rag: Append retrieved Mayo Clinic knowledge to prompts.
+        stats: Pre-loaded statistics dict (``mortality_rate``,
+            ``top_diseases``, ``demographics``). Defaults to built-in
+            MIMIC-III approximate values when ``None``.
+         stats_path: Path to a JSON file to load statistics from (e.g.
+            ``"test-resources/llmsyn/stats.json"``). Overrides ``stats``
+            when provided.
+        api_key: API key for ``"openai"`` or ``"claude"`` providers.
+        seed: Random seed for ``"mock"`` backend.
+
+    Examples:
+        >>> from pyhealth.datasets import create_sample_dataset
+        >>> from pyhealth.models import LLMSYNModel
+        >>> dataset = create_sample_dataset(
+        ...     samples=[{
+        ...         "patient_id": "p0", "visit_id": "v0",
+        ...         "conditions": ["4019", "41401"], "mortality": 0,
+        ...     }],
+        ...     input_schema={"conditions": "sequence"},
+        ...     output_schema={"mortality": "binary"},
+        ...     dataset_name="llmsyn_test",
+        ... )
+        >>> model = LLMSYNModel(dataset=dataset, llm_provider="mock", seed=0)
+        >>> records = model.generate(n=2)
+        >>> print(list(records[0].keys()))
+        ['Age', 'Gender', 'Ethnicity', 'Insurance', 'Survived',
+         'MainDiagnosis', 'Complications', 'Procedures']
+    """
+
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        llm_provider: str = "mock",
+        noise_scale: float = 0.0,
+        prior_mode: str = "full",
+        enable_rag: bool = False,
+        stats: Optional[Dict[str, Any]] = None,
+        stats_path: Optional[str] = None,
+        api_key: Optional[str] = None,
+        seed: Optional[int] = None,
+    ) -> None:
+        super().__init__(dataset)
+        self.label_key = self.label_keys[0]
+        # Projection layer converts the binary survival signal to a logit,
+        # satisfying PyHealth's forward() contract with a trainable parameter.
+        self._proj = nn.Linear(1, 1)
+        backend = self._build_backend(llm_provider, api_key, seed)
+        if stats_path is not None:
+            with open(stats_path, "r", encoding="utf-8") as f:
+                stats = json.load(f)
+        effective_stats = stats if stats is not None else _DEFAULT_STATS
+        self._pipeline = _LLMSYNPipeline(
+            backend=backend,
+            stats=effective_stats,
+            noise_scale=noise_scale,
+            prior_mode=prior_mode,
+            enable_rag=enable_rag,
+        )
+
+    @staticmethod
+    def _build_backend(
+        provider: str,
+        api_key: Optional[str],
+        seed: Optional[int],
+    ) -> _BaseLLMBackend:
+        """Instantiate the requested LLM backend.
+
+        Args:
+            provider: ``"mock"``, ``"openai"``, or ``"claude"``.
+            api_key: Required for real providers.
+            seed: Seed for mock backend.
+
+        Returns:
+            :class:`_BaseLLMBackend` instance.
+
+        Raises:
+            ValueError: Unknown provider or missing api_key.
+        """
+        if provider == "mock":
+            return _MockLLMBackend(seed=seed)
+        if provider == "openai":
+            if not api_key:
+                raise ValueError(
+                    "api_key is required for llm_provider='openai'"
+                )
+            return _OpenAILLMBackend(api_key=api_key)
+        if provider == "claude":
+            if not api_key:
+                raise ValueError(
+                    "api_key is required for llm_provider='claude'"
+                )
+            return _AnthropicLLMBackend(api_key=api_key)
+        raise ValueError(
+            f"Unknown llm_provider '{provider}'. "
+            "Choose from: 'mock', 'openai', 'claude'."
+        )
+
+    def generate(self, n: int = 1) -> List[Dict[str, Any]]:
+        """Generate synthetic EHR records using the LLMSYN pipeline.
+
+        Primary API for standalone bulk generation, independent of the
+        PyHealth training loop.
+
+        Args:
+            n: Number of records to generate.
+
+        Returns:
+            List of ``n`` EHR record dicts, each with keys:
+            ``Age``, ``Gender``, ``Ethnicity``, ``Insurance``,
+            ``Survived``, ``MainDiagnosis``, ``Complications``,
+            ``Procedures``.
+        """
+        return self._pipeline.generate_n(n)
+
+    def forward(self, **kwargs: Any) -> Dict[str, torch.Tensor]:
+        """Generate one synthetic record per batch item and compute TSTR loss.
+
+        Generates a synthetic EHR record for each batch item via the 4-step
+        Markov pipeline, then computes BCE loss between the generated
+        survival prediction and the real mortality label, implementing the
+        TSTR evaluation framing from the paper.
+
+        Args:
+            **kwargs: All keys from ``dataset.input_schema`` plus the label
+                key from ``dataset.output_schema``.
+
+        Returns:
+            Dict with keys:
+
+            - ``loss``: scalar BCE loss tensor.
+            - ``y_prob``: predicted survival probabilities,
+              shape ``(batch_size, 1)``.
+            - ``y_true``: real mortality labels, shape ``(batch_size,)``.
+            - ``logit``: raw projected logits, shape ``(batch_size, 1)``.
+        """
+        first = kwargs[self.feature_keys[0]]
+        batch_size = (
+            first.shape[0]
+            if isinstance(first, torch.Tensor)
+            else len(first)
+        )
+
+        records = self._pipeline.generate_n(batch_size)
+
+        survived_raw = torch.tensor(
+            [
+                [1.0 if r.get("Survived") == "Yes" else 0.0]
+                for r in records
+            ],
+            dtype=torch.float32,
+            device=self.device,
+        )
+        logit = self._proj(survived_raw)  # (batch_size, 1)
+
+        y_true = kwargs[self.label_key].float().to(self.device)
+        y_true_2d = (
+            y_true.unsqueeze(1) if y_true.dim() == 1 else y_true
+        )
+        loss = nn.BCEWithLogitsLoss()(logit, y_true_2d)
+        y_prob = torch.sigmoid(logit)
+
+        return {
+            "loss": loss,
+            "y_prob": y_prob,
+            "y_true": y_true,
+            "logit": logit,
+        }

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -67,3 +67,4 @@ from .variant_classification import (
     VariantClassificationClinVar,
 )
 from .patient_linkage_mimic3 import PatientLinkageMIMIC3Task
+from .synthetic_ehr_generation import SyntheticEHRGenerationTask

--- a/pyhealth/tasks/synthetic_ehr_generation.py
+++ b/pyhealth/tasks/synthetic_ehr_generation.py
@@ -1,0 +1,73 @@
+from typing import Any, Dict, List
+
+from .base_task import BaseTask
+
+
+class SyntheticEHRGenerationTask(BaseTask):
+    """Task for LLMSYN synthetic EHR generation evaluated via TSTR.
+
+    Converts real MIMIC-III admissions into samples used to initialize
+    LLMSYNModel. The model generates synthetic records per batch item and
+    computes BCE loss against the real mortality label (TSTR framing).
+
+    Each admission produces one sample: ICD-9 diagnosis codes as input,
+    hospital mortality as the binary label.
+
+    Examples:
+        >>> from pyhealth.datasets import MIMIC3Dataset
+        >>> from pyhealth.tasks import SyntheticEHRGenerationTask
+        >>> dataset = MIMIC3Dataset(
+        ...     root="/path/to/mimic-iii/1.4",
+        ...     tables=["diagnoses_icd"],
+        ... )
+        >>> task = SyntheticEHRGenerationTask()
+        >>> samples = dataset.set_task(task)
+    """
+
+    task_name: str = "SyntheticEHRGeneration"
+    input_schema: Dict[str, str] = {"conditions": "sequence"}
+    output_schema: Dict[str, str] = {"mortality": "binary"}
+
+    def __call__(self, patient: Any) -> List[Dict[str, Any]]:
+        """Process a single patient into per-admission TSTR samples.
+
+        Args:
+            patient: A PyHealth Patient object from MIMIC3Dataset.
+
+        Returns:
+            List of sample dicts, one per admission, each with:
+            patient_id, visit_id, conditions, mortality.
+        """
+        samples = []
+
+        admissions = patient.get_events(event_type="admissions")
+        if not admissions:
+            return []
+
+        for admission in admissions:
+            if admission.hospital_expire_flag not in [0, 1, "0", "1"]:
+                mortality_label = 0
+            else:
+                mortality_label = int(admission.hospital_expire_flag)
+
+            diagnoses = patient.get_events(
+                event_type="diagnoses_icd",
+                filters=[("hadm_id", "==", admission.hadm_id)],
+            )
+            conditions = [
+                event.icd9_code for event in diagnoses if event.icd9_code
+            ]
+
+            if not conditions:
+                continue
+
+            samples.append(
+                {
+                    "patient_id": patient.patient_id,
+                    "visit_id": admission.hadm_id,
+                    "conditions": conditions,
+                    "mortality": mortality_label,
+                }
+            )
+
+        return samples

--- a/test-resources/llmsyn/stats.json
+++ b/test-resources/llmsyn/stats.json
@@ -1,0 +1,851 @@
+{
+  "mortality_rate": 0.09926071622354857,
+  "top_diseases": [
+    {
+      "icd9_code": "4019",
+      "admission_count": 20696,
+      "deaths": 2023,
+      "mortality_rate": 0.09774835717046772,
+      "desc": "Unspecified essential hypertension"
+    },
+    {
+      "icd9_code": "4280",
+      "admission_count": 13111,
+      "deaths": 1884,
+      "mortality_rate": 0.14369613301807643,
+      "desc": "Congestive heart failure, unspecified"
+    },
+    {
+      "icd9_code": "42731",
+      "admission_count": 12886,
+      "deaths": 1930,
+      "mortality_rate": 0.14977494955765946,
+      "desc": "Atrial fibrillation"
+    },
+    {
+      "icd9_code": "41401",
+      "admission_count": 12428,
+      "deaths": 891,
+      "mortality_rate": 0.07169295140006438,
+      "desc": "Coronary atherosclerosis of native coronary artery"
+    },
+    {
+      "icd9_code": "5849",
+      "admission_count": 9118,
+      "deaths": 1819,
+      "mortality_rate": 0.19949550339986838,
+      "desc": "Acute kidney failure, unspecified"
+    },
+    {
+      "icd9_code": "25000",
+      "admission_count": 9057,
+      "deaths": 1083,
+      "mortality_rate": 0.11957601854918848,
+      "desc": "Diabetes mellitus without mention of complication, type II or unspecified type, not stated as uncontrolled"
+    },
+    {
+      "icd9_code": "2724",
+      "admission_count": 8689,
+      "deaths": 650,
+      "mortality_rate": 0.07480722752905973,
+      "desc": "Other and unspecified hyperlipidemia"
+    },
+    {
+      "icd9_code": "51881",
+      "admission_count": 7497,
+      "deaths": 2282,
+      "mortality_rate": 0.30438842203548083,
+      "desc": "Acute respiratory failure"
+    },
+    {
+      "icd9_code": "5990",
+      "admission_count": 6555,
+      "deaths": 811,
+      "mortality_rate": 0.12372234935163998,
+      "desc": "Urinary tract infection, site not specified"
+    },
+    {
+      "icd9_code": "53081",
+      "admission_count": 6324,
+      "deaths": 481,
+      "mortality_rate": 0.07605945604048071,
+      "desc": "Esophageal reflux"
+    },
+    {
+      "icd9_code": "2720",
+      "admission_count": 5930,
+      "deaths": 427,
+      "mortality_rate": 0.07200674536256324,
+      "desc": "Pure hypercholesterolemia"
+    },
+    {
+      "icd9_code": "V053",
+      "admission_count": 5779,
+      "deaths": 1,
+      "mortality_rate": 0.00017304031839418584,
+      "desc": "Need for prophylactic vaccination and inoculation against viral hepatitis"
+    },
+    {
+      "icd9_code": "V290",
+      "admission_count": 5519,
+      "deaths": 24,
+      "mortality_rate": 0.004348613879325965,
+      "desc": "Observation for suspected infectious condition"
+    },
+    {
+      "icd9_code": "2859",
+      "admission_count": 5405,
+      "deaths": 494,
+      "mortality_rate": 0.0913968547641073,
+      "desc": "Anemia, unspecified"
+    },
+    {
+      "icd9_code": "2449",
+      "admission_count": 4914,
+      "deaths": 573,
+      "mortality_rate": 0.11660561660561661,
+      "desc": "Unspecified acquired hypothyroidism"
+    },
+    {
+      "icd9_code": "486",
+      "admission_count": 4838,
+      "deaths": 983,
+      "mortality_rate": 0.2031831335262505,
+      "desc": "Pneumonia, organism unspecified"
+    },
+    {
+      "icd9_code": "2851",
+      "admission_count": 4552,
+      "deaths": 410,
+      "mortality_rate": 0.09007029876977153,
+      "desc": "Acute posthemorrhagic anemia"
+    },
+    {
+      "icd9_code": "2762",
+      "admission_count": 4528,
+      "deaths": 1167,
+      "mortality_rate": 0.2577296819787986,
+      "desc": "Acidosis"
+    },
+    {
+      "icd9_code": "496",
+      "admission_count": 4431,
+      "deaths": 629,
+      "mortality_rate": 0.14195441209659218,
+      "desc": "Chronic airway obstruction, not elsewhere classified"
+    },
+    {
+      "icd9_code": "99592",
+      "admission_count": 3912,
+      "deaths": 1423,
+      "mortality_rate": 0.3637525562372188,
+      "desc": "Severe sepsis"
+    },
+    {
+      "icd9_code": "V5861",
+      "admission_count": 3805,
+      "deaths": 417,
+      "mortality_rate": 0.10959264126149802,
+      "desc": "Long-term (current) use of anticoagulants"
+    },
+    {
+      "icd9_code": "0389",
+      "admission_count": 3725,
+      "deaths": 1330,
+      "mortality_rate": 0.35704697986577183,
+      "desc": "Unspecified septicemia"
+    },
+    {
+      "icd9_code": "5070",
+      "admission_count": 3680,
+      "deaths": 809,
+      "mortality_rate": 0.21983695652173912,
+      "desc": "Pneumonitis due to inhalation of food or vomitus"
+    },
+    {
+      "icd9_code": "V3000",
+      "admission_count": 3566,
+      "deaths": 11,
+      "mortality_rate": 0.0030846887268648347,
+      "desc": "Single liveborn, born in hospital, delivered without mention of cesarean section"
+    },
+    {
+      "icd9_code": "5859",
+      "admission_count": 3435,
+      "deaths": 471,
+      "mortality_rate": 0.137117903930131,
+      "desc": "Chronic kidney disease, unspecified"
+    },
+    {
+      "icd9_code": "311",
+      "admission_count": 3431,
+      "deaths": 255,
+      "mortality_rate": 0.0743223549985427,
+      "desc": "Depressive disorder, not elsewhere classified"
+    },
+    {
+      "icd9_code": "40390",
+      "admission_count": 3421,
+      "deaths": 448,
+      "mortality_rate": 0.13095586085939784,
+      "desc": "Hypertensive chronic kidney disease, unspecified, with chronic kidney disease stage I through stage IV, or unspecified"
+    },
+    {
+      "icd9_code": "3051",
+      "admission_count": 3358,
+      "deaths": 227,
+      "mortality_rate": 0.06759976176295414,
+      "desc": "Tobacco use disorder"
+    },
+    {
+      "icd9_code": "412",
+      "admission_count": 3278,
+      "deaths": 305,
+      "mortality_rate": 0.09304453935326419,
+      "desc": "Old myocardial infarction"
+    },
+    {
+      "icd9_code": "2875",
+      "admission_count": 3065,
+      "deaths": 549,
+      "mortality_rate": 0.17911908646003263,
+      "desc": "Thrombocytopenia, unspecified"
+    },
+    {
+      "icd9_code": "V4581",
+      "admission_count": 3056,
+      "deaths": 423,
+      "mortality_rate": 0.13841623036649214,
+      "desc": "Aortocoronary bypass status"
+    },
+    {
+      "icd9_code": "41071",
+      "admission_count": 3055,
+      "deaths": 422,
+      "mortality_rate": 0.1381342062193126,
+      "desc": "Subendocardial infarction, initial episode of care"
+    },
+    {
+      "icd9_code": "2761",
+      "admission_count": 3039,
+      "deaths": 490,
+      "mortality_rate": 0.16123724909509707,
+      "desc": "Hyposmolality and/or hyponatremia"
+    },
+    {
+      "icd9_code": "4240",
+      "admission_count": 2924,
+      "deaths": 243,
+      "mortality_rate": 0.08310533515731874,
+      "desc": "Mitral valve disorders"
+    },
+    {
+      "icd9_code": "V1582",
+      "admission_count": 2811,
+      "deaths": 259,
+      "mortality_rate": 0.09213802917111348,
+      "desc": "Personal history of tobacco use"
+    },
+    {
+      "icd9_code": "V3001",
+      "admission_count": 2758,
+      "deaths": 22,
+      "mortality_rate": 0.007976794778825236,
+      "desc": "Single liveborn, born in hospital, delivered by cesarean section"
+    },
+    {
+      "icd9_code": "5119",
+      "admission_count": 2734,
+      "deaths": 410,
+      "mortality_rate": 0.14996342355523043,
+      "desc": "Unspecified pleural effusion"
+    },
+    {
+      "icd9_code": "V4582",
+      "admission_count": 2725,
+      "deaths": 235,
+      "mortality_rate": 0.08623853211009175,
+      "desc": "Percutaneous transluminal coronary angioplasty status"
+    },
+    {
+      "icd9_code": "40391",
+      "admission_count": 2630,
+      "deaths": 407,
+      "mortality_rate": 0.15475285171102662,
+      "desc": "Hypertensive chronic kidney disease, unspecified, with chronic kidney disease stage V or end stage renal disease"
+    },
+    {
+      "icd9_code": "78552",
+      "admission_count": 2586,
+      "deaths": 964,
+      "mortality_rate": 0.3727764887857695,
+      "desc": "Septic shock"
+    },
+    {
+      "icd9_code": "4241",
+      "admission_count": 2550,
+      "deaths": 211,
+      "mortality_rate": 0.08274509803921569,
+      "desc": "Aortic valve disorders"
+    },
+    {
+      "icd9_code": "V5867",
+      "admission_count": 2538,
+      "deaths": 221,
+      "mortality_rate": 0.08707643814026793,
+      "desc": "Long-term (current) use of insulin"
+    },
+    {
+      "icd9_code": "42789",
+      "admission_count": 2453,
+      "deaths": 230,
+      "mortality_rate": 0.09376273950264982,
+      "desc": "Other specified cardiac dysrhythmias"
+    },
+    {
+      "icd9_code": "32723",
+      "admission_count": 2380,
+      "deaths": 144,
+      "mortality_rate": 0.06050420168067227,
+      "desc": "Obstructive sleep apnea (adult)(pediatric)"
+    },
+    {
+      "icd9_code": "9971",
+      "admission_count": 2343,
+      "deaths": 188,
+      "mortality_rate": 0.08023900981647461,
+      "desc": "Cardiac complications, not elsewhere classified"
+    },
+    {
+      "icd9_code": "5845",
+      "admission_count": 2287,
+      "deaths": 715,
+      "mortality_rate": 0.31263664188893747,
+      "desc": "Acute kidney failure with lesion of tubular necrosis"
+    },
+    {
+      "icd9_code": "2760",
+      "admission_count": 2272,
+      "deaths": 473,
+      "mortality_rate": 0.20818661971830985,
+      "desc": "Hyperosmolality and/or hypernatremia"
+    },
+    {
+      "icd9_code": "7742",
+      "admission_count": 2264,
+      "deaths": 23,
+      "mortality_rate": 0.010159010600706713,
+      "desc": "Neonatal jaundice associated with preterm delivery"
+    },
+    {
+      "icd9_code": "49390",
+      "admission_count": 2195,
+      "deaths": 122,
+      "mortality_rate": 0.05558086560364465,
+      "desc": "Asthma, unspecified type, unspecified"
+    },
+    {
+      "icd9_code": "2767",
+      "admission_count": 2167,
+      "deaths": 447,
+      "mortality_rate": 0.2062759575449931,
+      "desc": "Hyperpotassemia"
+    },
+    {
+      "icd9_code": "5180",
+      "admission_count": 2165,
+      "deaths": 220,
+      "mortality_rate": 0.10161662817551963,
+      "desc": "Pulmonary collapse"
+    },
+    {
+      "icd9_code": "4168",
+      "admission_count": 2148,
+      "deaths": 259,
+      "mortality_rate": 0.12057728119180633,
+      "desc": "Other chronic pulmonary heart diseases"
+    },
+    {
+      "icd9_code": "45829",
+      "admission_count": 2121,
+      "deaths": 117,
+      "mortality_rate": 0.055162659123055166,
+      "desc": "Other iatrogenic hypotension"
+    },
+    {
+      "icd9_code": "2749",
+      "admission_count": 2082,
+      "deaths": 231,
+      "mortality_rate": 0.11095100864553314,
+      "desc": "Gout, unspecified"
+    },
+    {
+      "icd9_code": "4589",
+      "admission_count": 2051,
+      "deaths": 303,
+      "mortality_rate": 0.1477328132618235,
+      "desc": "Hypotension, unspecified"
+    },
+    {
+      "icd9_code": "V502",
+      "admission_count": 2016,
+      "deaths": 0,
+      "mortality_rate": 0.0,
+      "desc": "Routine or ritual circumcision"
+    },
+    {
+      "icd9_code": "73300",
+      "admission_count": 1946,
+      "deaths": 206,
+      "mortality_rate": 0.10585817060637205,
+      "desc": "Osteoporosis, unspecified"
+    },
+    {
+      "icd9_code": "78039",
+      "admission_count": 1934,
+      "deaths": 245,
+      "mortality_rate": 0.1266804550155119,
+      "desc": "Other convulsions"
+    },
+    {
+      "icd9_code": "5856",
+      "admission_count": 1926,
+      "deaths": 272,
+      "mortality_rate": 0.14122533748701974,
+      "desc": "End stage renal disease"
+    },
+    {
+      "icd9_code": "4271",
+      "admission_count": 1811,
+      "deaths": 336,
+      "mortality_rate": 0.18553285477636663,
+      "desc": "Paroxysmal ventricular tachycardia"
+    },
+    {
+      "icd9_code": "5185",
+      "admission_count": 1807,
+      "deaths": 380,
+      "mortality_rate": 0.21029330381848368,
+      "desc": ""
+    },
+    {
+      "icd9_code": "4254",
+      "admission_count": 1709,
+      "deaths": 173,
+      "mortality_rate": 0.10122878876535986,
+      "desc": "Other primary cardiomyopathies"
+    },
+    {
+      "icd9_code": "4111",
+      "admission_count": 1663,
+      "deaths": 30,
+      "mortality_rate": 0.01803968731208659,
+      "desc": "Intermediate coronary syndrome"
+    },
+    {
+      "icd9_code": "V1251",
+      "admission_count": 1611,
+      "deaths": 175,
+      "mortality_rate": 0.10862818125387957,
+      "desc": "Personal history of venous thrombosis and embolism"
+    },
+    {
+      "icd9_code": "3572",
+      "admission_count": 1584,
+      "deaths": 118,
+      "mortality_rate": 0.07449494949494949,
+      "desc": "Polyneuropathy in diabetes"
+    },
+    {
+      "icd9_code": "30000",
+      "admission_count": 1580,
+      "deaths": 114,
+      "mortality_rate": 0.07215189873417721,
+      "desc": "Anxiety state, unspecified"
+    },
+    {
+      "icd9_code": "99811",
+      "admission_count": 1535,
+      "deaths": 170,
+      "mortality_rate": 0.11074918566775244,
+      "desc": "Hemorrhage complicating a procedure"
+    },
+    {
+      "icd9_code": "27800",
+      "admission_count": 1511,
+      "deaths": 87,
+      "mortality_rate": 0.05757776307081403,
+      "desc": "Obesity, unspecified"
+    },
+    {
+      "icd9_code": "E8798",
+      "admission_count": 1502,
+      "deaths": 200,
+      "mortality_rate": 0.13315579227696406,
+      "desc": "Other specified procedures as the cause of abnormal reaction of patient, or of later complication, without mention of misadventure at time of procedure"
+    },
+    {
+      "icd9_code": "41400",
+      "admission_count": 1494,
+      "deaths": 215,
+      "mortality_rate": 0.14390896921017404,
+      "desc": "Coronary atherosclerosis of unspecified type of vessel, native or graft"
+    },
+    {
+      "icd9_code": "60000",
+      "admission_count": 1490,
+      "deaths": 155,
+      "mortality_rate": 0.1040268456375839,
+      "desc": "Hypertrophy (benign) of prostate without urinary obstruction and other lower urinary tract symptom (LUTS)"
+    },
+    {
+      "icd9_code": "7907",
+      "admission_count": 1478,
+      "deaths": 148,
+      "mortality_rate": 0.10013531799729364,
+      "desc": "Bacteremia"
+    },
+    {
+      "icd9_code": "2930",
+      "admission_count": 1445,
+      "deaths": 136,
+      "mortality_rate": 0.09411764705882353,
+      "desc": "Delirium due to conditions classified elsewhere"
+    },
+    {
+      "icd9_code": "00845",
+      "admission_count": 1444,
+      "deaths": 272,
+      "mortality_rate": 0.1883656509695291,
+      "desc": "Intestinal infection due to Clostridium difficile"
+    },
+    {
+      "icd9_code": "2768",
+      "admission_count": 1425,
+      "deaths": 150,
+      "mortality_rate": 0.10526315789473684,
+      "desc": "Hypopotassemia"
+    },
+    {
+      "icd9_code": "4439",
+      "admission_count": 1401,
+      "deaths": 173,
+      "mortality_rate": 0.12348322626695217,
+      "desc": "Peripheral vascular disease, unspecified"
+    },
+    {
+      "icd9_code": "5789",
+      "admission_count": 1397,
+      "deaths": 276,
+      "mortality_rate": 0.19756621331424482,
+      "desc": "Hemorrhage of gastrointestinal tract, unspecified"
+    },
+    {
+      "icd9_code": "V4501",
+      "admission_count": 1390,
+      "deaths": 213,
+      "mortality_rate": 0.15323741007194244,
+      "desc": "Cardiac pacemaker in situ"
+    },
+    {
+      "icd9_code": "27651",
+      "admission_count": 1384,
+      "deaths": 160,
+      "mortality_rate": 0.11560693641618497,
+      "desc": "Dehydration"
+    },
+    {
+      "icd9_code": "28521",
+      "admission_count": 1383,
+      "deaths": 118,
+      "mortality_rate": 0.08532176428054954,
+      "desc": "Anemia in chronic kidney disease"
+    },
+    {
+      "icd9_code": "27652",
+      "admission_count": 1374,
+      "deaths": 175,
+      "mortality_rate": 0.12736535662299855,
+      "desc": "Hypovolemia"
+    },
+    {
+      "icd9_code": "431",
+      "admission_count": 1367,
+      "deaths": 431,
+      "mortality_rate": 0.3152889539136796,
+      "desc": "Intracerebral hemorrhage"
+    },
+    {
+      "icd9_code": "4275",
+      "admission_count": 1361,
+      "deaths": 737,
+      "mortality_rate": 0.5415135929463629,
+      "desc": "Cardiac arrest"
+    },
+    {
+      "icd9_code": "E8788",
+      "admission_count": 1350,
+      "deaths": 102,
+      "mortality_rate": 0.07555555555555556,
+      "desc": "Other specified surgical operations and procedures causing abnormal patient reaction, or later complication, without mention of misadventure at time of operation"
+    },
+    {
+      "icd9_code": "2765",
+      "admission_count": 1348,
+      "deaths": 207,
+      "mortality_rate": 0.15356083086053413,
+      "desc": ""
+    },
+    {
+      "icd9_code": "V4986",
+      "admission_count": 1327,
+      "deaths": 560,
+      "mortality_rate": 0.42200452147701584,
+      "desc": "Do not resuscitate status"
+    },
+    {
+      "icd9_code": "769",
+      "admission_count": 1314,
+      "deaths": 39,
+      "mortality_rate": 0.02968036529680365,
+      "desc": "Respiratory distress syndrome in newborn"
+    },
+    {
+      "icd9_code": "79902",
+      "admission_count": 1298,
+      "deaths": 181,
+      "mortality_rate": 0.13944530046224962,
+      "desc": "Hypoxemia"
+    },
+    {
+      "icd9_code": "70703",
+      "admission_count": 1289,
+      "deaths": 233,
+      "mortality_rate": 0.18076027928626842,
+      "desc": "Pressure ulcer, lower back"
+    },
+    {
+      "icd9_code": "5715",
+      "admission_count": 1287,
+      "deaths": 262,
+      "mortality_rate": 0.20357420357420358,
+      "desc": "Cirrhosis of liver without mention of alcohol"
+    },
+    {
+      "icd9_code": "V103",
+      "admission_count": 1277,
+      "deaths": 181,
+      "mortality_rate": 0.1417384494909945,
+      "desc": "Personal history of malignant neoplasm of breast"
+    },
+    {
+      "icd9_code": "99591",
+      "admission_count": 1271,
+      "deaths": 172,
+      "mortality_rate": 0.13532651455546812,
+      "desc": "Sepsis"
+    },
+    {
+      "icd9_code": "2639",
+      "admission_count": 1259,
+      "deaths": 213,
+      "mortality_rate": 0.1691818903891978,
+      "desc": "Unspecified protein-calorie malnutrition"
+    },
+    {
+      "icd9_code": "42832",
+      "admission_count": 1240,
+      "deaths": 115,
+      "mortality_rate": 0.09274193548387097,
+      "desc": "Chronic diastolic heart failure"
+    },
+    {
+      "icd9_code": "99812",
+      "admission_count": 1224,
+      "deaths": 100,
+      "mortality_rate": 0.08169934640522876,
+      "desc": "Hematoma complicating a procedure"
+    },
+    {
+      "icd9_code": "42833",
+      "admission_count": 1220,
+      "deaths": 121,
+      "mortality_rate": 0.09918032786885246,
+      "desc": "Acute on chronic diastolic heart failure"
+    },
+    {
+      "icd9_code": "07054",
+      "admission_count": 1218,
+      "deaths": 129,
+      "mortality_rate": 0.10591133004926108,
+      "desc": "Chronic hepatitis C without mention of hepatic coma"
+    },
+    {
+      "icd9_code": "42732",
+      "admission_count": 1217,
+      "deaths": 124,
+      "mortality_rate": 0.1018898931799507,
+      "desc": "Atrial flutter"
+    },
+    {
+      "icd9_code": "E8782",
+      "admission_count": 1211,
+      "deaths": 72,
+      "mortality_rate": 0.05945499587118084,
+      "desc": "Surgical operation with anastomosis, bypass, or graft, with natural or artificial tissues used as implant causing abnormal patient reaction, or later complication, without mention of misadventure at time of operation"
+    },
+    {
+      "icd9_code": "V1046",
+      "admission_count": 1207,
+      "deaths": 130,
+      "mortality_rate": 0.10770505385252693,
+      "desc": "Personal history of malignant neoplasm of prostate"
+    }
+  ],
+  "demographics": {
+    "ethnicity": {
+      "WHITE": 0.6951,
+      "BLACK/AFRICAN AMERICAN": 0.0922,
+      "UNKNOWN/NOT SPECIFIED": 0.0767,
+      "HISPANIC OR LATINO": 0.0288,
+      "OTHER": 0.0256,
+      "ASIAN": 0.0256,
+      "UNABLE TO OBTAIN": 0.0138,
+      "PATIENT DECLINED TO ANSWER": 0.0095,
+      "ASIAN - CHINESE": 0.0047,
+      "HISPANIC/LATINO - PUERTO RICAN": 0.0039,
+      "BLACK/CAPE VERDEAN": 0.0034,
+      "WHITE - RUSSIAN": 0.0028,
+      "MULTI RACE ETHNICITY": 0.0022,
+      "BLACK/HAITIAN": 0.0017,
+      "ASIAN - ASIAN INDIAN": 0.0014,
+      "WHITE - OTHER EUROPEAN": 0.0014,
+      "HISPANIC/LATINO - DOMINICAN": 0.0013,
+      "PORTUGUESE": 0.001,
+      "WHITE - BRAZILIAN": 0.001,
+      "ASIAN - VIETNAMESE": 0.0009,
+      "AMERICAN INDIAN/ALASKA NATIVE": 0.0009,
+      "BLACK/AFRICAN": 0.0007,
+      "MIDDLE EASTERN": 0.0007,
+      "HISPANIC/LATINO - GUATEMALAN": 0.0007,
+      "WHITE - EASTERN EUROPEAN": 0.0004,
+      "ASIAN - FILIPINO": 0.0004,
+      "HISPANIC/LATINO - CUBAN": 0.0004,
+      "HISPANIC/LATINO - SALVADORAN": 0.0003,
+      "NATIVE HAWAIIAN OR OTHER PACIFIC ISLANDER": 0.0003,
+      "ASIAN - CAMBODIAN": 0.0003,
+      "ASIAN - OTHER": 0.0003,
+      "HISPANIC/LATINO - CENTRAL AMERICAN (OTHER)": 0.0002,
+      "ASIAN - KOREAN": 0.0002,
+      "HISPANIC/LATINO - MEXICAN": 0.0002,
+      "CARIBBEAN ISLAND": 0.0002,
+      "HISPANIC/LATINO - COLOMBIAN": 0.0002,
+      "SOUTH AMERICAN": 0.0001,
+      "ASIAN - JAPANESE": 0.0001,
+      "ASIAN - THAI": 0.0001,
+      "HISPANIC/LATINO - HONDURAN": 0.0001,
+      "AMERICAN INDIAN/ALASKA NATIVE FEDERALLY RECOGNIZED TRIBE": 0.0001
+    },
+    "insurance": {
+      "Medicare": 0.4784,
+      "Private": 0.3829,
+      "Medicaid": 0.0981,
+      "Government": 0.0302,
+      "Self Pay": 0.0104
+    },
+    "marital_status": {
+      "MARRIED": 0.411,
+      "SINGLE": 0.2247,
+      "UNKNOWN": 0.1717,
+      "WIDOWED": 0.1223,
+      "DIVORCED": 0.0545,
+      "SEPARATED": 0.0097,
+      "UNKNOWN (DEFAULT)": 0.0058,
+      "LIFE PARTNER": 0.0003
+    },
+    "language": {
+      "ENGL": 0.4932,
+      "UNKNOWN": 0.4295,
+      "SPAN": 0.0184,
+      "RUSS": 0.0134,
+      "PTUN": 0.0106,
+      "CANT": 0.007,
+      "PORT": 0.0058,
+      "CAPE": 0.0043,
+      "MAND": 0.0026,
+      "HAIT": 0.0025,
+      "ITAL": 0.0021,
+      "VIET": 0.0016,
+      "GREE": 0.0013,
+      "ARAB": 0.0008,
+      "PERS": 0.0007,
+      "CAMB": 0.0006,
+      "POLI": 0.0006,
+      "AMER": 0.0005,
+      "HIND": 0.0004,
+      "KORE": 0.0004,
+      "ALBA": 0.0003,
+      "FREN": 0.0003,
+      "SOMA": 0.0002,
+      "THAI": 0.0002,
+      "ETHI": 0.0002,
+      "*ARM": 0.0002,
+      "*CHI": 0.0001,
+      "LAOT": 0.0001,
+      "*BEN": 0.0001,
+      "*HUN": 0.0001,
+      "*GUJ": 0.0001,
+      "*YID": 0.0001,
+      "URDU": 0.0001,
+      "*BUL": 0.0001,
+      "*URD": 0.0001,
+      "*BUR": 0.0001,
+      "*IBO": 0.0001,
+      "*CDI": 0.0001,
+      "*MAN": 0.0001,
+      "JAPA": 0.0001,
+      "*TEL": 0.0001,
+      "**TO": 0.0001,
+      "TAGA": 0.0001,
+      "*TOY": 0.0,
+      "*LEB": 0.0,
+      "*FUL": 0.0,
+      "* BE": 0.0,
+      "*CAN": 0.0,
+      "TURK": 0.0,
+      "*TOI": 0.0,
+      "BENG": 0.0,
+      "*AMH": 0.0,
+      "*MOR": 0.0,
+      "*DUT": 0.0,
+      "*KHM": 0.0,
+      "**SH": 0.0,
+      "*DEA": 0.0,
+      "*PUN": 0.0,
+      "*PHI": 0.0,
+      "*SPA": 0.0,
+      "*RUS": 0.0,
+      "GERM": 0.0,
+      "*BOS": 0.0,
+      "*ROM": 0.0,
+      "* FU": 0.0,
+      "*ARA": 0.0,
+      "*YOR": 0.0,
+      "*FAR": 0.0,
+      "SERB": 0.0,
+      "** T": 0.0,
+      "*NEP": 0.0,
+      "*CRE": 0.0,
+      "*FIL": 0.0,
+      "*LIT": 0.0,
+      "*PER": 0.0,
+      "*TAM": 0.0
+    },
+    "gender": {
+      "M": 0.5615,
+      "F": 0.4385
+    },
+    "age_mean": 55.0,
+    "age_std": 27.2
+  }
+}

--- a/tests/core/test_llmsyn.py
+++ b/tests/core/test_llmsyn.py
@@ -1,0 +1,235 @@
+import json
+import os
+import unittest
+
+import torch
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models import LLMSYNModel
+from pyhealth.models.llmsyn import (
+    _MockLLMBackend,
+    _LLMSYNPipeline,
+    _normalize_icd9,
+    _normalize_cpt,
+    _parse_codes,
+    _parse_output,
+    _DEFAULT_STATS,
+)
+from pyhealth.tasks import SyntheticEHRGenerationTask
+
+
+def _make_dataset():
+    samples = [
+        {
+            "patient_id": "p0",
+            "visit_id": "v0",
+            "conditions": ["4019", "41401"],
+            "mortality": 0,
+        },
+        {
+            "patient_id": "p1",
+            "visit_id": "v1",
+            "conditions": ["4280", "42731"],
+            "mortality": 1,
+        },
+    ]
+    return create_sample_dataset(
+        samples=samples,
+        input_schema={"conditions": "sequence"},
+        output_schema={"mortality": "binary"},
+        dataset_name="llmsyn_test",
+    )
+
+
+class TestCodeNormalization(unittest.TestCase):
+    def test_normalize_icd9_already_prefixed(self):
+        self.assertEqual(_normalize_icd9("ICD9:4019"), "ICD9:4019")
+
+    def test_normalize_icd9_bare(self):
+        self.assertEqual(_normalize_icd9("4019"), "ICD9:4019")
+
+    def test_normalize_cpt_already_prefixed(self):
+        self.assertEqual(_normalize_cpt("CPT:93000"), "CPT:93000")
+
+    def test_normalize_cpt_bare(self):
+        self.assertEqual(_normalize_cpt("93000"), "CPT:93000")
+
+    def test_parse_codes_icd9(self):
+        codes = _parse_codes("ICD9:4280,ICD9:42731", "ICD9")
+        self.assertEqual(codes, ["ICD9:4280", "ICD9:42731"])
+
+    def test_parse_codes_cpt(self):
+        codes = _parse_codes("CPT:93000,CPT:36415", "CPT")
+        self.assertEqual(codes, ["CPT:93000", "CPT:36415"])
+
+
+class TestParseOutput(unittest.TestCase):
+    def test_full_output(self):
+        text = (
+            "Age: 67\nGender: Female\nEthnicity: WHITE\n"
+            "Insurance: Medicare\nSurvived: Yes\n"
+            "MainDiagnosis: ICD9:41401\n"
+            "Complications: ICD9:4280,ICD9:42731\n"
+            "Procedures: CPT:93000,CPT:36415"
+        )
+        r = _parse_output(text)
+        self.assertEqual(r["Age"], 67)
+        self.assertEqual(r["Gender"], "Female")
+        self.assertEqual(r["Survived"], "Yes")
+        self.assertEqual(r["MainDiagnosis"], "ICD9:41401")
+        self.assertIn("ICD9:4280", r["Complications"])
+        self.assertIn("CPT:93000", r["Procedures"])
+
+    def test_none_complications(self):
+        r = _parse_output("Complications: None\nProcedures: None")
+        self.assertEqual(r["Complications"], [])
+        self.assertEqual(r["Procedures"], [])
+
+    def test_bare_code_normalized(self):
+        r = _parse_output("MainDiagnosis: 4019")
+        self.assertEqual(r["MainDiagnosis"], "ICD9:4019")
+
+
+class TestMockBackend(unittest.TestCase):
+    def setUp(self):
+        self.backend = _MockLLMBackend(seed=42)
+
+    def test_demographics_step(self):
+        out = self.backend.generate("Generate a synthetic EHR patient demographic profile")
+        self.assertIn("Age:", out)
+        self.assertIn("Gender:", out)
+        self.assertIn("Survived:", out)
+
+    def test_diagnosis_step(self):
+        out = self.backend.generate("Generate the main ICD-9 diagnosis")
+        self.assertIn("MainDiagnosis:", out)
+
+    def test_complications_step(self):
+        out = self.backend.generate("Generate complication ICD-9 codes")
+        self.assertIn("Complications:", out)
+
+    def test_procedures_step(self):
+        out = self.backend.generate("Generate CPT procedure codes")
+        self.assertIn("Procedures:", out)
+
+
+class TestPipeline(unittest.TestCase):
+    def setUp(self):
+        backend = _MockLLMBackend(seed=0)
+        self.pipeline = _LLMSYNPipeline(
+            backend=backend,
+            stats=_DEFAULT_STATS,
+            noise_scale=0.0,
+            prior_mode="full",
+            enable_rag=False,
+        )
+
+    def test_generate_record_keys(self):
+        record = self.pipeline.generate_record()
+        for key in ["Age", "Gender", "Ethnicity", "Insurance",
+                    "Survived", "MainDiagnosis", "Complications",
+                    "Procedures", "Raw"]:
+            self.assertIn(key, record)
+
+    def test_generate_n(self):
+        records = self.pipeline.generate_n(3)
+        self.assertEqual(len(records), 3)
+
+    def test_raw_contains_step_outputs(self):
+        record = self.pipeline.generate_record()
+        for key in ["step_0_raw", "step_1_raw", "step_2_raw", "step_3_raw"]:
+            self.assertIn(key, record["Raw"])
+
+
+class TestLLMSYNModel(unittest.TestCase):
+    def setUp(self):
+        self.dataset = _make_dataset()
+        self.model = LLMSYNModel(
+            dataset=self.dataset,
+            llm_provider="mock",
+            seed=42,
+        )
+
+    def test_forward_keys(self):
+        loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        batch = next(iter(loader))
+        with torch.no_grad():
+            out = self.model(**batch)
+        self.assertIn("loss", out)
+        self.assertIn("y_prob", out)
+        self.assertIn("y_true", out)
+        self.assertIn("logit", out)
+
+    def test_forward_shapes(self):
+        loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        batch = next(iter(loader))
+        with torch.no_grad():
+            out = self.model(**batch)
+        self.assertEqual(out["y_prob"].shape[0], 2)
+        self.assertEqual(out["y_true"].shape[0], 2)
+        self.assertEqual(out["loss"].dim(), 0)
+
+    def test_generate(self):
+        records = self.model.generate(n=3)
+        self.assertEqual(len(records), 3)
+        self.assertIn("MainDiagnosis", records[0])
+
+    def test_stats_path(self):
+        stats_path = os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "test-resources", "llmsyn", "stats.json",
+        )
+        stats_path = os.path.normpath(stats_path)
+        if not os.path.exists(stats_path):
+            self.skipTest("test-resources/llmsyn/stats.json not found")
+        model = LLMSYNModel(
+            dataset=self.dataset,
+            llm_provider="mock",
+            stats_path=stats_path,
+            seed=0,
+        )
+        records = model.generate(n=1)
+        self.assertEqual(len(records), 1)
+
+
+class TestAblationVariants(unittest.TestCase):
+    def setUp(self):
+        self.dataset = _make_dataset()
+
+    def _run_variant(self, prior_mode, enable_rag):
+        model = LLMSYNModel(
+            dataset=self.dataset,
+            llm_provider="mock",
+            prior_mode=prior_mode,
+            enable_rag=enable_rag,
+            seed=0,
+        )
+        return model.generate(n=1)
+
+    def test_llmsyn_full(self):
+        records = self._run_variant(prior_mode="full", enable_rag=True)
+        self.assertEqual(len(records), 1)
+
+    def test_llmsyn_prior(self):
+        records = self._run_variant(prior_mode="full", enable_rag=False)
+        self.assertEqual(len(records), 1)
+
+    def test_llmsyn_base(self):
+        records = self._run_variant(prior_mode="sampled", enable_rag=False)
+        self.assertEqual(len(records), 1)
+
+
+class TestSyntheticEHRGenerationTask(unittest.TestCase):
+    def test_task_name(self):
+        task = SyntheticEHRGenerationTask()
+        self.assertEqual(task.task_name, "SyntheticEHRGeneration")
+
+    def test_schemas(self):
+        task = SyntheticEHRGenerationTask()
+        self.assertIn("conditions", task.input_schema)
+        self.assertEqual(task.input_schema["conditions"], "sequence")
+        self.assertEqual(task.output_schema["mortality"], "binary")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_llmsyn.py
+++ b/tests/core/test_llmsyn.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -217,6 +218,57 @@ class TestAblationVariants(unittest.TestCase):
     def test_llmsyn_base(self):
         records = self._run_variant(prior_mode="sampled", enable_rag=False)
         self.assertEqual(len(records), 1)
+
+
+class TestRAG(unittest.TestCase):
+    def setUp(self):
+        backend = _MockLLMBackend(seed=42)
+        self.pipeline = _LLMSYNPipeline(
+            backend=backend,
+            stats=_DEFAULT_STATS,
+            noise_scale=0.0,
+            prior_mode="full",
+            enable_rag=True,
+        )
+
+    @patch(
+        "pyhealth.datasets.llmsyn_utils.get_medical_knowledge",
+        return_value="TEST_RAG_TEXT",
+    )
+    def test_rag_is_called(self, mock_rag):
+        self.pipeline.generate_record()
+        mock_rag.assert_called_once()
+
+    @patch(
+        "pyhealth.datasets.llmsyn_utils.get_medical_knowledge",
+        return_value="TEST_RAG_TEXT",
+    )
+    def test_rag_text_in_prompt(self, mock_rag):
+        captured = []
+        original = self.pipeline._backend.generate
+
+        def capturing(prompt, max_tokens=256):
+            captured.append(prompt)
+            return original(prompt, max_tokens)
+
+        self.pipeline._backend.generate = capturing
+        self.pipeline.generate_record()
+        mock_rag.assert_called_once()
+        self.assertTrue(any("TEST_RAG_TEXT" in p for p in captured))
+
+    def test_rag_not_called_when_disabled(self):
+        pipeline = _LLMSYNPipeline(
+            backend=_MockLLMBackend(seed=0),
+            stats=_DEFAULT_STATS,
+            noise_scale=0.0,
+            prior_mode="full",
+            enable_rag=False,
+        )
+        with patch(
+            "pyhealth.datasets.llmsyn_utils.get_medical_knowledge"
+        ) as mock_rag:
+            pipeline.generate_record()
+            mock_rag.assert_not_called()
 
 
 class TestSyntheticEHRGenerationTask(unittest.TestCase):


### PR DESCRIPTION
## Contributors
- Varunkumar Madhavan (madhava1)
- Hsinya Hsu (hyh2)
- Leticia Perez (lperez66)

## Type of Contribution
Model + Task (Option 4 Subset — Full Pipeline)

## Video Presentation
https://mediaspace.illinois.edu/media/t/1_1o9v0ngj

## Paper Reference
Hao, Y., Bhatt, R., & Sun, J. (2024). LLMSYN: Generating Synthetic Electronic Health Records Without Patient-Level Data. In *Proceedings of the Machine Learning for Healthcare Conference (MLHC)*, PMLR 252.
https://proceedings.mlr.press/v252/hao24a.html

## High-Level Description
This contribution ports the LLMSYN synthetic EHR generation pipeline (Hao et al., MLHC 2024) into PyHealth. LLMSYN generates realistic patient records using a 4-step Markov chain — each step (demographics → main diagnosis → complications → procedures) is conditioned on the previous step's LLM output, reducing hallucination. No real patient-level data is required at generation time; only aggregate MIMIC-III statistics are used as priors.

Three ablation variants from the paper are supported:
- **LLMSYNfull**: prior statistics + Mayo Clinic RAG (best performance in paper)
- **LLMSYNprior**: prior statistics only
- **LLMSYNbase**: minimal prompts, single sampled disease per record

PyHealth integration uses a TSTR (Train-on-Synthetic, Test-on-Real) framing: `LLMSYNModel.forward()` generates one synthetic record per batch item and computes BCE loss against real MIMIC-III mortality labels, fitting the generative pipeline into PyHealth's standard training loop.

## Usage

**OpenAI (GPT-3.5 / GPT-4):**
```python
from pyhealth.models import LLMSYNModel

model = LLMSYNModel(
    dataset=sample_dataset,
    llm_provider="openai",
    api_key="sk-...",
    prior_mode="full",
    enable_rag=True,        # LLMSYNfull variant
    noise_scale=0.05,
    seed=42,
)
records = model.generate(n=1500)   # paper uses 1500 synthetic records
```

**Claude (Anthropic):**

```
model = LLMSYNModel(
    dataset=sample_dataset,
    llm_provider="claude",
    api_key="sk-ant-...",
    prior_mode="full",
    enable_rag=True,
    seed=42,
)
records = model.generate(n=1500)
```
## File Guide

| Priority | File | Core Classes / Functions | Description |
|---|---|---|---|
| 1 | `pyhealth/models/llmsyn.py` | `LLMSYNModel`, `_LLMSYNPipeline`, `_MockLLMBackend`, `_OpenAILLMBackend`, `_AnthropicLLMBackend` | Core model — 4-step Markov pipeline, 3 ablation variants, mock/OpenAI/Claude backends, TSTR forward pass |
| 2 | `pyhealth/tasks/synthetic_ehr_generation.py` | `SyntheticEHRGenerationTask` | Task — converts MIMIC-III admissions into TSTR samples (ICD-9 conditions → binary mortality label) |
| 3 | `pyhealth/datasets/llmsyn_utils.py` | `compute_all_stats`, `compute_top_diseases`, `compute_demographics`, `get_medical_knowledge` | MIMIC-III stats ingestion and Mayo Clinic RAG for LLMSYNfull variant |
| 4 | `test-resources/llmsyn/stats.json` | — | Bundled real MIMIC-III aggregate statistics (9.9% mortality, top 100 diseases, demographics) |
| 5 | `tests/core/test_llmsyn.py` | `TestLLMSYNModel`, `TestSyntheticEHRGenerationTask`, `TestAblationVariants`, `TestPipeline` | 28 unit tests — all passing, mock data only, milliseconds |
| 6 | `examples/llmsyn_mimic3_synthetic_ehr.py` | `run_variants`, `run_tstr`, `create_mock_sample_dataset` | End-to-end example: all 3 ablation variants + TSTR training loop, runnable with mock or real MIMIC-III |
| 7 | `docs/api/models/pyhealth.models.LLMSYNModel.rst` | — | Sphinx API docs for LLMSYNModel |
| 8 | `docs/api/tasks/pyhealth.tasks.SyntheticEHRGenerationTask.rst` | — | Sphinx API docs for SyntheticEHRGenerationTask |


## Test Plan
- [x] `python -m pytest tests/core/test_llmsyn.py -v` — 28 tests pass
- [x] `python examples/llmsyn_mimic3_synthetic_ehr.py` — runs end-to-end with mock provider
