### PR TITLE
fix: add missing stacklevel=2 to 14 warnings.warn() calls (Fixes #1164)

### DIFF
--- a/pyhealth/data/__init__.py
+++ b/pyhealth/data/__init__.py
@@ -5,4 +5,4 @@ class Visit:
     """This class is deprecated and should not be used."""
     def __init__(self, *args, **kwargs):
         import warnings
-        warnings.warn("The Visit class is deprecated and will be removed in a future version.", DeprecationWarning)
+        warnings.warn("The Visit class is deprecated and will be removed in a future version.", DeprecationWarning, stacklevel=2)

--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -7,6 +7,7 @@ class BaseEHRDataset:
         warnings.warn(
             "The BaseEHRDataset class is deprecated and will be removed in a future version.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
 
@@ -19,6 +20,7 @@ class BaseSignalDataset:
         warnings.warn(
             "The BaseSignalDataset class is deprecated and will be removed in a future version.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
 
@@ -31,6 +33,7 @@ class SampleEHRDataset:
         warnings.warn(
             "The SampleEHRDataset class is deprecated and will be removed in a future version.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
 
@@ -43,6 +46,7 @@ class SampleSignalDataset:
         warnings.warn(
             "The SampleSignalDataset class is deprecated and will be removed in a future version.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
 

--- a/pyhealth/datasets/mimic3.py
+++ b/pyhealth/datasets/mimic3.py
@@ -60,6 +60,7 @@ class MIMIC3Dataset(BaseDataset):
                 "Events from prescriptions table only have date timestamp (no specific time). "
                 "This may affect temporal ordering of events.",
                 UserWarning,
+                stacklevel=2,
             )
         super().__init__(
             root=root,

--- a/pyhealth/datasets/mimic4.py
+++ b/pyhealth/datasets/mimic4.py
@@ -122,12 +122,14 @@ class MIMIC4NoteDataset(BaseDataset):
                 "Events from discharge table only have date timestamp (no specific time). "
                 "This may affect temporal ordering of events.",
                 UserWarning,
+                stacklevel=2,
             )
         if "discharge_detail" in tables:
             warnings.warn(
                 "Events from discharge_detail table only have date timestamp (no specific time). "
                 "This may affect temporal ordering of events.",
                 UserWarning,
+                stacklevel=2,
             )
         log_memory_usage(f"Before initializing {dataset_name}")
         super().__init__(

--- a/pyhealth/models/concare.py
+++ b/pyhealth/models/concare.py
@@ -954,6 +954,7 @@ class ConCare(BaseModel):
                     "and sum-pooled per visit for memory efficiency. This reduces "
                     "per-visit code representations to a single scalar.",
                     UserWarning,
+                    stacklevel=2,
                 )
             else:
                 input_dim = proc.size()

--- a/pyhealth/models/stagenet.py
+++ b/pyhealth/models/stagenet.py
@@ -440,6 +440,7 @@ class StageNet(BaseModel, Interpretable):
                     f"StageNet format with time intervals for "
                     f"better performance.",
                     UserWarning,
+                    stacklevel=2,
                 )
             else:
                 time = time.to(self.device)
@@ -453,6 +454,7 @@ class StageNet(BaseModel, Interpretable):
                     f"Feature '{feature_key}' does not have mask "
                     f"information. Default mask will be created from "
                     f"embedded values. But it may not be accurate.",
+                    stacklevel=2,
                 )
                 mask = (value.abs().sum(dim=-1) != 0).int()
             elif not processor.is_token() and value.dim() == mask.dim():

--- a/pyhealth/models/stagenet_mha.py
+++ b/pyhealth/models/stagenet_mha.py
@@ -516,6 +516,7 @@ class StageAttentionNet(BaseModel, CheferInterpretable):
                     f"StageNet format with time intervals for "
                     f"better performance.",
                     UserWarning,
+                    stacklevel=2,
                 )
             else:
                 time = time.to(self.device)
@@ -528,6 +529,7 @@ class StageAttentionNet(BaseModel, CheferInterpretable):
                     f"Feature '{feature_key}' does not have mask "
                     f"information. Default mask will be created from "
                     f"embedded values. But it may not be accurate.",
+                    stacklevel=2,
                 )
                 mask = (value.abs().sum(dim=-1) != 0).int()
             elif not processor.is_token() and value.dim() == mask.dim():

--- a/pyhealth/models/text_embedding.py
+++ b/pyhealth/models/text_embedding.py
@@ -244,6 +244,7 @@ class TextEmbedding(nn.Module):
                 f"Text produced {original_chunks} chunks, truncated to {self.max_chunks}. "
                 f"Consider increasing max_chunks or summarizing input.",
                 UserWarning,
+                stacklevel=2,
             )
 
         # Step 4: Pad chunks to uniform length for batched encoding


### PR DESCRIPTION
Fixes #1164

## Summary

Add `stacklevel=2` to 14 `warnings.warn()` calls across 8 files that were missing it. Without `stacklevel=2`, warnings point to library internals instead of the user's code, making them confusing and hard to act on.

## Changes

| File | Calls Fixed | Warning Context |
|------|-------------|-----------------|
| `pyhealth/data/__init__.py` | 1 | Visit class deprecation |
| `pyhealth/datasets/__init__.py` | 4 | BaseEHRDataset, BaseSignalDataset, SampleEHRDataset, SampleSignalDataset deprecations |
| `pyhealth/datasets/mimic3.py` | 1 | Prescriptions table date-only timestamps |
| `pyhealth/datasets/mimic4.py` | 2 | Discharge/discharge_detail table date-only timestamps |
| `pyhealth/models/concare.py` | 1 | Nested sequence vocab_size warning |
| `pyhealth/models/stagenet.py` | 2 | Missing time intervals and mask warnings |
| `pyhealth/models/stagenet_mha.py` | 2 | Missing time intervals and mask warnings |
| `pyhealth/models/text_embedding.py` | 1 | Text chunk truncation warning |

## Verification

```bash
# Syntax check all modified files
python3 -c "import ast, os; [ast.parse(open(os.path.join(r,f)).read()) for r,d,fs in os.walk('pyhealth') for f in fs if f.endswith('.py')]"

# Verify all warnings.warn() calls have stacklevel
python3 -c "
import ast, os
for r, d, fs in os.walk('pyhealth'):
    for f in fs:
        if f.endswith('.py'):
            tree = ast.parse(open(os.path.join(r,f)).read())
            for node in ast.walk(tree):
                if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == 'warn':
                    assert any(kw.arg == 'stacklevel' for kw in node.keywords), f'{os.path.join(r,f)}:{node.lineno}'
print('All warnings.warn() calls have stacklevel')
"
```

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-20 | Add stacklevel=2 to 14 warnings.warn() calls across 8 files | rtmalikian |

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
