### PR TITLE
Handle two-dimensional time embeddings

### DIFF
--- a/pyhealth/models/unified_embedding.py
+++ b/pyhealth/models/unified_embedding.py
@@ -57,7 +57,9 @@ class SinusoidalTimeEmbedding(nn.Module):
         self.max_hours = max_hours
         half = dim // 2
         freqs = torch.exp(
-            -math.log(10000.0) * torch.arange(half, dtype=torch.float32) / (half - 1)
+            -math.log(10000.0)
+            * torch.arange(half, dtype=torch.float32)
+            / max(half - 1, 1)
         )
         self.register_buffer("freqs", freqs)  # (dim//2,)
 

--- a/pyhealth/models/unified_embedding.py
+++ b/pyhealth/models/unified_embedding.py
@@ -40,6 +40,14 @@ class SinusoidalTimeEmbedding(nn.Module):
     Identical in spirit to the positional encoding in "Attention is All You
     Need" but operating on real-valued timestamps rather than integer positions.
 
+    Examples:
+        >>> embedding = SinusoidalTimeEmbedding(dim=2, max_hours=24.0)
+        >>> output = embedding(torch.tensor([0.0, 6.0]))
+        >>> output.shape
+        torch.Size([2, 2])
+        >>> torch.isfinite(output).all().item()
+        True
+
     Args:
         dim: Output embedding dimension (must be even).
         max_hours: Maximum expected time value in hours.  Values are normalised
@@ -57,9 +65,7 @@ class SinusoidalTimeEmbedding(nn.Module):
         self.max_hours = max_hours
         half = dim // 2
         freqs = torch.exp(
-            -math.log(10000.0)
-            * torch.arange(half, dtype=torch.float32)
-            / max(half - 1, 1)
+            -math.log(10000.0) * torch.arange(half, dtype=torch.float32) / max(half - 1, 1)
         )
         self.register_buffer("freqs", freqs)  # (dim//2,)
 

--- a/tests/core/test_unified_embedding.py
+++ b/tests/core/test_unified_embedding.py
@@ -1,0 +1,29 @@
+import math
+import unittest
+
+import torch
+
+from pyhealth.models import SinusoidalTimeEmbedding
+
+
+class TestSinusoidalTimeEmbedding(unittest.TestCase):
+    def test_dim_two_is_finite(self):
+        embedding = SinusoidalTimeEmbedding(dim=2, max_hours=24.0)
+
+        result = embedding(torch.tensor([0.0, 6.0, 24.0]))
+
+        self.assertEqual(result.shape, (3, 2))
+        self.assertTrue(torch.isfinite(result).all())
+
+    def test_standard_dimension_values_are_unchanged(self):
+        embedding = SinusoidalTimeEmbedding(dim=6, max_hours=24.0)
+        time = torch.tensor([6.0])
+        frequencies = torch.tensor([1.0, 0.01, 0.0001])
+        arguments = time.unsqueeze(-1) / 24.0 * 2 * math.pi * frequencies
+        expected = torch.cat([arguments.sin(), arguments.cos()], dim=-1)
+
+        self.assertTrue(torch.allclose(embedding(time), expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Issue**

SinusoidalTimeEmbedding divided its frequency indices by half - 1. For dim=2, half is 1, so the only frequency was computed as 0/0 and every embedding contained NaN values.

**Fix**

Clamp to at least 1. This gives the single-frequency case a finite frequency of 1 while leaving the frequency schedule unchanged for all dimensions greater than 2.

**Notes**

Added regression tests tests/core/test_unified_embedding.py with finite-output coverage for dim=2 and a known-value check for dim=6.