### PR TITLE
Fix BIOT channel embedding ignoring emb_size

### DIFF
--- a/pyhealth/models/biot.py
+++ b/pyhealth/models/biot.py
@@ -132,6 +132,7 @@ class BIOTEncoder(nn.Module):
     """Encoder for multichannel biosignals.
 
     Examples:
+        >>> _ = _get_linear_attention_transformer()
         >>> encoder = BIOTEncoder(
         ...     emb_size=128, heads=8, depth=2, n_channels=18
         ... )

--- a/pyhealth/models/biot.py
+++ b/pyhealth/models/biot.py
@@ -129,6 +129,17 @@ class PositionalEncoding(nn.Module):
 
 
 class BIOTEncoder(nn.Module):
+    """Encoder for multichannel biosignals.
+
+    Examples:
+        >>> encoder = BIOTEncoder(
+        ...     emb_size=128, heads=8, depth=2, n_channels=18
+        ... )
+        >>> signal = torch.randn(2, 18, 2000)
+        >>> encoder(signal).shape
+        torch.Size([2, 128])
+    """
+
     def __init__(
         self,
         emb_size=256,
@@ -158,7 +169,7 @@ class BIOTEncoder(nn.Module):
         self.positional_encoding = PositionalEncoding(emb_size)
 
         # channel token, N_channels >= your actual channels
-        self.channel_tokens = nn.Embedding(n_channels, 256)
+        self.channel_tokens = nn.Embedding(n_channels, emb_size)
         self.index = nn.Parameter(
             torch.LongTensor(range(n_channels)), requires_grad=False
         )

--- a/tests/core/test_biot.py
+++ b/tests/core/test_biot.py
@@ -176,6 +176,32 @@ class TestBIOT(unittest.TestCase):
 
         self.assertEqual(ret["logit"].shape[1], 1)
 
+    def test_model_non_default_emb_size(self):
+        """BIOT must honor a non-default emb_size.
+
+        Regression test: the channel-token embedding dimension was hardcoded
+        to 256, so it could not be added to the emb_size-dimensional spectral
+        embedding when emb_size != 256, crashing the forward pass.
+        """
+        model = BIOT(
+            dataset=self.dataset,
+            emb_size=128,
+            heads=8,
+            depth=2,
+            n_fft=200,
+            hop_length=100,
+            n_channels=18,
+        )
+        self.assertEqual(model.biot.biot.channel_tokens.weight.shape[1], 128)
+
+        train_loader = get_dataloader(self.dataset, batch_size=2, shuffle=False)
+        data_batch = next(iter(train_loader))
+        ret = model(**data_batch)
+        ret["loss"].backward()
+
+        expected_size = self.dataset.output_processors["label"].size()
+        self.assertEqual(ret["logit"].shape[1], expected_size)
+
     def test_model(self):
         """Test BIOT"""
         model_small = BIOT(


### PR DESCRIPTION
**Issue**

BIOTEncoder created its channel-token embedding as nn.Embedding(n_channels, 256) (biot.py:161), hardcoding dimension 256 while emb_size is user-configurable. In forward the channel-token embedding is added to the emb_size-dimensional spectral embedding, so any emb_size != 256 raises a shape-mismatch RuntimeError.

**Fix**

Changed the channel-token embedding to nn.Embedding(n_channels, emb_size) so it matches the rest of the encoder.

**Notes**

Added regression test test_model_non_default_emb_size in tests/core/test_biot.py using emb_size=128 (asserts the channel-token dim and runs a forward/backward pass). Full BIOT test suite (9 tests) passes.