### PR TITLE
Fix broken GAMENet example; flag legacy LOC scripts as 1.1.6-only

### DIFF
--- a/examples/benchmark_perf/loc/minimal_legacy_drug_rec.py
+++ b/examples/benchmark_perf/loc/minimal_legacy_drug_rec.py
@@ -1,3 +1,4 @@
+# Requires pyhealth==1.1.6 (legacy 1.x task_fn/Visit API) -- not runnable against pyhealth 2.0
 from pyhealth.data import Patient,Visit; from pyhealth.datasets import MIMIC4Dataset
 
 def drug_recommendation_mimic4_fn(patient):

--- a/examples/benchmark_perf/loc/minimal_legacy_los.py
+++ b/examples/benchmark_perf/loc/minimal_legacy_los.py
@@ -1,3 +1,4 @@
+# Requires pyhealth==1.1.6 (legacy 1.x task_fn/Visit API) -- not runnable against pyhealth 2.0
 from pyhealth.datasets import MIMIC4Dataset
 
 def categorize_los(d): return 0 if d<1 else (d if d<=7 else (8 if d<=14 else 9))

--- a/examples/benchmark_perf/loc/minimal_legacy_mortality.py
+++ b/examples/benchmark_perf/loc/minimal_legacy_mortality.py
@@ -1,3 +1,4 @@
+# Requires pyhealth==1.1.6 (legacy 1.x task_fn/Visit API) -- not runnable against pyhealth 2.0
 from collections import defaultdict; from pyhealth.data import Patient; from pyhealth.datasets import MIMIC4Dataset
 from typing import Dict,List
 

--- a/examples/drug_recommendation/drug_recommendation_mimic4_gamenet.py
+++ b/examples/drug_recommendation/drug_recommendation_mimic4_gamenet.py
@@ -1,12 +1,8 @@
-# import pyhealth
-import pyhealth
-
-# import mimic4 dataset and drug recommendaton task
+# import mimic4 dataset and drug recommendation task
 from pyhealth.datasets import MIMIC4Dataset
-from pyhealth.tasks import drug_recommendation_mimic4_fn
+from pyhealth.tasks import DrugRecommendationMIMIC4
 
 # import dataloader related functions
-from pyhealth.datasets.splitter import split_by_patient
 from pyhealth.datasets import split_by_patient, get_dataloader
 
 # import gamenet model
@@ -23,16 +19,14 @@ _DECAY_WEIGHT = 1e-5
 
 def prepare_drug_task_data():
     mimicvi = MIMIC4Dataset(
-        root="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
-        tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
+        ehr_root="/srv/local/data/physionet.org/files/mimiciv/2.0/hosp",
+        ehr_tables=["diagnoses_icd", "procedures_icd", "prescriptions"],
+        dev=_DEV,
     )
 
-    print("stat")
-    mimicvi.stat()
-    print("info")
-    mimicvi.info()
+    mimicvi.stats()
 
-    mimic4_sample = mimicvi.set_task(drug_recommendation_mimic4_fn)
+    mimic4_sample = mimicvi.set_task(DrugRecommendationMIMIC4())
     print(mimic4_sample[0])
 
     return mimic4_sample
@@ -50,14 +44,10 @@ def get_dataloaders(mimic4_sample):
 
 
 def train_gamenet(mimic4_sample, train_loader, val_loader):
-    # gamenet = GAMENet(mimicvi)
-    gamenet = GAMENet(mimic4_sample)
+    gamenet = GAMENet(dataset=mimic4_sample)
 
-    # print(gamenet.generate_ddi_adj())
     trainer = Trainer(
         model=gamenet,
-        # metrics = ["jaccard_weighted", "pr_auc_micro", "pr_auc_macro"],
-        # metrics = ["jaccard", "pr_auc_micro", "pr_auc_macro"],
         metrics=[
             "jaccard_samples",
             "accuracy",
@@ -67,7 +57,6 @@ def train_gamenet(mimic4_sample, train_loader, val_loader):
             "pr_auc_samples",
             "f1_samples",
         ],
-        device="cuda",
         exp_name="drug_recommendation",
     )
 


### PR DESCRIPTION
- drug_recommendation_mimic4_gamenet.py called set_task() with a dead legacy function and used several other stale pre-2.0 API calls (root=/tables= kwargs, .stat()/.info(), hardcoded device="cuda"). Rewrote it to use DrugRecommendationMIMIC4, current dataset kwargs, and .stats(); dropped the CUDA hardcode so it runs on CPU too

- minimal_legacy_*.py (LOC benchmark scripts) are deliberately pre-2.0-API by design, for comparison against their 2.0-style siblings, but unlike their legacy_ver/ counterparts, they didn't disclose that. Added the same "requires pyhealth==1.1.6" note; no behavior change