### PR TITLE
fix: include __init__ docstrings in Sphinx documentation output (Fixes #1144)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,9 +102,10 @@ nbsphinx_execute = "never"
 # Generate the API documentation when building
 autosummary_generate = True
 autodoc_member_order = "bysource"
+autoclass_content = "both"  # include both class and __init__ docstrings
 napoleon_google_docstring = True  # for pytorch lightning
 napoleon_numpy_docstring = True
-napoleon_include_init_with_doc = False
+napoleon_include_init_with_doc = True
 napoleon_use_rtype = True  # separate entry generally helps readability
 napoleon_use_param = True
 napoleon_custom_sections = [("Params", "Parameters")]


### PR DESCRIPTION
Fixes #1144

## Problem

The current Sphinx documentation configuration excludes `__init__` docstrings from the generated HTML output. This means important constructor parameter documentation is missing from the ReadTheDocs pages.

For example, `ChestXray14Dataset`'s `__init__` docstring documents the `tables` parameter, but it doesn't appear in the generated docs.

## Root Cause

Two settings in `docs/conf.py` prevent `__init__` docstrings from appearing:

1. `autoclass_content` defaults to `"class"` — only the class-level docstring is included
2. `napoleon_include_init_with_doc = False` — Napoleon explicitly excludes `__init__` docs

## Solution

- Set `autoclass_content = "both"` so Sphinx renders both the class-level and `__init__` docstrings
- Change `napoleon_include_init_with_doc` from `False` to `True` so Napoleon-flavoured init docs appear in the generated HTML

## Testing

The fix can be verified by building the docs locally:

```bash
cd docs && make html
```

Or by checking that `__init__` parameter docs now appear in class pages on ReadTheDocs after merge.

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-20 | Add autoclass_content='both' and enable napoleon_include_init_with_doc | rtmalikian |

### Files Changed
- docs/conf.py — Added `autoclass_content = "both"`, changed `napoleon_include_init_with_doc` to `True`

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
