### PR TITLE
Add LABEL example for MIMIC-IV length-of-stay

### DIFF
--- a/examples/conformal_ehr/los_mimic4_conformal.py
+++ b/examples/conformal_ehr/los_mimic4_conformal.py
@@ -70,7 +70,7 @@ def run_seed(samples, seed: int, alphas: list[float], epochs: int) -> dict:
         train_dataloader=train_loader,
         val_dataloader=val_loader,
         epochs=epochs,
-        monitor="accuracy",
+        monitor="f1_macro",
     )
 
     results = {}

--- a/examples/conformal_ehr/los_mimic4_conformal.py
+++ b/examples/conformal_ehr/los_mimic4_conformal.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--alphas",
-        default="0.2,0.1,0.05",
+        default="0.2,0.1,0.05,0.01",
         help="Comma-separated target miscoverage rates, e.g. '0.2,0.1,0.05'.",
     )
     parser.add_argument(

--- a/examples/conformal_ehr/los_mimic4_conformal.py
+++ b/examples/conformal_ehr/los_mimic4_conformal.py
@@ -8,10 +8,6 @@ This example demonstrates:
 3. Evaluating the prediction sets via overall coverage, average set size, and
    per-class miscoverage, averaged over multiple random seeds.
 
-Coverage on any single calibration/test split is high-variance, so results are
-averaged over several seeds and reported as mean +/- std. Per-class miscoverage is
-also reported, since it exposes class imbalance that overall coverage can hide.
-
 Usage:
     # Full dataset
     python los_mimic4_conformal.py --root /path/to/mimiciv/2.2
@@ -57,7 +53,7 @@ def run_seed(samples, seed: int, alphas: list[float], epochs: int) -> dict:
     np.random.seed(seed)
     torch.manual_seed(seed)
 
-    # Train / validation / calibration / test split (calibration is conformal-specific).
+    # Train / validation / calibration / test split.
     train_data, val_data, cal_data, test_data = split_by_patient_conformal(
         samples, ratios=[0.6, 0.1, 0.1, 0.2], seed=seed
     )
@@ -81,7 +77,6 @@ def run_seed(samples, seed: int, alphas: list[float], epochs: int) -> dict:
             test_loader, additional_outputs=["y_predset"]
         )
         predset = extra["y_predset"]
-        # The miscoverage metrics expect a 1D integer array of labels.
         y_true = np.asarray(y_true)
         coverage = 1 - miscoverage_overall_ps(predset, y_true)
         set_size = size(predset)
@@ -124,7 +119,6 @@ def main(
         print(f"{a:.2f}    {1 - a:.0%}    {cov.mean():.2f} +/- {cov.std():.2f}   "
               f"{sizes.mean():.1f} +/- {sizes.std():.1f}")
 
-    # Per-class miscoverage_ps (one value per LOS class), averaged over seeds.
     print(f"\nPer-class miscoverage_ps (mean over {len(seeds)} seeds):")
     for a in alphas:
         per_class = np.stack(class_miscov[a]).mean(0)

--- a/examples/conformal_ehr/los_mimic4_conformal.py
+++ b/examples/conformal_ehr/los_mimic4_conformal.py
@@ -1,30 +1,26 @@
 """
-Split conformal prediction for length of stay prediction on MIMIC-IV.
+Split conformal prediction for length-of-stay prediction on MIMIC-IV.
 
-Trains a Transformer on the MIMIC-IV LOS task (10 classes), then wraps it with
-LABEL (split conformal prediction) to use prediction sets instead of point predictions to
-guarantee coverage.
+This example demonstrates:
+1. Training a Transformer on the MIMIC-IV length-of-stay task (10 classes).
+2. Wrapping the trained model with LABEL (split conformal prediction) to produce
+   prediction sets with a user-specified coverage guarantee (1 - alpha).
+3. Evaluating the prediction sets via overall coverage, average set size, and
+   per-class miscoverage, averaged over multiple random seeds.
 
-Coverage on a single split is noisy here bc the demo only leaves  about 15 calibration
-patients, so I averaged over a few seeds like the conformal eeg example.
+Coverage on any single calibration/test split is high-variance, so results are
+averaged over several seeds and reported as mean +/- std. Per-class miscoverage is
+also reported, since it exposes class imbalance that overall coverage can hide.
 
-Results on the MIMIC-IV demo (100 patients):
+Usage:
+    # Full dataset
+    python los_mimic4_conformal.py --root /path/to/mimiciv/2.2
 
-    alpha  target  coverage        avg_set_size
-    0.20    80%    0.74 +/- 0.11    6.6 +/- 1.4
-    0.10    90%    0.93 +/- 0.08    8.8 +/- 0.6
-    0.05    95%    0.96 +/- 0.07    9.4 +/- 0.7
-
-The targets are all within the error bars. Coverage is near the target
-but noisy with so little patients. Sets shrink w/ less coverage.
-On full MIMIC-IV the model would be stronger, so the sets get much smaller and coverage
-tighter.
-
-I also print the per-class miscoverage_ps (miscoverage on each true LOS class).
-
-Run on the demo:
-    python los_mimic4_conformal.py --root /path/to/mimic-iv-clinical-database-demo-2.2
+    # Quick smoke test on a subsampled dataset
+    python los_mimic4_conformal.py --dev --epochs 1 --seeds 0
 """
+
+from __future__ import annotations
 
 import argparse
 import logging
@@ -48,12 +44,12 @@ from pyhealth.models import Transformer
 from pyhealth.tasks import LengthOfStayPredictionMIMIC4
 from pyhealth.trainer import Trainer
 
-# pyhealth logs the whole model at info on every Trainer init ( just want to quiet it down)
+# Quiet PyHealth's per-init model summary logging.
 logging.getLogger("pyhealth").setLevel(logging.WARNING)
 
 
-def run_seed(samples, seed, alphas):
-    """Split, train, and run conformal for one seed.
+def run_seed(samples, seed: int, alphas: list[float], epochs: int) -> dict:
+    """Train the base model and run split conformal prediction for a single seed.
 
     Returns {alpha: (coverage, avg_set_size, per_class_miscoverage)} on the test split.
     """
@@ -61,7 +57,7 @@ def run_seed(samples, seed, alphas):
     np.random.seed(seed)
     torch.manual_seed(seed)
 
-    # train / validation / calibration / test (calibration is the conformal specific one)
+    # Train / validation / calibration / test split (calibration is conformal-specific).
     train_data, val_data, cal_data, test_data = split_by_patient_conformal(
         samples, ratios=[0.6, 0.1, 0.1, 0.2], seed=seed
     )
@@ -73,7 +69,7 @@ def run_seed(samples, seed, alphas):
     Trainer(model=model, enable_logging=False).train(
         train_dataloader=train_loader,
         val_dataloader=val_loader,
-        epochs=10,
+        epochs=epochs,
         monitor="accuracy",
     )
 
@@ -85,7 +81,8 @@ def run_seed(samples, seed, alphas):
             test_loader, additional_outputs=["y_predset"]
         )
         predset = extra["y_predset"]
-        y_true = np.asarray(y_true)  # the miscoverage fns need a 1D int array
+        # The miscoverage metrics expect a 1D integer array of labels.
+        y_true = np.asarray(y_true)
         coverage = 1 - miscoverage_overall_ps(predset, y_true)
         set_size = size(predset)
         class_miscov = miscoverage_ps(predset, y_true)
@@ -93,31 +90,34 @@ def run_seed(samples, seed, alphas):
     return results
 
 
-def main(root):
+def main(
+    root: str,
+    seeds: list[int],
+    alphas: list[float],
+    epochs: int,
+    dev: bool,
+) -> None:
     dataset = MIMIC4Dataset(
         ehr_root=root,
         ehr_tables=["patients", "admissions", "diagnoses_icd",
                     "procedures_icd", "prescriptions"],
-        dev=False,
+        dev=dev,
     )
     samples = dataset.set_task(LengthOfStayPredictionMIMIC4())
-    print("samples:", len(samples))
+    print(f"Samples: {len(samples)}")
 
-    alphas = [0.2, 0.1, 0.05]
-    seeds = [0, 1, 2, 3, 4]
-
-    # average seeds
+    # Aggregate results across seeds.
     coverage = {a: [] for a in alphas}
     set_size = {a: [] for a in alphas}
     class_miscov = {a: [] for a in alphas}
     for seed in seeds:
-        results = run_seed(samples, seed, alphas)
+        results = run_seed(samples, seed, alphas, epochs)
         for a in alphas:
             coverage[a].append(results[a][0])
             set_size[a].append(results[a][1])
             class_miscov[a].append(results[a][2])
 
-    print(f"\nresults over {len(seeds)} seeds (mean +/- std)")
+    print(f"\nResults over {len(seeds)} seeds (mean +/- std):")
     print("alpha  target  coverage      avg_set_size")
     for a in alphas:
         cov = np.array(coverage[a])
@@ -125,19 +125,45 @@ def main(root):
         print(f"{a:.2f}    {1 - a:.0%}    {cov.mean():.2f} +/- {cov.std():.2f}   "
               f"{sizes.mean():.1f} +/- {sizes.std():.1f}")
 
-    # per-class miscoverage_ps (one value per LOS class), averaged over seeds
-    print(f"\nper-class miscoverage_ps (mean over {len(seeds)} seeds)")
+    # Per-class miscoverage_ps (one value per LOS class), averaged over seeds.
+    print(f"\nPer-class miscoverage_ps (mean over {len(seeds)} seeds):")
     for a in alphas:
         per_class = np.stack(class_miscov[a]).mean(0)
         print(f"alpha={a:.2f}: " + np.array2string(per_class, precision=2, floatmode="fixed"))
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Split conformal prediction for MIMIC-IV length-of-stay prediction."
+    )
     parser.add_argument(
         "--root",
         default="/srv/local/data/physionet.org/files/mimiciv/2.2",
-        help="MIMIC-IV root (the folder containing hosp/)",
+        help="MIMIC-IV root (the folder containing hosp/).",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=10,
+        help="Training epochs per seed.",
+    )
+    parser.add_argument(
+        "--seeds",
+        default="0,1,2,3,4",
+        help="Comma-separated random seeds to average over.",
+    )
+    parser.add_argument(
+        "--alphas",
+        default="0.2,0.1,0.05",
+        help="Comma-separated target miscoverage rates, e.g. '0.2,0.1,0.05'.",
+    )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Use a subsampled dataset for a quick smoke test.",
     )
     args = parser.parse_args()
-    main(args.root)
+
+    seeds = [int(s) for s in args.seeds.split(",")]
+    alphas = [float(a) for a in args.alphas.split(",")]
+    main(args.root, seeds, alphas, args.epochs, args.dev)

--- a/examples/conformal_ehr/los_mimic4_conformal.py
+++ b/examples/conformal_ehr/los_mimic4_conformal.py
@@ -128,7 +128,8 @@ def main(
     print(f"\nPer-class miscoverage_ps (mean over {len(seeds)} seeds):")
     for a in alphas:
         per_class = np.stack(class_miscov[a]).mean(0)
-        print(f"alpha={a:.2f}: " + np.array2string(per_class, precision=2, floatmode="fixed"))
+        print(f"alpha={a:.2f}: "
+              + np.array2string(per_class, precision=2, floatmode="fixed"))
 
 
 if __name__ == "__main__":
@@ -154,7 +155,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--alphas",
         default="0.2,0.1,0.05,0.01",
-        help="Comma-separated target miscoverage rates, e.g. '0.2,0.1,0.05'.",
+        help="Comma-separated target miscoverage rates, e.g. '0.2,0.1,0.05,0.01'.",
     )
     parser.add_argument(
         "--dev",

--- a/examples/conformal_ehr/los_mimic4_conformal.py
+++ b/examples/conformal_ehr/los_mimic4_conformal.py
@@ -66,7 +66,7 @@ def run_seed(samples, seed: int, alphas: list[float], epochs: int) -> dict:
     test_loader = get_dataloader(test_data, batch_size=32, shuffle=False)
 
     model = Transformer(dataset=samples)
-    Trainer(model=model, enable_logging=False).train(
+    Trainer(model=model).train(
         train_dataloader=train_loader,
         val_dataloader=val_loader,
         epochs=epochs,
@@ -99,8 +99,7 @@ def main(
 ) -> None:
     dataset = MIMIC4Dataset(
         ehr_root=root,
-        ehr_tables=["patients", "admissions", "diagnoses_icd",
-                    "procedures_icd", "prescriptions"],
+        ehr_tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
         dev=dev,
     )
     samples = dataset.set_task(LengthOfStayPredictionMIMIC4())

--- a/examples/conformal_ehr/los_mimic4_conformal.py
+++ b/examples/conformal_ehr/los_mimic4_conformal.py
@@ -3,7 +3,7 @@ Split conformal prediction for length of stay prediction on MIMIC-IV.
 
 Trains a Transformer on the MIMIC-IV LOS task (10 classes), then wraps it with
 LABEL (split conformal prediction) to use prediction sets instead of point predictions to
-guarantee coverage?
+guarantee coverage.
 
 Coverage on a single split is noisy here bc the demo only leaves  about 15 calibration
 patients, so I averaged over a few seeds like the conformal eeg example.
@@ -19,6 +19,8 @@ The targets are all within the error bars. Coverage is near the target
 but noisy with so little patients. Sets shrink w/ less coverage.
 On full MIMIC-IV the model would be stronger, so the sets get much smaller and coverage
 tighter.
+
+I also print the per-class miscoverage_ps (miscoverage on each true LOS class).
 
 Run on the demo:
     python los_mimic4_conformal.py --root /path/to/mimic-iv-clinical-database-demo-2.2
@@ -37,6 +39,11 @@ from pyhealth.datasets import (
     get_dataloader,
     split_by_patient_conformal,
 )
+from pyhealth.metrics.prediction_set import (
+    miscoverage_overall_ps,
+    miscoverage_ps,
+    size,
+)
 from pyhealth.models import Transformer
 from pyhealth.tasks import LengthOfStayPredictionMIMIC4
 from pyhealth.trainer import Trainer
@@ -48,7 +55,7 @@ logging.getLogger("pyhealth").setLevel(logging.WARNING)
 def run_seed(samples, seed, alphas):
     """Split, train, and run conformal for one seed.
 
-    Returns {alpha: (coverage, avg_set_size)} measured on the test split.
+    Returns {alpha: (coverage, avg_set_size, per_class_miscoverage)} on the test split.
     """
     random.seed(seed)
     np.random.seed(seed)
@@ -78,9 +85,11 @@ def run_seed(samples, seed, alphas):
             test_loader, additional_outputs=["y_predset"]
         )
         predset = extra["y_predset"]
-        coverage = predset[np.arange(len(y_true)), y_true].mean()
-        set_size = predset.sum(axis=1).mean()
-        results[alpha] = (coverage, set_size)
+        y_true = np.asarray(y_true)  # the miscoverage fns need a 1D int array
+        coverage = 1 - miscoverage_overall_ps(predset, y_true)
+        set_size = size(predset)
+        class_miscov = miscoverage_ps(predset, y_true)
+        results[alpha] = (coverage, set_size, class_miscov)
     return results
 
 
@@ -100,19 +109,27 @@ def main(root):
     # average seeds
     coverage = {a: [] for a in alphas}
     set_size = {a: [] for a in alphas}
+    class_miscov = {a: [] for a in alphas}
     for seed in seeds:
         results = run_seed(samples, seed, alphas)
         for a in alphas:
             coverage[a].append(results[a][0])
             set_size[a].append(results[a][1])
+            class_miscov[a].append(results[a][2])
 
     print(f"\nresults over {len(seeds)} seeds (mean +/- std)")
     print("alpha  target  coverage      avg_set_size")
     for a in alphas:
         cov = np.array(coverage[a])
-        size = np.array(set_size[a])
+        sizes = np.array(set_size[a])
         print(f"{a:.2f}    {1 - a:.0%}    {cov.mean():.2f} +/- {cov.std():.2f}   "
-              f"{size.mean():.1f} +/- {size.std():.1f}")
+              f"{sizes.mean():.1f} +/- {sizes.std():.1f}")
+
+    # per-class miscoverage_ps (one value per LOS class), averaged over seeds
+    print(f"\nper-class miscoverage_ps (mean over {len(seeds)} seeds)")
+    for a in alphas:
+        per_class = np.stack(class_miscov[a]).mean(0)
+        print(f"alpha={a:.2f}: " + np.array2string(per_class, precision=2, floatmode="fixed"))
 
 
 if __name__ == "__main__":

--- a/examples/conformal_ehr/los_mimic4_conformal.py
+++ b/examples/conformal_ehr/los_mimic4_conformal.py
@@ -1,0 +1,126 @@
+"""
+Split conformal prediction for length of stay prediction on MIMIC-IV.
+
+Trains a Transformer on the MIMIC-IV LOS task (10 classes), then wraps it with
+LABEL (split conformal prediction) to use prediction sets instead of point predictions to
+guarantee coverage?
+
+Coverage on a single split is noisy here bc the demo only leaves  about 15 calibration
+patients, so I averaged over a few seeds like the conformal eeg example.
+
+Results on the MIMIC-IV demo (100 patients):
+
+    alpha  target  coverage        avg_set_size
+    0.20    80%    0.74 +/- 0.11    6.6 +/- 1.4
+    0.10    90%    0.93 +/- 0.08    8.8 +/- 0.6
+    0.05    95%    0.96 +/- 0.07    9.4 +/- 0.7
+
+The targets are all within the error bars. Coverage is near the target
+but noisy with so little patients. Sets shrink w/ less coverage.
+On full MIMIC-IV the model would be stronger, so the sets get much smaller and coverage
+tighter.
+
+Run on the demo:
+    python los_mimic4_conformal.py --root /path/to/mimic-iv-clinical-database-demo-2.2
+"""
+
+import argparse
+import logging
+import random
+
+import numpy as np
+import torch
+
+from pyhealth.calib.predictionset import LABEL
+from pyhealth.datasets import (
+    MIMIC4Dataset,
+    get_dataloader,
+    split_by_patient_conformal,
+)
+from pyhealth.models import Transformer
+from pyhealth.tasks import LengthOfStayPredictionMIMIC4
+from pyhealth.trainer import Trainer
+
+# pyhealth logs the whole model at info on every Trainer init ( just want to quiet it down)
+logging.getLogger("pyhealth").setLevel(logging.WARNING)
+
+
+def run_seed(samples, seed, alphas):
+    """Split, train, and run conformal for one seed.
+
+    Returns {alpha: (coverage, avg_set_size)} measured on the test split.
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+    # train / validation / calibration / test (calibration is the conformal specific one)
+    train_data, val_data, cal_data, test_data = split_by_patient_conformal(
+        samples, ratios=[0.6, 0.1, 0.1, 0.2], seed=seed
+    )
+    train_loader = get_dataloader(train_data, batch_size=32, shuffle=True)
+    val_loader = get_dataloader(val_data, batch_size=32, shuffle=False)
+    test_loader = get_dataloader(test_data, batch_size=32, shuffle=False)
+
+    model = Transformer(dataset=samples)
+    Trainer(model=model, enable_logging=False).train(
+        train_dataloader=train_loader,
+        val_dataloader=val_loader,
+        epochs=10,
+        monitor="accuracy",
+    )
+
+    results = {}
+    for alpha in alphas:
+        cal_model = LABEL(model, alpha=alpha)
+        cal_model.calibrate(cal_dataset=cal_data)
+        y_true, _, _, extra = Trainer(model=cal_model, enable_logging=False).inference(
+            test_loader, additional_outputs=["y_predset"]
+        )
+        predset = extra["y_predset"]
+        coverage = predset[np.arange(len(y_true)), y_true].mean()
+        set_size = predset.sum(axis=1).mean()
+        results[alpha] = (coverage, set_size)
+    return results
+
+
+def main(root):
+    dataset = MIMIC4Dataset(
+        ehr_root=root,
+        ehr_tables=["patients", "admissions", "diagnoses_icd",
+                    "procedures_icd", "prescriptions"],
+        dev=False,
+    )
+    samples = dataset.set_task(LengthOfStayPredictionMIMIC4())
+    print("samples:", len(samples))
+
+    alphas = [0.2, 0.1, 0.05]
+    seeds = [0, 1, 2, 3, 4]
+
+    # average seeds
+    coverage = {a: [] for a in alphas}
+    set_size = {a: [] for a in alphas}
+    for seed in seeds:
+        results = run_seed(samples, seed, alphas)
+        for a in alphas:
+            coverage[a].append(results[a][0])
+            set_size[a].append(results[a][1])
+
+    print(f"\nresults over {len(seeds)} seeds (mean +/- std)")
+    print("alpha  target  coverage      avg_set_size")
+    for a in alphas:
+        cov = np.array(coverage[a])
+        size = np.array(set_size[a])
+        print(f"{a:.2f}    {1 - a:.0%}    {cov.mean():.2f} +/- {cov.std():.2f}   "
+              f"{size.mean():.1f} +/- {size.std():.1f}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root",
+        default="/srv/local/data/physionet.org/files/mimiciv/2.2",
+        help="MIMIC-IV root (the folder containing hosp/)",
+    )
+    args = parser.parse_args()
+    main(args.root)


### PR DESCRIPTION
Adds an example that wraps a Transformer with LABEL on the MIMIC-IV length-of-stay task (10 classes).

The script splits by patient into train/val/cal/test, trains the Transformer,
calibrates LABEL per alpha, and reports coverage / average set size / per-class miscoverage
averaged over 5 seeds. 

Results (full MIMIC-IV, marginal LABEL, mean ± std over 5 seeds):

| alpha | target | coverage | avg set size |
|-------|--------|----------|--------------|
| 0.20  | 80%    | 0.80 ± 0.00 | 3.6 ± 0.1 |
| 0.10  | 90%    | 0.90 ± 0.00 | 4.7 ± 0.1 |
| 0.05  | 95%    | 0.95 ± 0.00 | 5.7 ± 0.1 |
| 0.01  | 99%    | 0.99 ± 0.00 | 7.3 ± 0.1 |

Per-class miscoverage (one value per LOS class):

alpha=0.20: [0.18 0.15 0.15 0.16 0.23 0.28 0.37 0.49 0.12 0.14]
alpha=0.10: [0.11 0.08 0.08 0.08 0.10 0.12 0.17 0.22 0.06 0.09]
alpha=0.05: [0.07 0.05 0.04 0.04 0.05 0.05 0.07 0.10 0.03 0.05]
alpha=0.01: [0.02 0.01 0.01 0.01 0.01 0.01 0.01 0.01 0.01 0.02]

Some notes:
- Marginal LABEL only for now unless we want class condition al