### PR TITLE
 Fix ImportError in kg_emb caused by SampleBaseDataset rename

### DIFF
--- a/pyhealth/medcode/pretrained_embeddings/kg_emb/datasets/sample_kg_dataset.py
+++ b/pyhealth/medcode/pretrained_embeddings/kg_emb/datasets/sample_kg_dataset.py
@@ -1,10 +1,10 @@
-from pyhealth.datasets import SampleBaseDataset
+from pyhealth.datasets import SampleDataset
 
 
-class SampleKGDataset(SampleBaseDataset):
+class SampleKGDataset(SampleDataset):
     """Sample KG dataset class.
 
-    This class inherits from `SampleBaseDataset` and is specifically designed
+    This class inherits from `SampleDataset` and is specifically designed
         for KG datasets.
 
     Args:

--- a/pyhealth/medcode/pretrained_embeddings/kg_emb/datasets/splitter.py
+++ b/pyhealth/medcode/pretrained_embeddings/kg_emb/datasets/splitter.py
@@ -4,18 +4,18 @@ from typing import Optional, Tuple, Union, List
 import numpy as np
 import torch
 
-from pyhealth.datasets import SampleBaseDataset
+from pyhealth.datasets import SampleDataset
 
 
 def split(
-    dataset: SampleBaseDataset,
+    dataset: SampleDataset,
     ratios: Union[Tuple[float, float, float], List[float]],
     seed: Optional[int] = None,
 ):
     """Splits the dataset by its outermost indexed items
 
     Args:
-        dataset: a `SampleBaseDataset` object
+        dataset: a `SampleDataset` object
         ratios: a list/tuple of ratios for train / val / test
         seed: random seed for shuffling the dataset
 

--- a/pyhealth/medcode/pretrained_embeddings/kg_emb/models/complex.py
+++ b/pyhealth/medcode/pretrained_embeddings/kg_emb/models/complex.py
@@ -1,5 +1,5 @@
 from.kg_base import KGEBaseModel
-from pyhealth.datasets import SampleBaseDataset
+from pyhealth.datasets import SampleDataset
 import torch
 
 
@@ -13,7 +13,7 @@ class ComplEx(KGEBaseModel):
 
     def __init__(
         self, 
-        dataset: SampleBaseDataset, 
+        dataset: SampleDataset,
         e_dim: int = 600, 
         r_dim: int = 600, 
         ns: str = "adv", 

--- a/pyhealth/medcode/pretrained_embeddings/kg_emb/models/distmult.py
+++ b/pyhealth/medcode/pretrained_embeddings/kg_emb/models/distmult.py
@@ -1,5 +1,5 @@
 from.kg_base import KGEBaseModel
-from pyhealth.datasets import SampleBaseDataset
+from pyhealth.datasets import SampleDataset
 import torch
 
 
@@ -12,7 +12,7 @@ class DistMult(KGEBaseModel):
     """
     def __init__(
         self, 
-        dataset: SampleBaseDataset, 
+        dataset: SampleDataset,
         e_dim: int = 300, 
         r_dim: int = 300, 
         ns: str = "adv", 

--- a/pyhealth/medcode/pretrained_embeddings/kg_emb/models/kg_base.py
+++ b/pyhealth/medcode/pretrained_embeddings/kg_emb/models/kg_base.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from pyhealth.datasets import SampleBaseDataset
+from pyhealth.datasets import SampleDataset
 
 import torch
 import time
@@ -32,7 +32,7 @@ class KGEBaseModel(ABC, nn.Module):
 
     def __init__(
         self, 
-        dataset: SampleBaseDataset,
+        dataset: SampleDataset,
         e_dim: int = 500,
         r_dim: int = 500,
         ns: str = "uniform",

--- a/pyhealth/medcode/pretrained_embeddings/kg_emb/models/rotate.py
+++ b/pyhealth/medcode/pretrained_embeddings/kg_emb/models/rotate.py
@@ -1,5 +1,5 @@
 from.kg_base import KGEBaseModel
-from pyhealth.datasets import SampleBaseDataset
+from pyhealth.datasets import SampleDataset
 import torch
 
 
@@ -13,7 +13,7 @@ class RotatE(KGEBaseModel):
 
     def __init__(
         self, 
-        dataset: SampleBaseDataset, 
+        dataset: SampleDataset,
         e_dim: int = 600, 
         r_dim: int = 300, 
         ns='adv', 

--- a/pyhealth/medcode/pretrained_embeddings/kg_emb/models/transe.py
+++ b/pyhealth/medcode/pretrained_embeddings/kg_emb/models/transe.py
@@ -1,5 +1,5 @@
 from.kg_base import KGEBaseModel
-from pyhealth.datasets import SampleBaseDataset
+from pyhealth.datasets import SampleDataset
 import torch
 
 
@@ -13,7 +13,7 @@ class TransE(KGEBaseModel):
 
     def __init__(
         self, 
-        dataset: SampleBaseDataset, 
+        dataset: SampleDataset, 
         e_dim: int = 300, 
         r_dim: int = 300, 
         ns: str = "adv", 


### PR DESCRIPTION
Fixes #952.

  `SampleBaseDataset` was renamed to `SampleDataset` during the PyHealth 2.0
  upgrade, but 7 files in the `kg_emb` module were never updated. Any user
  importing from `pyhealth.medcode.pretrained_embeddings.kg_emb` hit an
  immediate `ImportError` because `SampleBaseDataset` no longer exists in
  `pyhealth.datasets`.

  Updated all imports and type annotations across the affected files:
  - `datasets/sample_kg_dataset.py`
  - `datasets/splitter.py`
  - `models/kg_base.py`
  - `models/complex.py`
  - `models/distmult.py`
  - `models/rotate.py`
  - `models/transe.py`

  ## Test plan

  - [ ] `from pyhealth.medcode.pretrained_embeddings.kg_emb.datasets import SampleKGDataset` no longer raises
  `ImportError`
  - [ ] `from pyhealth.medcode.pretrained_embeddings.kg_emb.models import ComplEx, DistMult, RotatE, TransE` no
  longer raises `ImportError`

  And a short commit message (no body needed since the PR description covers it):

  fix: update kg_emb imports from SampleBaseDataset to SampleDataset