### PR TITLE
feat: add CNN3DAD model for Alzheimer's disease classification

### DIFF
--- a/pyhealth/models/__init__.py
+++ b/pyhealth/models/__init__.py
@@ -4,6 +4,7 @@ from .base_model import BaseModel
 from .transformer_deid import TransformerDeID
 from .biot import BIOT
 from .cnn import CNN, CNNLayer
+from .cnn3d_ad import CNN3DAD, ConvBlock3D
 from .concare import ConCare, ConCareLayer
 from .contrawr import ContraWR, ResBlock2D
 from .deepr import Deepr, DeeprLayer

--- a/pyhealth/models/cnn3d_ad.py
+++ b/pyhealth/models/cnn3d_ad.py
@@ -1,0 +1,381 @@
+# Author: Paul Nguyen, Shayan Jaffar, William Lee
+# Description: 3D CNN for Alzheimer's disease classification
+# Reference: Liu et al. 2020, "On the Design of Convolutional Neural Networks
+#            for Automatic Detection of Alzheimer's Disease"
+#            (http://proceedings.mlr.press/v116/liu20a)
+
+import math
+from typing import Dict
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from pyhealth.datasets import SampleDataset, create_sample_dataset, get_dataloader
+from pyhealth.models import BaseModel
+
+# Architecture constants from reference implementation
+# https://github.com/NYUMedML/CNN_design_for_AD/blob/master/models/models.py
+_BLOCK_KERNELS = [1, 3, 5, 3]  # Conv kernel sizes for each block
+_BLOCK_CHANNELS = [4, 32, 64, 64]  # Base channel counts (scaled by widening_factor)
+_BLOCK_DILATIONS = [1, 2, 2, 2]  # Dilation rates for dilated convolutions
+_BLOCK_PADDINGS = [0, 0, 2, 1]  # Padding values for each conv layer
+_POOL_KERNELS = [3, 3, 3, 5]  # MaxPool kernel sizes for each block
+
+
+def _make_norm(norm_type: str, num_channels: int) -> nn.Module:
+    """Create a normalization layer.
+
+    Args:
+        norm_type: Type of normalization - "instance" or "batch".
+        num_channels: Number of input channels.
+
+    Returns:
+        A normalization module.
+
+    Raises:
+        ValueError: If norm_type is not "instance" or "batch".
+    """
+    if norm_type == "instance":
+        # affine=False matches reference implementation default
+        return nn.InstanceNorm3d(num_channels)
+    elif norm_type == "batch":
+        return nn.BatchNorm3d(num_channels)
+    else:
+        raise ValueError(f"Unknown norm_type: {norm_type}. Expected 'instance' or 'batch'.")
+
+
+class ConvBlock3D(nn.Module):
+    """3D convolutional block with normalization and ReLU activation.
+
+    Architecture: Conv3d -> Norm -> ReLU
+
+    Args:
+        in_channels: Number of input channels.
+        out_channels: Number of output channels.
+        kernel_size: Size of the convolving kernel.
+        norm_type: Type of normalization ("instance" or "batch"). Default: "instance".
+        stride: Stride of the convolution. Default: 1.
+        dilation: Dilation rate for the convolution. Default: 1.
+        padding: Zero-padding added to all sides. If None, uses kernel_size // 2.
+
+    Note:
+        Input shape: [B, in_ch, D, H, W]
+        Output shape: [B, out_ch, D', H', W'] where spatial dims depend on kernel/stride/padding
+
+        Unlike reference implementation, we use bias=False since normalization follows.
+        This is an intentional deviation for better training stability.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        norm_type: str = "instance",
+        stride: int = 1,
+        dilation: int = 1,
+        padding: int = None,
+    ):
+        super().__init__()
+        if padding is None:
+            padding = kernel_size // 2
+
+        self.block = nn.Sequential(
+            nn.Conv3d(
+                in_channels,
+                out_channels,
+                kernel_size,
+                stride=stride,
+                dilation=dilation,
+                padding=padding,
+                bias=False,  # Intentional deviation: bias=False since norm follows
+            ),
+            _make_norm(norm_type, out_channels),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass through the convolutional block.
+
+        Args:
+            x: Input tensor of shape [B, in_channels, D, H, W].
+
+        Returns:
+            Output tensor of shape [B, out_channels, D', H', W'].
+        """
+        return self.block(x)
+
+
+class CNN3DAD(BaseModel):
+    """3D CNN for Alzheimer's Disease classification.
+
+    Implements the architecture from Liu et al. 2020 "On the Design of
+    Convolutional Neural Networks for Automatic Detection of Alzheimer's Disease".
+
+    The model consists of:
+    - 4 dilated convolutional blocks with instance normalization
+    - Adaptive global average pooling (improvement over reference's hardcoded flatten)
+    - Optional sinusoidal age encoding with MLP fusion
+    - Two-layer classifier head
+
+    Args:
+        dataset: PyHealth SampleDataset with fitted processors.
+        scan_key: Key for the 3D MRI scan in the input data. Default: "scan".
+        age_key: Key for the patient age in the input data. Default: "age".
+        label_key: Key for the classification label. Default: "label".
+        norm_type: Type of normalization ("instance" or "batch"). Default: "instance".
+        widening_factor: Channel multiplier for the backbone. Default: 8.
+        num_blocks: Number of convolutional blocks. Default: 4.
+        age_encoding_dim: Dimension of age encoding. Set to 0 to disable. Default: 512.
+        classifier_hidden: Hidden dimension of classifier. Default: 200.
+        dropout: Dropout rate after age fusion. Default: 0.1.
+
+    Reference:
+        Liu et al. 2020, "On the Design of Convolutional Neural Networks for
+        Automatic Detection of Alzheimer's Disease"
+        http://proceedings.mlr.press/v116/liu20a
+
+        Code reference: https://github.com/NYUMedML/CNN_design_for_AD
+
+    Example:
+        >>> from pyhealth.datasets import create_sample_dataset
+        >>> samples = [
+        ...     {"patient_id": "p0", "scan": np.random.randn(1,96,96,96),
+        ...      "age": np.array([60.0]), "label": 0},
+        ... ]
+        >>> dataset = create_sample_dataset(
+        ...     samples=samples,
+        ...     input_schema={"scan": "tensor", "age": "tensor"},
+        ...     output_schema={"label": "multiclass"},
+        ...     dataset_name="adni",
+        ... )
+        >>> model = CNN3DAD(dataset=dataset)
+    """
+
+    def __init__(
+        self,
+        dataset: SampleDataset,
+        scan_key: str = "scan",
+        age_key: str = "age",
+        label_key: str = "label",
+        norm_type: str = "instance",
+        widening_factor: int = 8,
+        num_blocks: int = 4,
+        age_encoding_dim: int = 512,
+        classifier_hidden: int = 200,
+        dropout: float = 0.1,
+    ):
+        super().__init__(dataset)
+
+        # Store configuration
+        self.scan_key = scan_key
+        self.age_key = age_key
+        self.label_key = label_key
+        self.norm_type = norm_type
+        self.use_age_encoding = age_encoding_dim > 0
+        self.age_encoding_dim = age_encoding_dim
+
+        # Build backbone: Conv blocks + MaxPool layers
+        blocks = []
+        in_ch = 1  # Single channel MRI input
+
+        for i in range(num_blocks):
+            # Use last valid spec if num_blocks exceeds defined specs
+            spec_idx = min(i, len(_BLOCK_KERNELS) - 1)
+
+            out_ch = _BLOCK_CHANNELS[spec_idx] * widening_factor
+            kernel = _BLOCK_KERNELS[spec_idx]
+            dilation = _BLOCK_DILATIONS[spec_idx]
+            padding = _BLOCK_PADDINGS[spec_idx]
+            pool_kernel = _POOL_KERNELS[spec_idx]
+
+            # Add conv block
+            blocks.append(
+                ConvBlock3D(
+                    in_channels=in_ch,
+                    out_channels=out_ch,
+                    kernel_size=kernel,
+                    norm_type=norm_type,
+                    dilation=dilation,
+                    padding=padding,
+                )
+            )
+
+            # Add pooling
+            blocks.append(nn.MaxPool3d(kernel_size=pool_kernel, stride=2))
+
+            in_ch = out_ch
+
+        self.backbone = nn.Sequential(*blocks)
+
+        # Global pooling (improvement over reference's hardcoded 5x5x5 flatten)
+        self.global_pool = nn.AdaptiveAvgPool3d(1)
+
+        # FC layer to feature dimension
+        self.fc1 = nn.Linear(in_ch, 1024)
+
+        # Age encoding (sinusoidal positional encoding)
+        if self.use_age_encoding:
+            # Build positional encoding table (max_len=240 for ages 0-120 at 0.5 year resolution)
+            max_len = 240
+            d_model = age_encoding_dim
+
+            pe = torch.zeros(max_len, d_model)
+            position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+            div_term = torch.exp(
+                torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model)
+            )
+            pe[:, 0::2] = torch.sin(position * div_term)
+            pe[:, 1::2] = torch.cos(position * div_term)
+
+            self.register_buffer("age_pe", pe)
+
+            # Age MLP: Linear -> LayerNorm -> Linear (NO ReLU per reference)
+            self.age_fc = nn.Sequential(
+                nn.Linear(age_encoding_dim, 512),
+                nn.LayerNorm(512),
+                nn.Linear(512, 1024),
+            )
+
+            # Dropout applied after residual addition
+            self.age_dropout = nn.Dropout(p=dropout)
+        else:
+            self.age_fc = None
+            self.age_dropout = None
+
+        # Two-layer classifier head (matches reference's LinearClassifierAlexNet)
+        self.classifier = nn.Sequential(
+            nn.Linear(1024, classifier_hidden),
+            nn.Linear(classifier_hidden, self.get_output_size()),
+        )
+
+        # Initialize weights
+        self.apply(self._init_weights)
+
+    @staticmethod
+    def _init_weights(m: nn.Module):
+        """Initialize weights using Xavier normal and bias to 0.1.
+
+        Args:
+            m: Module to initialize.
+        """
+        if isinstance(m, (nn.Conv3d, nn.Linear)):
+            nn.init.xavier_normal_(m.weight)
+            if m.bias is not None:
+                nn.init.constant_(m.bias, 0.1)
+
+    def forward(self, **kwargs) -> Dict[str, torch.Tensor]:
+        """Forward pass for the CNN3DAD model.
+
+        Args:
+            **kwargs: Dictionary containing:
+                - scan_key: 3D MRI scan tensor [B, D, H, W] or [B, 1, D, H, W]
+                - age_key: Patient age tensor [B] or [B, 1]
+                - label_key: Classification labels [B]
+
+        Returns:
+            Dictionary with keys:
+                - loss: Scalar loss value
+                - y_prob: Predicted probabilities [B, num_classes]
+                - y_true: True labels [B]
+                - logit: Raw logits [B, num_classes]
+        """
+        # Extract inputs
+        scan = kwargs[self.scan_key]
+        age = kwargs[self.age_key]
+        label = kwargs[self.label_key]
+
+        # Cast to float
+        scan = scan.float()
+        age = age.float()
+
+        # Ensure scan has channel dimension [B, 1, D, H, W]
+        if scan.dim() == 4:
+            scan = scan.unsqueeze(1)
+
+        # Ensure age has shape [B, 1]
+        if age.dim() == 1:
+            age = age.unsqueeze(1)
+
+        # Move to device
+        scan = scan.to(self.device)
+        age = age.to(self.device)
+        label = label.to(self.device)
+
+        # Forward through backbone
+        feat = self.backbone(scan)
+        feat = self.global_pool(feat)
+        feat = feat.view(feat.size(0), -1)
+        feat = self.fc1(feat)
+
+        # Apply age encoding if enabled
+        if self.use_age_encoding:
+            # Convert age to index: age * 2 to get half-year resolution
+            age_idx = (age.squeeze(1) * 2).long().clamp(0, 239)
+            age_embed = self.age_pe[age_idx]  # [B, age_encoding_dim]
+            age_embed = self.age_fc(age_embed)  # [B, 1024]
+            feat = self.age_dropout(feat + age_embed)
+
+        # Classifier
+        logits = self.classifier(feat)
+
+        # Compute outputs
+        y_true = label
+        loss = self.get_loss_function()(logits, y_true)
+        y_prob = self.prepare_y_prob(logits)
+
+        return {
+            "loss": loss,
+            "y_prob": y_prob,
+            "y_true": y_true,
+            "logit": logits,
+        }
+
+
+if __name__ == "__main__":
+    # Create synthetic ADNI-like dataset for testing
+    samples = [
+        {
+            "patient_id": "p0",
+            "scan": np.random.randn(1, 96, 96, 96).astype("float32"),
+            "age": np.array([60.0]),
+            "label": 0,  # CN (Cognitively Normal)
+        },
+        {
+            "patient_id": "p1",
+            "scan": np.random.randn(1, 96, 96, 96).astype("float32"),
+            "age": np.array([72.0]),
+            "label": 1,  # MCI (Mild Cognitive Impairment)
+        },
+        {
+            "patient_id": "p2",
+            "scan": np.random.randn(1, 96, 96, 96).astype("float32"),
+            "age": np.array([68.0]),
+            "label": 2,  # AD (Alzheimer's Disease)
+        },
+        {
+            "patient_id": "p3",
+            "scan": np.random.randn(1, 96, 96, 96).astype("float32"),
+            "age": np.array([65.0]),
+            "label": 0,  # CN
+        },
+    ]
+
+    dataset = create_sample_dataset(
+        samples=samples,
+        input_schema={"scan": "tensor", "age": "tensor"},
+        output_schema={"label": "multiclass"},
+        dataset_name="adni_test",
+    )
+
+    # Instantiate model
+    model = CNN3DAD(dataset=dataset)
+
+    # Get a batch
+    batch = next(iter(get_dataloader(dataset, batch_size=4, shuffle=False)))
+
+    # Forward pass
+    result = model(**batch)
+
+    print(result)

--- a/tests/test_cnn3d_ad.py
+++ b/tests/test_cnn3d_ad.py
@@ -1,0 +1,265 @@
+"""Tests for CNN3DAD model for Alzheimer's disease classification.
+
+This module contains comprehensive tests for:
+- _make_norm helper function
+- ConvBlock3D module
+- CNN3DAD model instantiation and forward pass
+- Gradient computation
+"""
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from pyhealth.datasets import create_sample_dataset, get_dataloader
+from pyhealth.models.cnn3d_ad import CNN3DAD, ConvBlock3D, _make_norm
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def dataset():
+    """Create synthetic ADNI-like dataset for testing."""
+    samples = [
+        {
+            "patient_id": "p0",
+            "scan": np.random.randn(1, 96, 96, 96).astype("float32"),
+            "age": np.array([60.0]),
+            "label": 0,  # CN
+        },
+        {
+            "patient_id": "p1",
+            "scan": np.random.randn(1, 96, 96, 96).astype("float32"),
+            "age": np.array([72.0]),
+            "label": 1,  # MCI
+        },
+        {
+            "patient_id": "p2",
+            "scan": np.random.randn(1, 96, 96, 96).astype("float32"),
+            "age": np.array([68.0]),
+            "label": 2,  # AD
+        },
+        {
+            "patient_id": "p3",
+            "scan": np.random.randn(1, 96, 96, 96).astype("float32"),
+            "age": np.array([65.0]),
+            "label": 0,  # CN
+        },
+    ]
+    return create_sample_dataset(
+        samples=samples,
+        input_schema={"scan": "tensor", "age": "tensor"},
+        output_schema={"label": "multiclass"},
+        dataset_name="adni_test",
+    )
+
+
+@pytest.fixture(scope="module")
+def model(dataset):
+    """Create CNN3DAD model with small widening factor for fast testing."""
+    return CNN3DAD(dataset=dataset, widening_factor=1)
+
+
+@pytest.fixture(scope="module")
+def forward_out(model, dataset):
+    """Run a single forward pass and cache the result."""
+    batch = next(iter(get_dataloader(dataset, batch_size=4, shuffle=False)))
+    with torch.no_grad():
+        return model(**batch)
+
+
+# =============================================================================
+# Group 1: _make_norm tests
+# =============================================================================
+
+
+def test_make_norm_instance():
+    """Test that _make_norm returns InstanceNorm3d for 'instance' type."""
+    norm = _make_norm("instance", 32)
+    assert isinstance(norm, nn.InstanceNorm3d)
+    assert norm.num_features == 32
+
+
+def test_make_norm_batch():
+    """Test that _make_norm returns BatchNorm3d for 'batch' type."""
+    norm = _make_norm("batch", 64)
+    assert isinstance(norm, nn.BatchNorm3d)
+    assert norm.num_features == 64
+
+
+def test_make_norm_invalid():
+    """Test that _make_norm raises ValueError for invalid type."""
+    with pytest.raises(ValueError, match="Unknown norm_type"):
+        _make_norm("invalid", 32)
+
+
+# =============================================================================
+# Group 2: ConvBlock3D tests
+# =============================================================================
+
+
+def test_convblock_output_shape():
+    """Test ConvBlock3D output shape with 8x8x8 input."""
+    block = ConvBlock3D(in_channels=1, out_channels=16, kernel_size=3)
+    x = torch.randn(2, 1, 8, 8, 8)
+    out = block(x)
+    assert out.shape == (2, 16, 8, 8, 8)
+
+
+def test_convblock_relu_activation():
+    """Test that ConvBlock3D output is non-negative (ReLU applied)."""
+    block = ConvBlock3D(in_channels=1, out_channels=16, kernel_size=3)
+    x = torch.randn(2, 1, 8, 8, 8)
+    out = block(x)
+    assert (out >= 0).all(), "ReLU should ensure all outputs are non-negative"
+
+
+# =============================================================================
+# Group 3: CNN3DAD instantiation tests
+# =============================================================================
+
+
+def test_attributes_stored(model):
+    """Test that model stores configuration attributes correctly."""
+    assert model.scan_key == "scan"
+    assert model.age_key == "age"
+    assert model.label_key == "label"
+    assert model.norm_type == "instance"
+
+
+def test_backbone_length(model):
+    """Test backbone has correct number of modules (4 conv + 4 pool = 8)."""
+    assert len(model.backbone) == 8
+
+
+def test_age_pe_buffer_shape(model):
+    """Test age positional encoding buffer has correct shape."""
+    assert hasattr(model, "age_pe")
+    assert model.age_pe.shape == (240, 512)
+
+
+def test_no_relu_in_age_mlp(model):
+    """Test that age MLP has no ReLU activation (per reference)."""
+    for module in model.age_fc.modules():
+        assert not isinstance(module, nn.ReLU), "age_fc should not contain ReLU"
+
+
+def test_age_disabled(dataset):
+    """Test that age encoding can be disabled."""
+    model_no_age = CNN3DAD(dataset=dataset, age_encoding_dim=0, widening_factor=1)
+    assert model_no_age.age_fc is None
+    assert model_no_age.age_dropout is None
+    assert not model_no_age.use_age_encoding
+
+
+def test_batch_norm_variant(dataset):
+    """Test that batch normalization variant works."""
+    model_bn = CNN3DAD(dataset=dataset, norm_type="batch", widening_factor=1)
+    # Check first conv block uses BatchNorm3d
+    first_block = model_bn.backbone[0]
+    has_batch_norm = any(
+        isinstance(m, nn.BatchNorm3d) for m in first_block.block.modules()
+    )
+    assert has_batch_norm, "First block should use BatchNorm3d"
+
+
+def test_widening_factor(dataset):
+    """Test that widening factor scales channel counts."""
+    model_w2 = CNN3DAD(dataset=dataset, widening_factor=2)
+    # First conv block output channels should be 4 * 2 = 8
+    first_conv = model_w2.backbone[0].block[0]
+    assert first_conv.out_channels == 8
+
+
+# =============================================================================
+# Group 4: Forward pass tests (reuse forward_out fixture)
+# =============================================================================
+
+
+def test_output_keys(forward_out):
+    """Test that forward pass returns all required keys."""
+    assert "loss" in forward_out
+    assert "y_prob" in forward_out
+    assert "y_true" in forward_out
+    assert "logit" in forward_out
+
+
+def test_loss_scalar(forward_out):
+    """Test that loss is a scalar."""
+    assert forward_out["loss"].shape == ()
+
+
+def test_logit_shape(forward_out):
+    """Test logit shape is (batch_size, num_classes)."""
+    assert forward_out["logit"].shape == (4, 3)
+
+
+def test_y_prob_shape(forward_out):
+    """Test y_prob shape is (batch_size, num_classes)."""
+    assert forward_out["y_prob"].shape == (4, 3)
+
+
+def test_y_prob_sums_to_one(forward_out):
+    """Test that softmax probabilities sum to 1."""
+    sums = forward_out["y_prob"].sum(dim=1)
+    assert torch.allclose(sums, torch.ones(4), atol=1e-5)
+
+
+def test_y_true_passthrough(forward_out):
+    """Test that y_true matches input labels."""
+    expected = torch.tensor([0, 1, 2, 0])
+    assert torch.equal(forward_out["y_true"].cpu(), expected)
+
+
+def test_classifier_two_layer(model):
+    """Test that classifier has exactly 2 Linear layers."""
+    linear_count = sum(1 for m in model.classifier if isinstance(m, nn.Linear))
+    assert linear_count == 2
+
+
+# =============================================================================
+# Group 5: Gradient tests (fresh models for each)
+# =============================================================================
+
+
+def test_grad_classifier(dataset):
+    """Test that gradients flow to classifier weights."""
+    model = CNN3DAD(dataset=dataset, widening_factor=1)
+    batch = next(iter(get_dataloader(dataset, batch_size=4, shuffle=False)))
+    out = model(**batch)
+    out["loss"].backward()
+
+    # Check classifier first layer has gradients
+    classifier_linear = model.classifier[0]
+    assert classifier_linear.weight.grad is not None
+    assert classifier_linear.weight.grad.abs().sum() > 0
+
+
+def test_grad_backbone(dataset):
+    """Test that gradients flow to backbone conv layers."""
+    model = CNN3DAD(dataset=dataset, widening_factor=1)
+    batch = next(iter(get_dataloader(dataset, batch_size=4, shuffle=False)))
+    out = model(**batch)
+    out["loss"].backward()
+
+    # Check first backbone conv has gradients
+    first_conv = model.backbone[0].block[0]
+    assert first_conv.weight.grad is not None
+    assert first_conv.weight.grad.abs().sum() > 0
+
+
+def test_grad_age_mlp(dataset):
+    """Test that gradients flow to age MLP."""
+    model = CNN3DAD(dataset=dataset, widening_factor=1)
+    batch = next(iter(get_dataloader(dataset, batch_size=4, shuffle=False)))
+    out = model(**batch)
+    out["loss"].backward()
+
+    # Check age_fc first linear has gradients
+    age_linear = model.age_fc[0]
+    assert age_linear.weight.grad is not None
+    assert age_linear.weight.grad.abs().sum() > 0


### PR DESCRIPTION
<html><head></head><body><h2>Contributor</h2>
<p>Paul Nguyen (pnguyen-1), Shayan Jaffar, William Lee (willlee497)</p>
<h2>Contribution Type</h2>
<p>Model</p>
<h2>Original Paper</h2>
<p>Liu et al. 2020, "On the Design of Convolutional Neural Networks for Automatic Detection of Alzheimer's Disease"
(Link: <a href="http://proceedings.mlr.press/v116/liu20a">http://proceedings.mlr.press/v116/liu20a</a>)</p>
<p>Code reference: <a href="https://github.com/NYUMedML/CNN_design_for_AD">https://github.com/NYUMedML/CNN_design_for_AD</a></p>
<h2>Summary</h2>
<p>This PR adds a PyHealth-native implementation of <strong>CNN3DAD</strong>, a 3D convolutional neural network for Alzheimer's disease classification from structural MRI scans. The model performs 3-class classification: Cognitively Normal (CN), Mild Cognitive Impairment (MCI), and Alzheimer's Disease (AD).</p>
<p>The implementation includes:</p>
<ul>
<li>4-block dilated convolutional backbone with instance normalization (matching Table 2 of the paper)</li>
<li>Configurable widening factor for channel scaling (default f=8, the paper's best-performing variant)</li>
<li>Sinusoidal age encoding with MLP fusion (positional encoding → Linear → LayerNorm → Linear, added residually)</li>
<li>Adaptive global average pooling (improvement over reference's hardcoded spatial flatten for input-size robustness)</li>
<li>Two-layer classifier head matching the reference's <code>LinearClassifierAlexNet</code> architecture</li>
<li>Xavier weight initialization with bias=0.1 per the reference implementation</li>
<li>Full integration with PyHealth's <code>BaseModel</code>, <code>SampleDataset</code>, <code>create_sample_dataset</code>, and <code>get_dataloader</code> APIs</li>
</ul>
<h3>Architecture Details</h3>














































Block | Kernel | Channels (×f) | Dilation | Padding | Pool Kernel
-- | -- | -- | -- | -- | --
1 | 1 | 4 | 1 | 0 | 3
2 | 3 | 32 | 2 | 0 | 3
3 | 5 | 64 | 2 | 2 | 3
4 | 3 | 64 | 2 | 1 | 5


<h2>Files to Review</h2>
<ul>
<li><code>pyhealth/models/cnn3d_ad.py</code> → model implementation (<code>_make_norm</code>, <code>ConvBlock3D</code>, <code>CNN3DAD</code>)</li>
<li><code>pyhealth/models/__init__.py</code> → module registration</li>
<li><code>tests/test_cnn3d_ad.py</code> → 22 unit tests across 5 groups (norm, conv block, instantiation, forward pass, gradients)</li>
</ul>
<h2>Validation</h2>
<ul>
<li>All 22 pytest tests pass (<code>python -m pytest tests/test_cnn3d_ad.py -v</code>)</li>
<li>Smoke test runs successfully (<code>python pyhealth/models/cnn3d_ad.py</code>)</li>
<li>Tests cover: helper functions, module shapes, model instantiation with various configs, forward pass output correctness, softmax probability constraints, label passthrough, and gradient flow through all three model sections (backbone, age MLP, classifier)</li>
</ul>
<h2>Notes</h2>
<ul>
<li>This implementation is based on the reference code at <a href="https://github.com/NYUMedML/CNN_design_for_AD/blob/master/models/models.py">NYUMedML/CNN_design_for_AD</a> and verified against the paper's Table 2 architecture specification</li>
<li>The age encoding MLP intentionally has <strong>no ReLU</strong> between layers, matching the reference source code (<code>AgeEncoding.fc6</code> in <code>models/models.py</code>)</li>
<li>The reference repository is licensed under AGPL-3.0; this is a clean-room PyHealth-native reimplementation following the paper's architecture description</li>
</ul></body></html>## Contributor

Paul Nguyen (pnguyen-1), Shayan Jaffar, William Lee (willlee497)

## Contribution Type

Model

## Original Paper

Liu et al. 2020, "On the Design of Convolutional Neural Networks for Automatic Detection of Alzheimer's Disease"
(Link: http://proceedings.mlr.press/v116/liu20a)

Code reference: https://github.com/NYUMedML/CNN_design_for_AD

## Summary

This PR adds a PyHealth-native implementation of **CNN3DAD**, a 3D convolutional neural network for Alzheimer's disease classification from structural MRI scans. The model performs 3-class classification: Cognitively Normal (CN), Mild Cognitive Impairment (MCI), and Alzheimer's Disease (AD).

The implementation includes:
- 4-block dilated convolutional backbone with instance normalization (matching Table 2 of the paper)
- Configurable widening factor for channel scaling (default f=8, the paper's best-performing variant)
- Sinusoidal age encoding with MLP fusion (positional encoding → Linear → LayerNorm → Linear, added residually)
- Adaptive global average pooling (improvement over reference's hardcoded spatial flatten for input-size robustness)
- Two-layer classifier head matching the reference's `LinearClassifierAlexNet` architecture
- Xavier weight initialization with bias=0.1 per the reference implementation
- Full integration with PyHealth's `BaseModel`, `SampleDataset`, `create_sample_dataset`, and `get_dataloader` APIs

### Architecture Details

| Block | Kernel | Channels (×f) | Dilation | Padding | Pool Kernel |
|-------|--------|---------------|----------|---------|-------------|
| 1     | 1      | 4             | 1        | 0       | 3           |
| 2     | 3      | 32            | 2        | 0       | 3           |
| 3     | 5      | 64            | 2        | 2       | 3           |
| 4     | 3      | 64            | 2        | 1       | 5           |

### Intentional Deviations from Reference

| Deviation | Rationale |
|-----------|-----------|
| `bias=False` on Conv3d | Normalization layer follows; redundant bias removed for training stability |
| `AdaptiveAvgPool3d(1)` instead of hardcoded flatten | Handles arbitrary input spatial sizes without architecture changes |

## Files to Review

- `pyhealth/models/cnn3d_ad.py` → model implementation (`_make_norm`, `ConvBlock3D`, `CNN3DAD`)
- `pyhealth/models/__init__.py` → module registration
- `tests/test_cnn3d_ad.py` → 22 unit tests across 5 groups (norm, conv block, instantiation, forward pass, gradients)

## Validation

- All 22 pytest tests pass (`python -m pytest tests/test_cnn3d_ad.py -v`)
- Smoke test runs successfully (`python pyhealth/models/cnn3d_ad.py`)
- Tests cover: helper functions, module shapes, model instantiation with various configs, forward pass output correctness, softmax probability constraints, label passthrough, and gradient flow through all three model sections (backbone, age MLP, classifier)

## Notes

- This implementation is based on the reference code at [[NYUMedML/CNN_design_for_AD](https://github.com/NYUMedML/CNN_design_for_AD/blob/master/models/models.py)](https://github.com/NYUMedML/CNN_design_for_AD/blob/master/models/models.py) and verified against the paper's Table 2 architecture specification
- The age encoding MLP intentionally has **no ReLU** between layers, matching the reference source code (`AgeEncoding.fc6` in `models/models.py`)
- The reference repository is licensed under AGPL-3.0; this is a clean-room PyHealth-native reimplementation following the paper's architecture description