### PR TITLE
Fix ECE confidence binary crash

### DIFF
--- a/pyhealth/metrics/calibration.py
+++ b/pyhealth/metrics/calibration.py
@@ -149,13 +149,10 @@ def ece_confidence_binary(prob:np.ndarray, label:np.ndarray, bins=20, adaptive=F
 
     prob = np.asarray(prob)
     label = np.asarray(label)
-    # Confidence in the positive class (class 1). Accept either a 1D array of
-    # positive-class probabilities (as binary_metrics_fn passes) or a 2D
-    # (N, C) probability matrix.
+
     conf = prob[:, 1] if prob.ndim > 1 else prob
-    # Whether each sample truly belongs to the positive class. Accept either a
-    # 1D 0/1 label array or a 2D one-hot label matrix.
     acc = label[:, 1] if label.ndim > 1 else label
+    
     df = pd.DataFrame({'acc': acc, 'conf': conf})
     return _ECE_confidence(df, bins, adaptive)[1]
 

--- a/pyhealth/metrics/calibration.py
+++ b/pyhealth/metrics/calibration.py
@@ -156,8 +156,8 @@ def ece_confidence_binary(prob:np.ndarray, label:np.ndarray, bins=20, adaptive=F
     prob = np.asarray(prob)
     label = np.asarray(label)
 
-    conf = prob[:, 1] if prob.ndim > 1 else prob
-    acc = label[:, 1] if label.ndim > 1 else label
+    conf = prob[:, 0 if prob.shape[1] == 1 else 1] if prob.ndim > 1 else prob
+    acc = label[:, 0 if label.shape[1] == 1 else 1] if label.ndim > 1 else label
     
     df = pd.DataFrame({'acc': acc, 'conf': conf})
     return _ECE_confidence(df, bins, adaptive)[1]

--- a/pyhealth/metrics/calibration.py
+++ b/pyhealth/metrics/calibration.py
@@ -147,7 +147,16 @@ def ece_confidence_binary(prob:np.ndarray, label:np.ndarray, bins=20, adaptive=F
             of points. Defaults to False.
     """
 
-    df = pd.DataFrame({'acc': label[:,0], 'conf': prob[:,0]})
+    prob = np.asarray(prob)
+    label = np.asarray(label)
+    # Confidence in the positive class (class 1). Accept either a 1D array of
+    # positive-class probabilities (as binary_metrics_fn passes) or a 2D
+    # (N, C) probability matrix.
+    conf = prob[:, 1] if prob.ndim > 1 else prob
+    # Whether each sample truly belongs to the positive class. Accept either a
+    # 1D 0/1 label array or a 2D one-hot label matrix.
+    acc = label[:, 1] if label.ndim > 1 else label
+    df = pd.DataFrame({'acc': acc, 'conf': conf})
     return _ECE_confidence(df, bins, adaptive)[1]
 
 def ece_classwise(prob, label, bins=20, threshold=0., adaptive=False):

--- a/pyhealth/metrics/calibration.py
+++ b/pyhealth/metrics/calibration.py
@@ -137,6 +137,12 @@ def ece_confidence_binary(prob:np.ndarray, label:np.ndarray, bins=20, adaptive=F
 
     Similar to :func:`ece_confidence_multiclass`, but on class 1 instead of the top-prediction.
 
+    Examples:
+        >>> prob = np.array([0.1, 0.8])
+        >>> label = np.array([0, 1])
+        >>> ece = ece_confidence_binary(prob, label, bins=2)
+        >>> 0.0 <= ece <= 1.0
+        True
 
     Args:
         prob (np.ndarray): (N, C)

--- a/tests/core/test_calibration_binary_ece.py
+++ b/tests/core/test_calibration_binary_ece.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from pyhealth.metrics import binary_metrics_fn
+from pyhealth.metrics.calibration import ece_confidence_binary
+
+
+class TestBinaryECE(unittest.TestCase):
+    def test_binary_metrics_fn_ece_does_not_crash(self):
+        y_true = np.array([0, 0, 1, 1, 0, 1])
+        y_prob = np.array([0.1, 0.4, 0.35, 0.8, 0.2, 0.7])
+        for metric in ("ECE", "ECE_adapt"):
+            out = binary_metrics_fn(y_true, y_prob, metrics=[metric])
+            self.assertIn(metric, out)
+            self.assertTrue(np.isfinite(out[metric]))
+            self.assertGreaterEqual(out[metric], 0.0)
+            self.assertLessEqual(out[metric], 1.0)
+
+    def test_two_dim_inputs_use_positive_class(self):
+        prob = np.array([[0.2, 0.8], [0.7, 0.3]])
+        label = np.array([[0, 1], [1, 0]])
+
+        with patch(
+            "pyhealth.metrics.calibration._ECE_confidence",
+            return_value=(None, 0.0),
+        ) as ece:
+            ece_confidence_binary(prob, label)
+
+        frame = ece.call_args.args[0]
+        np.testing.assert_array_equal(frame["conf"].to_numpy(), prob[:, 1])
+        np.testing.assert_array_equal(frame["acc"].to_numpy(), label[:, 1])

--- a/tests/core/test_calibration_binary_ece.py
+++ b/tests/core/test_calibration_binary_ece.py
@@ -31,3 +31,17 @@ class TestBinaryECE(unittest.TestCase):
         frame = ece.call_args.args[0]
         np.testing.assert_array_equal(frame["conf"].to_numpy(), prob[:, 1])
         np.testing.assert_array_equal(frame["acc"].to_numpy(), label[:, 1])
+
+    def test_single_column_inputs_use_only_column(self):
+        prob = np.array([[0.2], [0.7]])
+        label = np.array([[0], [1]])
+
+        with patch(
+            "pyhealth.metrics.calibration._ECE_confidence",
+            return_value=(None, 0.0),
+        ) as ece:
+            ece_confidence_binary(prob, label)
+
+        frame = ece.call_args.args[0]
+        np.testing.assert_array_equal(frame["conf"].to_numpy(), prob[:, 0])
+        np.testing.assert_array_equal(frame["acc"].to_numpy(), label[:, 0])


### PR DESCRIPTION
**Issue**

ece_confidence_binary indexed prob[:,0] and label[:,0] (calibration.py:150), requiring 2D arrays. Its only real caller, binary_metrics_fn (binary.py:91), passes 1D positive-class probabilities and 1D 0/1 labels, so ECE and ECE_adapt always raised IndexError for binary tasks via the documented API. As a secondary defect, even for 2D input the code used column 0 (class 0) despite the docstring stating the metric is computed on class 1.

**Fix**

Compute confidence from the positive class (prob[:,1] when 2D, else the 1D array) and use the 0/1 label as the accuracy target (label[:,1] when 2D one-hot, else the 1D array). This makes the function work with the 1D shapes the caller actually uses and corrects the class-0/class-1 indexing. ece_classwise is unaffected (it calls a separate internal helper, not this function).

**Notes**

Added new test file tests/core/test_calibration_binary_ece.py with two tests. No prior tests existed for this function.