### PR TITLE
Fix PatientLinkageMIMIC3Task crashing on invalid processor names

### DIFF
--- a/docs/api/tasks.rst
+++ b/docs/api/tasks.rst
@@ -219,7 +219,8 @@ Available Tasks
     MPF Clinical Prediction (FHIR) <tasks/pyhealth.tasks.mpf_clinical_prediction>
     Mortality Prediction (Next Visit) <tasks/pyhealth.tasks.mortality_prediction>
     Mortality Prediction (StageNet MIMIC-IV) <tasks/pyhealth.tasks.mortality_prediction_stagenet_mimic4>
-    Patient Linkage (MIMIC-III) <tasks/pyhealth.tasks.patient_linkage_mimic3_fn>
+    Patient Linkage (MIMIC-III, legacy) <tasks/pyhealth.tasks.patient_linkage_mimic3_fn>
+    Patient Linkage (MIMIC-III) <tasks/pyhealth.tasks.patient_linkage_mimic3>
     Readmission Prediction <tasks/pyhealth.tasks.readmission_prediction>
     Sleep Staging <tasks/pyhealth.tasks.sleep_staging>
     Sleep Staging (SleepEDF) <tasks/pyhealth.tasks.SleepStagingSleepEDF>

--- a/docs/api/tasks/pyhealth.tasks.patient_linkage_mimic3.rst
+++ b/docs/api/tasks/pyhealth.tasks.patient_linkage_mimic3.rst
@@ -1,0 +1,7 @@
+pyhealth.tasks.patient_linkage_mimic3
+=======================================
+
+.. autoclass:: pyhealth.tasks.patient_linkage_mimic3.PatientLinkageMIMIC3Task
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/patient_linkage_mimic3_medlink.py
+++ b/examples/patient_linkage_mimic3_medlink.py
@@ -37,7 +37,7 @@ task = PatientLinkageMIMIC3Task()
 sample_dataset = base_dataset.set_task(task)
 print(f"Number of samples: {len(sample_dataset)}")
 corpus, queries, qrels, corpus_meta, queries_meta = convert_to_ir_format(
-    sample_dataset.samples
+    sample_dataset
 )
 tr_queries, va_queries, te_queries, tr_qrels, va_qrels, te_qrels = tvt_split(
     queries, qrels

--- a/examples/patient_linkage_mimic3_medlink.py
+++ b/examples/patient_linkage_mimic3_medlink.py
@@ -30,12 +30,12 @@ base_dataset = MIMIC3Dataset(
     root="/srv/local/data/physionet.org/files/mimiciii/1.4",
     tables=["DIAGNOSES_ICD"],
 )
-base_dataset.stat()
+base_dataset.stats()
 
 """ STEP 2: set task """
 task = PatientLinkageMIMIC3Task()
 sample_dataset = base_dataset.set_task(task)
-sample_dataset.stat()
+print(f"Number of samples: {len(sample_dataset)}")
 corpus, queries, qrels, corpus_meta, queries_meta = convert_to_ir_format(
     sample_dataset.samples
 )

--- a/pyhealth/tasks/patient_linkage_mimic3.py
+++ b/pyhealth/tasks/patient_linkage_mimic3.py
@@ -16,29 +16,13 @@ class PatientLinkageMIMIC3Task(BaseTask):
 
     Example:
         >>> from pyhealth.datasets import MIMIC3Dataset
-        >>> from pyhealth.tasks import patient_linkage_mimic3
+        >>> from pyhealth.tasks import PatientLinkageMIMIC3Task
         >>> dataset = MIMIC3Dataset(
         ...     root="/srv/local/data/physionet.org/files/mimiciii/1.4",
-        ...     tables=["DIAGNOSES_ICD", "ADMISSIONS", "PATIENTS"],
-        ...     code_mapping={"ICD9CM": ("CCSCM", {"target": "dx"})},
+        ...     tables=["diagnoses_icd", "admissions", "patients"],
         ... )
-        >>> sample_dataset = dataset.set_task(patient_linkage_mimic3)
-        >>> sample_dataset.samples[0]
-        {
-            'patient_id': '109',
-            'visit_id': '173633',
-            'conditions': ['', '989'],
-            'age': 25,
-            'identifiers': 'F+Government+English+NOT SPECIFIED+SINGLE+BLACK/AFRICAN AMERICAN',
-            'timestamp': datetime.datetime(2141, 9, 18, 11, 23),
-            'd_visit_id': '172335',
-            'd_conditions': ['', '989', '[SEP]', '989'],
-            'd_age': 25,
-            'd_identifiers': 'F+Government+English+NOT SPECIFIED+SINGLE+BLACK/AFRICAN AMERICAN',
-            'd_timestamp': datetime.datetime(2141, 9, 18, 11, 23),
-            'time_gap_days': 0,
-            'd_visit_ids': '172335|170258'
-        }
+        >>> task = PatientLinkageMIMIC3Task()
+        >>> sample_dataset = dataset.set_task(task)
     """
 
     task_name = "patient_linkage_mimic3"
@@ -46,22 +30,22 @@ class PatientLinkageMIMIC3Task(BaseTask):
     input_schema = {
         # Query side (last admission)
         "conditions": "sequence",
-        "age": "integer",
-        "identifiers": "string",
-        "visit_id": "string",
-        "timestamp": "datetime",
-        
+        "age": "raw",
+        "identifiers": "raw",
+        "visit_id": "raw",
+        "timestamp": "raw",
+
         # Positive database side (all previous admissions concatenated)
         "d_conditions": "sequence",  # concatenated with [SEP] tokens
-        "d_age": "integer",
-        "d_identifiers": "string",
-        "d_visit_id": "string",      # hadm_id of the most recent prior admission
-        "d_timestamp": "datetime",   # timestamp of most recent prior admission
-        
+        "d_age": "raw",
+        "d_identifiers": "raw",
+        "d_visit_id": "raw",      # hadm_id of the most recent prior admission
+        "d_timestamp": "raw",   # timestamp of most recent prior admission
+
         # Metadata
-        "patient_id": "string",      # ground truth for evaluation
-        "time_gap_days": "integer",  # for analysis by time interval
-        "d_visit_ids": "string",     # pipe-separated list of all prior hadm_ids
+        "patient_id": "raw",      # ground truth for evaluation
+        "time_gap_days": "raw",  # for analysis by time interval
+        "d_visit_ids": "raw",     # pipe-separated list of all prior hadm_ids
     }
     
     output_schema = {}  # Task just creates pairs; model outputs matching scores

--- a/tests/core/test_patient_linkage_mimic3.py
+++ b/tests/core/test_patient_linkage_mimic3.py
@@ -1,0 +1,60 @@
+import unittest
+from pathlib import Path
+
+from pyhealth.datasets import MIMIC3Dataset
+from pyhealth.tasks import PatientLinkageMIMIC3Task
+
+
+class TestPatientLinkageMIMIC3Task(unittest.TestCase):
+    """Regression test: PatientLinkageMIMIC3Task's input_schema previously
+    used processor-type strings ("integer", "string", "datetime") that
+    aren't registered in pyhealth.processors, so dataset.set_task() failed
+    immediately with ValueError: Unknown processor. Fixed to use "raw"
+    (pass-through), the correct processor for these metadata fields.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        test_dir = Path(__file__).parent.parent.parent
+        root = str(test_dir / "test-resources" / "core" / "mimic3demo")
+        cls.dataset = MIMIC3Dataset(
+            root=root, tables=["diagnoses_icd", "admissions", "patients"]
+        )
+
+    def test_set_task_runs_without_error(self):
+        # This is the direct regression check: set_task() used to raise
+        # ValueError: Unknown processor: integer before reaching any patient.
+        sample_dataset = self.dataset.set_task(PatientLinkageMIMIC3Task())
+        self.assertGreater(len(sample_dataset), 0)
+
+    def test_raw_call_produces_query_and_history_pair(self):
+        # Patient 44083 has 3 admissions; the query is the last (198330),
+        # and the history side concatenates the two earlier ones
+        # (125157, then 131048) with a single [SEP] separator.
+        patient = self.dataset.get_patient("44083")
+        samples = PatientLinkageMIMIC3Task()(patient)
+        self.assertEqual(len(samples), 1)
+        sample = samples[0]
+
+        self.assertEqual(sample["visit_id"], "198330")
+        self.assertEqual(sample["d_visit_id"], "131048")
+        self.assertEqual(sample["d_visit_ids"], "125157|131048")
+        self.assertIn("[SEP]", sample["d_conditions"])
+        self.assertGreater(len(sample["conditions"]), 0)
+        self.assertGreater(len(sample["d_conditions"]), 0)
+
+    def test_single_prior_admission_has_no_separator(self):
+        # Patient 10094 has exactly one prior admission (168074) before the
+        # query, so d_conditions should have no [SEP] token and a single
+        # entry in d_visit_ids.
+        patient = self.dataset.get_patient("10094")
+        samples = PatientLinkageMIMIC3Task()(patient)
+        self.assertEqual(len(samples), 1)
+        sample = samples[0]
+
+        self.assertEqual(sample["d_visit_ids"], "168074")
+        self.assertNotIn("[SEP]", sample["d_conditions"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_patient_linkage_mimic3.py
+++ b/tests/core/test_patient_linkage_mimic3.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 
 from pyhealth.datasets import MIMIC3Dataset
+from pyhealth.models.medlink import convert_to_ir_format
 from pyhealth.tasks import PatientLinkageMIMIC3Task
 
 
@@ -54,6 +55,23 @@ class TestPatientLinkageMIMIC3Task(unittest.TestCase):
 
         self.assertEqual(sample["d_visit_ids"], "168074")
         self.assertNotIn("[SEP]", sample["d_conditions"])
+
+    def test_convert_to_ir_format_accepts_sample_dataset_directly(self):
+        # Regression check for the patient_linkage_mimic3_medlink.py example:
+        # it used to call convert_to_ir_format(sample_dataset.samples), but
+        # SampleDataset has no .samples attribute (only __iter__/__getitem__/
+        # __len__), so that line raised AttributeError even after the
+        # processor-name fix above. convert_to_ir_format only iterates its
+        # argument, so the SampleDataset itself must work directly.
+        sample_dataset = self.dataset.set_task(PatientLinkageMIMIC3Task())
+        corpus, queries, qrels, corpus_meta, queries_meta = convert_to_ir_format(
+            sample_dataset
+        )
+        self.assertEqual(len(queries), len(sample_dataset))
+        self.assertEqual(set(queries.keys()), set(qrels.keys()))
+        self.assertEqual(set(queries.keys()), set(queries_meta.keys()))
+        self.assertTrue(corpus)
+        self.assertEqual(set(corpus.keys()), set(corpus_meta.keys()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- input_schema used "integer"/"string"/"datetime" processor-type strings, none of which are registered in pyhealth.processors, so dataset.set_task() failed immediately with ValueError: Unknown processor. Fixed to use "raw" (pass-through), the correct processor for these metadata fields
- Fix the class docstring's example, which referenced a non-existent patient_linkage_mimic3 importable name instead of the class itself
- Add the missing docs page for PatientLinkageMIMIC3Task
- examples/patient_linkage_mimic3_medlink.py uses this exact class and was broken by the same bug plus two unrelated .stat()/.stats() typos; fix the typos and confirm data loading + task application now run and produce real samples