### PR TITLE
Fix SyntaxWarning in ece_confidence_multiclass docstring (#1142)

### DIFF
--- a/pyhealth/metrics/calibration.py
+++ b/pyhealth/metrics/calibration.py
@@ -99,7 +99,7 @@ def _ECE_classwise(prob:np.ndarray, label_onehot:np.ndarray, bins=20, threshold=
     return summs, class_losses
 
 def ece_confidence_multiclass(prob:np.ndarray, label:np.ndarray, bins=20, adaptive=False):
-    """Expected Calibration Error (ECE).
+    r"""Expected Calibration Error (ECE).
 
     We group samples into 'bins' basing on the top-class prediction.
     Then, we compute the absolute difference between the average top-class prediction and


### PR DESCRIPTION
## Summary
- Fixes #1142 by changing the `ece_confidence_multiclass` docstring to a raw string (`r"""..."""`).
- Prevents Python from treating LaTeX `\cdot` as an invalid escape sequence (`\c`) in the docstring example.

## Problem
Importing or parsing `pyhealth/metrics/calibration.py` emits:

This comes from the `:math:` example in `ece_confidence_multiclass`, where `\cdot` is interpreted as an escape sequence in a normal string.

## Solution
Use a raw docstring so backslashes in LaTeX notation are preserved literally.