### PR TITLE
Fix invalid escape sequences in calibration.py docstrings

### DIFF
--- a/pyhealth/metrics/calibration.py
+++ b/pyhealth/metrics/calibration.py
@@ -99,7 +99,7 @@ def _ECE_classwise(prob:np.ndarray, label_onehot:np.ndarray, bins=20, threshold=
     return summs, class_losses
 
 def ece_confidence_multiclass(prob:np.ndarray, label:np.ndarray, bins=20, adaptive=False):
-    """Expected Calibration Error (ECE).
+    r"""Expected Calibration Error (ECE).
 
     We group samples into 'bins' basing on the top-class prediction.
     Then, we compute the absolute difference between the average top-class prediction and
@@ -133,7 +133,7 @@ def ece_confidence_multiclass(prob:np.ndarray, label:np.ndarray, bins=20, adapti
     return _ECE_confidence(df, bins, adaptive)[1]
 
 def ece_confidence_binary(prob:np.ndarray, label:np.ndarray, bins=20, adaptive=False):
-    """Expected Calibration Error (ECE) for binary classification.
+    r"""Expected Calibration Error (ECE) for binary classification.
 
     Similar to :func:`ece_confidence_multiclass`, but on class 1 instead of the top-prediction.
 


### PR DESCRIPTION
## Summary
- Fixed SyntaxWarning about invalid escape sequences in LaTeX math notation
- Changed docstrings to raw strings (r"""...""") to preserve backslashes

## Fixes #1142

## Changes
- `ece_confidence_multiclass()`: Changed opening docstring from `"""` to `r"""`
- `ece_confidence_binary()`: Changed opening docstring from `"""` to `r"""`

## Issue
This fixes SyntaxWarnings that appeared when running tests:
```
SyntaxWarning: invalid escape sequence "\c"
```

Which occurred in LaTeX expressions like \frac and \cdot within the docstrings.

## Testing
Verified with:
```bash
python -W error::SyntaxWarning -c "import pyhealth.metrics.calibration; print(\"No syntax warnings - fix successful\")"
```
Output: `No syntax warnings - fix successful`