### PR TITLE
Fix: Use configured TransformerDeID field names

### DIFF
--- a/pyhealth/models/transformer_deid.py
+++ b/pyhealth/models/transformer_deid.py
@@ -243,7 +243,12 @@ class TransformerDeID(BaseModel):
         dummy_labels = " ".join(["O"] * len(words))
         self.eval()
         with torch.no_grad():
-            result = self(text=[text], labels=[dummy_labels])
+            result = self(
+                **{
+                    self.feature_key: [text],
+                    self.label_key: [dummy_labels],
+                }
+            )
 
         preds = result["logit"][0].argmax(dim=-1)
         y_true = result["y_true"][0]

--- a/tests/core/test_transformer_deid.py
+++ b/tests/core/test_transformer_deid.py
@@ -195,5 +195,31 @@ class TestTransformerDeIDForward(unittest.TestCase):
             )
 
 
+class TestTransformerDeIDCustomFieldNames(unittest.TestCase):
+    class StubModel(TransformerDeID):
+        def __init__(self):
+            torch.nn.Module.__init__(self)
+            self.feature_key = "clinical_note"
+            self.label_key = "bio_tags"
+
+        def forward(self, **kwargs):
+            texts = kwargs[self.feature_key]
+            labels = kwargs[self.label_key]
+            word_count = len(texts[0].split())
+            self.received_labels = labels
+            return {
+                "logit": torch.zeros(1, word_count, len(LABEL_VOCAB)),
+                "y_true": torch.zeros(1, word_count, dtype=torch.long),
+            }
+
+    def test_deidentify_uses_configured_field_names(self):
+        model = self.StubModel()
+
+        result = model.deidentify("Patient Jane Doe")
+
+        self.assertEqual(result, "Patient Jane Doe")
+        self.assertEqual(model.received_labels, ["O O O"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Issue**
TransformerDeID.deidentify() always called the model with text= and labels=, even when the dataset configured different feature and label field names. Custom schemas therefore failed with a missing-key error

**Fix**
Build the de-identification call from self.feature_key and self.label_key so inference follows the field names established from the dataset schema

**Notes**
Regression test added