### PR TITLE
fix: use context manager for file operations in cardiology_detect.py (Fixes #1171)

### DIFF
--- a/pyhealth/tasks/cardiology_detect.py
+++ b/pyhealth/tasks/cardiology_detect.py
@@ -73,7 +73,8 @@ def cardiology_isAR_fn(record, epoch_sec=10, shift=5):
         
         # X load
         X = loadmat(os.path.join(root, signal))["val"]
-        label_content =  open(os.path.join(root, label), "r").readlines()
+        with open(os.path.join(root, label), "r") as f:
+            label_content = f.readlines()
         Dx, Sex, Age = label_content[-4].split(" ")[-1][:-1].split(","), \
                 label_content[-5].split(" ")[-1][:-1].split(","), \
                 label_content[-6].split(" ")[-1][:-1].split(",")
@@ -169,7 +170,8 @@ def cardiology_isBBBFB_fn(record, epoch_sec=10, shift=5):
         
         # X load
         X = loadmat(os.path.join(root, signal))["val"]
-        label_content =  open(os.path.join(root, label), "r").readlines()
+        with open(os.path.join(root, label), "r") as f:
+            label_content = f.readlines()
         Dx, Sex, Age = label_content[-4].split(" ")[-1][:-1].split(","), label_content[-5].split(" ")[-1][:-1].split(","), label_content[-6].split(" ")[-1][:-1].split(",")
 
         y = 1 if set(Dx).intersection(BBBFB_space) else 0
@@ -263,7 +265,8 @@ def cardiology_isAD_fn(record, epoch_sec=10, shift=5):
         
         # X load
         X = loadmat(os.path.join(root, signal))["val"]
-        label_content =  open(os.path.join(root, label), "r").readlines()
+        with open(os.path.join(root, label), "r") as f:
+            label_content = f.readlines()
         Dx, Sex, Age = label_content[-4].split(" ")[-1][:-1].split(","), label_content[-5].split(" ")[-1][:-1].split(","), label_content[-6].split(" ")[-1][:-1].split(",")
 
         y = 1 if set(Dx).intersection(AD_space) else 0
@@ -357,7 +360,8 @@ def cardiology_isCD_fn(record, epoch_sec=10, shift=5):
         
         # X load
         X = loadmat(os.path.join(root, signal))["val"]
-        label_content =  open(os.path.join(root, label), "r").readlines()
+        with open(os.path.join(root, label), "r") as f:
+            label_content = f.readlines()
         Dx, Sex, Age = label_content[-4].split(" ")[-1][:-1].split(","), label_content[-5].split(" ")[-1][:-1].split(","), label_content[-6].split(" ")[-1][:-1].split(",")
 
         y = 1 if set(Dx).intersection(CD_space) else 0
@@ -451,7 +455,8 @@ def cardiology_isWA_fn(record, epoch_sec=10, shift=5):
         
         # X load
         X = loadmat(os.path.join(root, signal))["val"]
-        label_content =  open(os.path.join(root, label), "r").readlines()
+        with open(os.path.join(root, label), "r") as f:
+            label_content = f.readlines()
         Dx, Sex, Age = label_content[-4].split(" ")[-1][:-1].split(","), label_content[-5].split(" ")[-1][:-1].split(","), label_content[-6].split(" ")[-1][:-1].split(",")
 
 


### PR DESCRIPTION
Fixes #1171

## Problem
`pyhealth/tasks/cardiology_detect.py` uses bare `open().readlines()` calls in 5 places. These rely on CPython's reference counting for file handle cleanup, which is not guaranteed behavior across all Python implementations.

## Root Cause
The original code uses the pattern:
```python
label_content = open(os.path.join(root, label), "r").readlines()
```
This leaves the file handle cleanup to garbage collection rather than explicit resource management.

## Solution
Replaced all 5 occurrences with `with open() as f:` context managers:
```python
with open(os.path.join(root, label), "r") as f:
    label_content = f.readlines()
```

## Verification
- `grep -c "=  open(" pyhealth/tasks/cardiology_detect.py` → 0 (all bare open calls removed)
- `ast.parse()`: syntax check passes
- `git diff`: 10 insertions, 5 deletions across 5 sites

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-07-01 | Replace 5 bare open() calls with context managers | rtmalikian |

### Files Changed
- pyhealth/tasks/cardiology_detect.py — Wrapped 5 `open().readlines()` calls in `with` statements

### Verification
- 0 bare open() calls remaining in the file
- Syntax check: ast.parse() passes

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from DeepSeek-V4 (DeepSeek) via Hermes Agent (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
