### PR TITLE
Exclude pediatric patients (younger than 18) from clinical prediction tasks

### DIFF
--- a/pyhealth/tasks/drug_recommendation.py
+++ b/pyhealth/tasks/drug_recommendation.py
@@ -339,7 +339,7 @@ class DrugRecommendationMIMIC4(BaseTask):
         return samples
 
 
-def drug_recommendation_mimic3_fn(patient: Patient):
+def drug_recommendation_mimic3_fn(patient: Patient, exclude_minors: bool = True):
     """Processes a single patient for the drug recommendation task.
 
     Drug recommendation aims at recommending a set of drugs given the patient health
@@ -382,17 +382,18 @@ def drug_recommendation_mimic3_fn(patient: Patient):
     samples = []
 
     # Skip pediatric patients
-    demographics = patient.get_events(event_type="patients")
-    admissions = patient.get_events(event_type="admissions")
-    if demographics and admissions:
-        dob_str = getattr(demographics[0], "dob", None)
-        if dob_str is not None:
-            try:
-                dob = datetime.strptime(str(dob_str)[:10], "%Y-%m-%d")
-                if (admissions[0].timestamp - dob).days / 365.25 < 18:
-                    return []
-            except (ValueError, TypeError):
-                pass
+    if exclude_minors:
+        demographics = patient.get_events(event_type="patients")
+        admissions = patient.get_events(event_type="admissions")
+        if demographics and admissions:
+            dob_str = getattr(demographics[0], "dob", None)
+            if dob_str is not None:
+                try:
+                    dob = datetime.strptime(str(dob_str)[:10], "%Y-%m-%d")
+                    if (admissions[0].timestamp - dob).days / 365.25 < 18:
+                        return []
+                except (ValueError, TypeError):
+                    pass
 
     for i in range(len(patient)):
         visit: Visit = patient[i]
@@ -439,7 +440,7 @@ def drug_recommendation_mimic3_fn(patient: Patient):
     return samples
 
 
-def drug_recommendation_mimic4_fn(patient: Patient):
+def drug_recommendation_mimic4_fn(patient: Patient, exclude_minors: bool = True):
     """Processes a single patient for the drug recommendation task.
 
     Drug recommendation aims at recommending a set of drugs given the patient health
@@ -475,14 +476,15 @@ def drug_recommendation_mimic4_fn(patient: Patient):
     samples = []
 
     # Skip pediatric patients
-    demographics = patient.get_events(event_type="patients")
-    if demographics:
-        anchor_age = getattr(demographics[0], "anchor_age", None)
-        try:
-            if anchor_age is not None and int(float(anchor_age)) < 18:
-                return []
-        except (ValueError, TypeError):
-            pass
+    if exclude_minors:
+        demographics = patient.get_events(event_type="patients")
+        if demographics:
+            anchor_age = getattr(demographics[0], "anchor_age", None)
+            try:
+                if anchor_age is not None and int(float(anchor_age)) < 18:
+                    return []
+            except (ValueError, TypeError):
+                pass
 
     for i in range(len(patient)):
         visit: Visit = patient[i]
@@ -668,7 +670,7 @@ class DrugRecommendationEICU(BaseTask):
         return samples
 
 
-def drug_recommendation_omop_fn(patient: Patient):
+def drug_recommendation_omop_fn(patient: Patient, exclude_minors: bool = True):
     """Processes a single patient for the drug recommendation task.
 
     Drug recommendation aims at recommending a set of drugs given the patient health
@@ -697,20 +699,21 @@ def drug_recommendation_omop_fn(patient: Patient):
     samples = []
 
     # Skip pediatric patients
-    demographics = patient.get_events(event_type="person")
-    if demographics:
-        person = demographics[0]
-        birth_year = getattr(person, "year_of_birth", None)
-        if birth_year is not None:
-            try:
-                birth_month = int(getattr(person, "month_of_birth", None) or 1)
-                birth_day = int(getattr(person, "day_of_birth", None) or 1)
-                dob = datetime(int(birth_year), birth_month, birth_day)
-                visits = patient.get_events(event_type="visit_occurrence")
-                if visits and (visits[0].timestamp - dob).days / 365.25 < 18:
-                    return []
-            except (ValueError, TypeError):
-                pass
+    if exclude_minors:
+        demographics = patient.get_events(event_type="person")
+        if demographics:
+            person = demographics[0]
+            birth_year = getattr(person, "year_of_birth", None)
+            if birth_year is not None:
+                try:
+                    birth_month = int(getattr(person, "month_of_birth", None) or 1)
+                    birth_day = int(getattr(person, "day_of_birth", None) or 1)
+                    dob = datetime(int(birth_year), birth_month, birth_day)
+                    visits = patient.get_events(event_type="visit_occurrence")
+                    if visits and (visits[0].timestamp - dob).days / 365.25 < 18:
+                        return []
+                except (ValueError, TypeError):
+                    pass
 
     for i in range(len(patient)):
         visit: Visit = patient[i]

--- a/pyhealth/tasks/drug_recommendation.py
+++ b/pyhealth/tasks/drug_recommendation.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
 import polars as pl
@@ -379,6 +380,20 @@ def drug_recommendation_mimic3_fn(patient: Patient):
         }
     """
     samples = []
+
+    # Skip pediatric patients
+    demographics = patient.get_events(event_type="patients")
+    admissions = patient.get_events(event_type="admissions")
+    if demographics and admissions:
+        dob_str = getattr(demographics[0], "dob", None)
+        if dob_str is not None:
+            try:
+                dob = datetime.strptime(str(dob_str)[:10], "%Y-%m-%d")
+                if (admissions[0].timestamp - dob).days / 365.25 < 18:
+                    return []
+            except (ValueError, TypeError):
+                pass
+
     for i in range(len(patient)):
         visit: Visit = patient[i]
         conditions = visit.get_code_list(table="DIAGNOSES_ICD")
@@ -388,7 +403,6 @@ def drug_recommendation_mimic3_fn(patient: Patient):
         # exclude: visits without condition, procedure, or drug code
         if len(conditions) * len(procedures) * len(drugs) == 0:
             continue
-        # TODO: should also exclude visit with age < 18
         samples.append(
             {
                 "visit_id": visit.visit_id,
@@ -459,6 +473,17 @@ def drug_recommendation_mimic4_fn(patient: Patient):
         [{'visit_id': '130744', 'patient_id': '103', 'conditions': [['42', '109', '19', '122', '98', '663', '58', '51']], 'procedures': [['1']], 'label': [['2', '3', '4']]}]
     """
     samples = []
+
+    # Skip pediatric patients
+    demographics = patient.get_events(event_type="patients")
+    if demographics:
+        anchor_age = getattr(demographics[0], "anchor_age", None)
+        try:
+            if anchor_age is not None and int(float(anchor_age)) < 18:
+                return []
+        except (ValueError, TypeError):
+            pass
+
     for i in range(len(patient)):
         visit: Visit = patient[i]
         conditions = visit.get_code_list(table="diagnoses_icd")
@@ -468,7 +493,6 @@ def drug_recommendation_mimic4_fn(patient: Patient):
         # exclude: visits without condition, procedure, or drug code
         if len(conditions) * len(procedures) * len(drugs) == 0:
             continue
-        # TODO: should also exclude visit with age < 18
         samples.append(
             {
                 "visit_id": visit.visit_id,
@@ -671,6 +695,23 @@ def drug_recommendation_omop_fn(patient: Patient):
     """
 
     samples = []
+
+    # Skip pediatric patients
+    demographics = patient.get_events(event_type="person")
+    if demographics:
+        person = demographics[0]
+        birth_year = getattr(person, "year_of_birth", None)
+        if birth_year is not None:
+            try:
+                birth_month = int(getattr(person, "month_of_birth", None) or 1)
+                birth_day = int(getattr(person, "day_of_birth", None) or 1)
+                dob = datetime(int(birth_year), birth_month, birth_day)
+                visits = patient.get_events(event_type="visit_occurrence")
+                if visits and (visits[0].timestamp - dob).days / 365.25 < 18:
+                    return []
+            except (ValueError, TypeError):
+                pass
+
     for i in range(len(patient)):
         visit: Visit = patient[i]
         conditions = visit.get_code_list(table="condition_occurrence")
@@ -679,7 +720,6 @@ def drug_recommendation_omop_fn(patient: Patient):
         # exclude: visits without condition, procedure, or drug code
         if len(conditions) * len(procedures) * len(drugs) == 0:
             continue
-        # TODO: should also exclude visit with age < 18
         samples.append(
             {
                 "visit_id": visit.visit_id,

--- a/pyhealth/tasks/length_of_stay_prediction.py
+++ b/pyhealth/tasks/length_of_stay_prediction.py
@@ -73,6 +73,17 @@ class LengthOfStayPredictionMIMIC3(BaseTask):
     }
     output_schema: Dict[str, str] = {"los": "multiclass"}
 
+    def __init__(self, exclude_minors: bool = True, **kwargs) -> None:
+        """Initializes the task object.
+
+        Args:
+            exclude_minors: Whether to exclude admissions where the patient
+                was under 18 years old. Defaults to True.
+            **kwargs: Passed to :class:`~pyhealth.tasks.BaseTask`.
+        """
+        super().__init__(**kwargs)
+        self.exclude_minors = exclude_minors
+
     def __call__(self, patient: Patient) -> List[Dict]:
         samples = []
 
@@ -117,16 +128,17 @@ class LengthOfStayPredictionMIMIC3(BaseTask):
             los_category = categorize_los(los_days)
 
             # Skip pediatric admissions
-            demographics = patient.get_events(event_type="patients")
-            if demographics:
-                dob_str = getattr(demographics[0], "dob", None)
-                if dob_str is not None:
-                    try:
-                        dob = datetime.strptime(str(dob_str)[:10], "%Y-%m-%d")
-                        if (admit_time - dob).days / 365.25 < 18:
-                            continue
-                    except (ValueError, TypeError):
-                        pass
+            if self.exclude_minors:
+                demographics = patient.get_events(event_type="patients")
+                if demographics:
+                    dob_str = getattr(demographics[0], "dob", None)
+                    if dob_str is not None:
+                        try:
+                            dob = datetime.strptime(str(dob_str)[:10], "%Y-%m-%d")
+                            if (admit_time - dob).days / 365.25 < 18:
+                                continue
+                        except (ValueError, TypeError):
+                            pass
 
             samples.append(
                 {
@@ -182,6 +194,17 @@ class LengthOfStayPredictionMIMIC4(BaseTask):
     }
     output_schema: Dict[str, str] = {"los": "multiclass"}
 
+    def __init__(self, exclude_minors: bool = True, **kwargs) -> None:
+        """Initializes the task object.
+
+        Args:
+            exclude_minors: Whether to exclude admissions where the patient
+                was under 18 years old. Defaults to True.
+            **kwargs: Passed to :class:`~pyhealth.tasks.BaseTask`.
+        """
+        super().__init__(**kwargs)
+        self.exclude_minors = exclude_minors
+
     def __call__(self, patient: Patient) -> List[Dict]:
         samples = []
 
@@ -231,14 +254,15 @@ class LengthOfStayPredictionMIMIC4(BaseTask):
             los_category = categorize_los(los_days)
 
             # Skip pediatric admissions
-            demographics = patient.get_events(event_type="patients")
-            if demographics:
-                anchor_age = getattr(demographics[0], "anchor_age", None)
-                try:
-                    if anchor_age is not None and int(float(anchor_age)) < 18:
-                        continue
-                except (ValueError, TypeError):
-                    pass
+            if self.exclude_minors:
+                demographics = patient.get_events(event_type="patients")
+                if demographics:
+                    anchor_age = getattr(demographics[0], "anchor_age", None)
+                    try:
+                        if anchor_age is not None and int(float(anchor_age)) < 18:
+                            continue
+                    except (ValueError, TypeError):
+                        pass
 
             samples.append(
                 {
@@ -422,6 +446,17 @@ class LengthOfStayPredictionOMOP(BaseTask):
     }
     output_schema: Dict[str, str] = {"los": "multiclass"}
 
+    def __init__(self, exclude_minors: bool = True, **kwargs) -> None:
+        """Initializes the task object.
+
+        Args:
+            exclude_minors: Whether to exclude visits where the patient
+                was under 18 years old. Defaults to True.
+            **kwargs: Passed to :class:`~pyhealth.tasks.BaseTask`.
+        """
+        super().__init__(**kwargs)
+        self.exclude_minors = exclude_minors
+
     def __call__(self, patient: Patient) -> List[Dict]:
         samples = []
 
@@ -468,19 +503,20 @@ class LengthOfStayPredictionOMOP(BaseTask):
             los_category = categorize_los(los_days)
 
             # Skip pediatric visits
-            demographics = patient.get_events(event_type="person")
-            if demographics:
-                person = demographics[0]
-                birth_year = getattr(person, "year_of_birth", None)
-                if birth_year is not None:
-                    try:
-                        birth_month = int(getattr(person, "month_of_birth", None) or 1)
-                        birth_day = int(getattr(person, "day_of_birth", None) or 1)
-                        dob = datetime(int(birth_year), birth_month, birth_day)
-                        if (admit_time - dob).days / 365.25 < 18:
-                            continue
-                    except (ValueError, TypeError):
-                        pass
+            if self.exclude_minors:
+                demographics = patient.get_events(event_type="person")
+                if demographics:
+                    person = demographics[0]
+                    birth_year = getattr(person, "year_of_birth", None)
+                    if birth_year is not None:
+                        try:
+                            birth_month = int(getattr(person, "month_of_birth", None) or 1)
+                            birth_day = int(getattr(person, "day_of_birth", None) or 1)
+                            dob = datetime(int(birth_year), birth_month, birth_day)
+                            if (admit_time - dob).days / 365.25 < 18:
+                                continue
+                        except (ValueError, TypeError):
+                            pass
 
             samples.append(
                 {

--- a/pyhealth/tasks/length_of_stay_prediction.py
+++ b/pyhealth/tasks/length_of_stay_prediction.py
@@ -116,7 +116,18 @@ class LengthOfStayPredictionMIMIC3(BaseTask):
             los_days = (discharge_time - admit_time).days
             los_category = categorize_los(los_days)
 
-            # TODO: should also exclude visit with age < 18
+            # Skip pediatric admissions
+            demographics = patient.get_events(event_type="patients")
+            if demographics:
+                dob_str = getattr(demographics[0], "dob", None)
+                if dob_str is not None:
+                    try:
+                        dob = datetime.strptime(str(dob_str)[:10], "%Y-%m-%d")
+                        if (admit_time - dob).days / 365.25 < 18:
+                            continue
+                    except (ValueError, TypeError):
+                        pass
+
             samples.append(
                 {
                     "visit_id": admission.hadm_id,
@@ -219,7 +230,16 @@ class LengthOfStayPredictionMIMIC4(BaseTask):
             los_days = (discharge_time - admit_time).days
             los_category = categorize_los(los_days)
 
-            # TODO: should also exclude visit with age < 18
+            # Skip pediatric admissions
+            demographics = patient.get_events(event_type="patients")
+            if demographics:
+                anchor_age = getattr(demographics[0], "anchor_age", None)
+                try:
+                    if anchor_age is not None and int(float(anchor_age)) < 18:
+                        continue
+                except (ValueError, TypeError):
+                    pass
+
             samples.append(
                 {
                     "visit_id": admission.hadm_id,
@@ -447,7 +467,21 @@ class LengthOfStayPredictionOMOP(BaseTask):
             los_days = (discharge_time - admit_time).days
             los_category = categorize_los(los_days)
 
-            # TODO: should also exclude visit with age < 18
+            # Skip pediatric visits
+            demographics = patient.get_events(event_type="person")
+            if demographics:
+                person = demographics[0]
+                birth_year = getattr(person, "year_of_birth", None)
+                if birth_year is not None:
+                    try:
+                        birth_month = int(getattr(person, "month_of_birth", None) or 1)
+                        birth_day = int(getattr(person, "day_of_birth", None) or 1)
+                        dob = datetime(int(birth_year), birth_month, birth_day)
+                        if (admit_time - dob).days / 365.25 < 18:
+                            continue
+                    except (ValueError, TypeError):
+                        pass
+
             samples.append(
                 {
                     "visit_id": visit.visit_occurrence_id,

--- a/pyhealth/tasks/length_of_stay_prediction.py
+++ b/pyhealth/tasks/length_of_stay_prediction.py
@@ -319,6 +319,17 @@ class LengthOfStayPredictioneICU(BaseTask):
     }
     output_schema: Dict[str, str] = {"los": "multiclass"}
 
+    def __init__(self, exclude_minors: bool = True, **kwargs) -> None:
+        """Initializes the task object.
+
+        Args:
+            exclude_minors: Whether to exclude stays where the patient
+                was under 18 years old. Defaults to True.
+            **kwargs: Passed to :class:`~pyhealth.tasks.BaseTask`.
+        """
+        super().__init__(**kwargs)
+        self.exclude_minors = exclude_minors
+
     def __call__(self, patient: Patient) -> List[Dict]:
         samples = []
 
@@ -376,6 +387,15 @@ class LengthOfStayPredictioneICU(BaseTask):
             # Exclude stays without condition, procedure, or drug code
             if len(conditions) * len(procedures) * len(drugs) == 0:
                 continue
+
+            # Skip pediatric stays
+            if self.exclude_minors:
+                age = getattr(stay, "age", None)
+                try:
+                    if age is not None and str(age) != "> 89" and int(float(age)) < 18:
+                        continue
+                except (ValueError, TypeError):
+                    pass
 
             # --- Length of stay ---
             # unitdischargeoffset is the number of minutes from ICU admission

--- a/pyhealth/tasks/mortality_prediction.py
+++ b/pyhealth/tasks/mortality_prediction.py
@@ -811,6 +811,17 @@ class MortalityPredictionEICU(BaseTask):
     }
     output_schema: Dict[str, str] = {"mortality": "binary"}
 
+    def __init__(self, exclude_minors: bool = True, **kwargs) -> None:
+        """Initializes the task object.
+
+        Args:
+            exclude_minors: Whether to exclude stays where the patient
+                was under 18 years old. Defaults to True.
+            **kwargs: Passed to :class:`~pyhealth.tasks.BaseTask`.
+        """
+        super().__init__(**kwargs)
+        self.exclude_minors = exclude_minors
+
     def __call__(self, patient: Any) -> List[Dict[str, Any]]:
         """Processes a single patient for the mortality prediction task.
 
@@ -875,13 +886,13 @@ class MortalityPredictionEICU(BaseTask):
             if len(conditions) * len(procedures_list) * len(drugs) == 0:
                 continue
 
-            # Exclude stays with age < 18
-            age = getattr(stay, "age", None)
-            try:
-                if age is not None and str(age) != "> 89" and int(float(age)) < 18:
-                    continue
-            except (ValueError, TypeError):
-                pass
+            if self.exclude_minors:
+                age = getattr(stay, "age", None)
+                try:
+                    if age is not None and str(age) != "> 89" and int(float(age)) < 18:
+                        continue
+                except (ValueError, TypeError):
+                    pass
 
             samples.append(
                 {
@@ -921,6 +932,17 @@ class MortalityPredictionEICU2(BaseTask):
     task_name: str = "MortalityPredictionEICU2"
     input_schema: Dict[str, str] = {"conditions": "sequence", "procedures": "sequence"}
     output_schema: Dict[str, str] = {"mortality": "binary"}
+
+    def __init__(self, exclude_minors: bool = True, **kwargs) -> None:
+        """Initializes the task object.
+
+        Args:
+            exclude_minors: Whether to exclude stays where the patient
+                was under 18 years old. Defaults to True.
+            **kwargs: Passed to :class:`~pyhealth.tasks.BaseTask`.
+        """
+        super().__init__(**kwargs)
+        self.exclude_minors = exclude_minors
 
     def __call__(self, patient: Any) -> List[Dict[str, Any]]:
         """Processes a single patient for the mortality prediction task.
@@ -997,13 +1019,13 @@ class MortalityPredictionEICU2(BaseTask):
             if len(conditions) * len(treatment_codes) == 0:
                 continue
 
-            # Exclude stays with age < 18
-            age = getattr(stay, "age", None)
-            try:
-                if age is not None and str(age) != "> 89" and int(float(age)) < 18:
-                    continue
-            except (ValueError, TypeError):
-                pass
+            if self.exclude_minors:
+                age = getattr(stay, "age", None)
+                try:
+                    if age is not None and str(age) != "> 89" and int(float(age)) < 18:
+                        continue
+                except (ValueError, TypeError):
+                    pass
 
             samples.append(
                 {

--- a/pyhealth/tasks/mortality_prediction.py
+++ b/pyhealth/tasks/mortality_prediction.py
@@ -875,7 +875,13 @@ class MortalityPredictionEICU(BaseTask):
             if len(conditions) * len(procedures_list) * len(drugs) == 0:
                 continue
 
-            # TODO: Exclude visits with age < 18
+            # Exclude stays with age < 18
+            age = getattr(stay, "age", None)
+            try:
+                if age is not None and str(age) != "> 89" and int(float(age)) < 18:
+                    continue
+            except (ValueError, TypeError):
+                pass
 
             samples.append(
                 {
@@ -991,7 +997,13 @@ class MortalityPredictionEICU2(BaseTask):
             if len(conditions) * len(treatment_codes) == 0:
                 continue
 
-            # TODO: Exclude visits with age < 18
+            # Exclude stays with age < 18
+            age = getattr(stay, "age", None)
+            try:
+                if age is not None and str(age) != "> 89" and int(float(age)) < 18:
+                    continue
+            except (ValueError, TypeError):
+                pass
 
             samples.append(
                 {


### PR DESCRIPTION
Multiple clinical prediction tasks had TODO comments saying that patients under 18 should be excluded, but the filtering was never implemented.

This adds age filtering to the mortality prediction, length-of-stay, and drug recommendation tasks across MIMIC-III, MIMIC-IV, eICU, and OMOP datasets. Adult prediction benchmarks shouldn't mix in pediatric cohorts b/c the clinical patterns are too different.

Some notes:
- eICU stores age as a string and uses "> 89" for patients over 89, so that case is handled explicitly
- MIMIC-III requires deriving age from dob and admission time since it doesn't store a precomputed age field
- All checks fail-open: if age data is missing or unparseable, the patient is included instead of dropped
